### PR TITLE
EDGEPOD-372:Context Not found error handling for TAU, Service Request…

### DIFF
--- a/include/cmn/componentDb.h
+++ b/include/cmn/componentDb.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020-present Infosys Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef COMPONENTDB_H_
+#define COMPONENTDB_H_
+
+#include <map>
+#include <stdint.h>
+
+namespace cmn
+{
+    class ComponentIf{
+    public:
+    virtual ~ComponentIf() {};
+    };
+
+    class ComponentDb{
+    public:
+    void registerComponent(uint16_t componentId, ComponentIf* comp);
+    ComponentIf& getComponent(uint16_t componentId);
+  
+    private:
+    std::map<uint16_t, ComponentIf*> componentContainer;
+    };
+
+extern ComponentDb compDb;
+}
+
+#endif /* COMPONENTDB_H_ */
+
+

--- a/include/common/msgType.h
+++ b/include/common/msgType.h
@@ -404,7 +404,7 @@ struct RB_Q_msg{
 
 struct DDN_ACK_Q_msg{
 	msg_type_t msg_type;
-	int ue_idx;
+	int s11_sgw_cp_teid;
 	uint32_t seq_no;
 	uint8_t cause;
 };

--- a/include/mme-app/interfaces/mmeIpcInterface.h
+++ b/include/mme-app/interfaces/mmeIpcInterface.h
@@ -8,15 +8,16 @@
 #define INCLUDE_MME_APP_INTERFACES_MMEIPCINTERFACE_H_
 
 #include <ipcChannel.h>
+#include <componentDb.h>
 
 namespace cmn{
     class IpcEventMessage;
 namespace utils{
-	class MsgBuffer;
+    class MsgBuffer;
 }
 }
 
-class MmeIpcInterface {
+class MmeIpcInterface:public cmn::ComponentIf {
 
 public:
 	MmeIpcInterface();

--- a/include/mme-app/mme_app.h
+++ b/include/mme-app/mme_app.h
@@ -42,6 +42,7 @@ typedef struct mme_config
 } mme_config;
 
 const size_t fifoQSize_c = 1000;
+const uint16_t MmeIpcInterfaceCompId = 1;
 
 void stat_init();
 

--- a/include/mme-app/utils/mmeCommonUtils.h
+++ b/include/mme-app/utils/mmeCommonUtils.h
@@ -49,11 +49,14 @@ namespace mme
 
 		static SM::ControlBlock* findControlBlock(cmn::utils::MsgBuffer* msgData_p);
 
+		static SM::ControlBlock* findControlBlockForS11Msg(cmn::utils::MsgBuffer* msg_p);
+
 		static AttachType getAttachType(UEContext* ueCtxt_p, const struct ue_attach_info& attachReqMsg_r);
 
 		static void formatS1apPlmnId(struct PLMN* plmn_p);
 
 		static bool isEmmInfoRequired(SM::ControlBlock& cb, UEContext& ueCtxt, MmeProcedureCtxt& procCtxt);
+
 
 	private:
 		MmeCommonUtils();

--- a/include/mme-app/utils/mmeContextManagerUtils.h
+++ b/include/mme-app/utils/mmeContextManagerUtils.h
@@ -33,6 +33,12 @@ class MmeContextManagerUtils
 {
 public:
 
+    static MmeSvcReqProcedureCtxt*
+    allocateServiceRequestProcedureCtxt( SM::ControlBlock& cb_r, PagingTrigger pagingTrigger);
+
+    static MmeTauProcedureCtxt*
+    allocateTauProcedureCtxt(SM::ControlBlock& cb_r);
+
     static MmeProcedureCtxt* findProcedureCtxt(SM::ControlBlock& cb_r, ProcedureType procType);
 
 	static bool deleteProcedureCtxt(MmeProcedureCtxt* procedure_p);

--- a/src/cmn/Makefile
+++ b/src/cmn/Makefile
@@ -39,7 +39,8 @@ CMNUTILS_SRCS := ./cTime.cpp \
 		 ./debug.cpp \
 		 ./msgBuffer.cpp \
 		 ./timerQueue.cpp \
-		 ./timeoutManager.cpp
+		 ./timeoutManager.cpp \
+		 ./componentDb.cpp
 		 
 
 SRCDIR := .

--- a/src/cmn/componentDb.cpp
+++ b/src/cmn/componentDb.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020-present Infosys Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+ 
+#include "componentDb.h"
+#include <assert.h>
+
+namespace cmn
+{
+    void ComponentDb::registerComponent(uint16_t componentId, ComponentIf* comp)
+    {
+	auto ret = componentContainer.insert(std::pair < uint16_t,
+                             ComponentIf * >(componentId, comp));
+	assert(ret.second == true);
+    }
+
+    ComponentIf& ComponentDb::getComponent(uint16_t componentId)
+    {
+        std::map < uint16_t, ComponentIf * >::iterator it;
+        it = componentContainer.find (componentId);
+
+	assert( it != componentContainer.end());
+	return *(it->second);
+    }
+
+    ComponentDb compDb;
+}

--- a/src/cmn/dataGroupManager.cpp
+++ b/src/cmn/dataGroupManager.cpp
@@ -56,7 +56,13 @@ namespace DGM
 
 	ControlBlock* DataGroupManager::findControlBlock(uint32_t cbIndex)
 	{
-		ControlBlock* cbp = &cbstore_m[cbIndex - 1];
+		if (cbIndex > ControlBlock::controlBlockArrayIdx ||
+                    cbIndex == 0)
+                {
+                    return NULL;
+                }
+        
+                ControlBlock* cbp = &cbstore_m[cbIndex - 1];
 		if (cbp != NULL && cbp->getControlBlockState() != FREE)
 		    return cbp;
 		else
@@ -65,7 +71,13 @@ namespace DGM
 	
 	void DataGroupManager::deAllocateCB( uint32_t cbIndex )
 	{
-        cbstore_m[cbIndex - 1].reset();
+                if (cbIndex > ControlBlock::controlBlockArrayIdx ||
+                    cbIndex == 0)
+                {
+                    return;
+                }
+        
+                cbstore_m[cbIndex - 1].reset();
 
 		std::lock_guard<std::mutex> lock(mutex_m);
 		freeQ_m.push_back( &cbstore_m[cbIndex - 1]);

--- a/src/common/unix_conn.c
+++ b/src/common/unix_conn.c
@@ -33,7 +33,7 @@ int create_unix_socket()
 {
 	int fd;
 	struct sockaddr_un addr;
-	char *socket_path = "/mnt/host-rootfs/unix_socket";
+	char *socket_path = "/tmp/unix_socket";
 
 	fd = socket(AF_UNIX, SOCK_STREAM, 0);
 

--- a/src/mme-app/actionHandlers/attachActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/attachActionHandlers.cpp
@@ -16,6 +16,7 @@
 #include <3gpp_24008.h>
 #include <typeinfo>
 #include "actionHandlers/actionHandlers.h"
+#include "mme_app.h"
 #include "controlBlock.h"
 #include "msgType.h"
 #include "contextManager/subsDataGroupManager.h"
@@ -39,9 +40,8 @@
 
 using namespace SM;
 using namespace mme;
+using namespace cmn;
 using namespace cmn::utils;
-
-extern MmeIpcInterface* mmeIpcIf_g;
 
 ActStatus ActionHandlers::validate_imsi_in_ue_context(ControlBlock& cb)
 {
@@ -88,8 +88,9 @@ ActStatus ActionHandlers::send_identity_request_to_ue(ControlBlock& cb)
 
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
-
-	mmeIpcIf_g->dispatchIpcMsg((char *) &idReqMsg, sizeof(idReqMsg), destAddr);
+	
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));        
+	mmeIpcIf.dispatchIpcMsg((char *) &idReqMsg, sizeof(idReqMsg), destAddr);
 
     	ProcedureStats::num_of_id_req_sent ++;
 	
@@ -186,7 +187,8 @@ ActStatus ActionHandlers::send_air_to_hss(SM::ControlBlock& cb)
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s6AppInstanceNum_c;
 
-	mmeIpcIf_g->dispatchIpcMsg((char *) &s6a_req, sizeof(s6a_req), destAddr);
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));        
+	mmeIpcIf.dispatchIpcMsg((char *) &s6a_req, sizeof(s6a_req), destAddr);
 
 	ProcedureStats::num_of_air_sent ++;
 	log_msg(LOG_DEBUG, "Leaving send_air_to_hss \n");
@@ -218,8 +220,9 @@ ActStatus ActionHandlers::send_ulr_to_hss(SM::ControlBlock& cb)
 
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s6AppInstanceNum_c;
-
-	mmeIpcIf_g->dispatchIpcMsg((char *) &s6a_req, sizeof(s6a_req), destAddr);
+	
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
+	mmeIpcIf.dispatchIpcMsg((char *) &s6a_req, sizeof(s6a_req), destAddr);
 
 	ProcedureStats::num_of_ulr_sent ++;
 	log_msg(LOG_DEBUG, "Leaving send_ulr_to_hss \n");
@@ -238,14 +241,13 @@ ActStatus ActionHandlers::process_aia(SM::ControlBlock& cb)
 		log_msg(LOG_DEBUG, "handle_aia: ue context is NULL \n");
 		return ActStatus::HALT;
 	}
-
-    MmeProcedureCtxt *procedure_p =
-            dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-    if (procedure_p == NULL)
-    {
-        log_msg(LOG_DEBUG, "handle_aia: procedure context is NULL \n");
-        return ActStatus::HALT;
-    }
+	
+	MmeProcedureCtxt *procedure_p = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
+	if (procedure_p == NULL)
+	{
+        	log_msg(LOG_DEBUG, "handle_aia: procedure context is NULL \n");
+        	return ActStatus::HALT;
+        }
 
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
 
@@ -257,10 +259,9 @@ ActStatus ActionHandlers::process_aia(SM::ControlBlock& cb)
 	if (msgData_p->msg_data.aia_Q_msg_m.res == S6A_AIA_FAILED)
 	{	
 		/* send attach reject and release UE */
-        log_msg(LOG_INFO, "AIA failed. UE %d", ue_ctxt->getContextID());
-        procedure_p->setMmeErrorCause(s6AiaFailure_c);
-        return ActStatus::ABORT;
-
+        	log_msg(LOG_INFO, "AIA failed. UE %d", ue_ctxt->getContextID());
+        	procedure_p->setMmeErrorCause(s6AiaFailure_c);
+        	return ActStatus::ABORT;
 	}
 
 	ue_ctxt->setAiaSecInfo(E_utran_sec_vector(msgData_p->msg_data.aia_Q_msg_m.sec));
@@ -354,9 +355,9 @@ ActStatus ActionHandlers::auth_req_to_ue(SM::ControlBlock& cb)
 	
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
-
-	mmeIpcIf_g->dispatchIpcMsg((char *) &authreq, sizeof(authreq), destAddr);
-
+	
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
+	mmeIpcIf.dispatchIpcMsg((char *) &authreq, sizeof(authreq), destAddr);
 	
 	ProcedureStats::num_of_auth_req_to_ue_sent ++;
 	log_msg(LOG_DEBUG, "Leaving auth_req_to_ue_v \n");
@@ -484,8 +485,9 @@ ActStatus ActionHandlers::sec_mode_cmd_to_ue(SM::ControlBlock& cb)
 
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
-
-	mmeIpcIf_g->dispatchIpcMsg((char *) &sec_mode_msg, sizeof(sec_mode_msg), destAddr);
+	
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
+	mmeIpcIf.dispatchIpcMsg((char *) &sec_mode_msg, sizeof(sec_mode_msg), destAddr);
 	
 	ProcedureStats::num_of_sec_mode_cmd_to_ue_sent ++;
 	log_msg(LOG_DEBUG, "Leaving sec_mode_cmd_to_ue \n");
@@ -616,7 +618,8 @@ ActStatus ActionHandlers::send_esm_info_req_to_ue(SM::ControlBlock& cb)
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
 
-	mmeIpcIf_g->dispatchIpcMsg((char *) &esmreq, sizeof(esmreq), destAddr);
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
+	mmeIpcIf.dispatchIpcMsg((char *) &esmreq, sizeof(esmreq), destAddr);
 
 	log_msg(LOG_DEBUG, "Leaving send_esm_info_req_to_ue \n");
 	ProcedureStats::num_of_esm_info_req_to_ue_sent ++;
@@ -632,12 +635,12 @@ ActStatus ActionHandlers::process_esm_info_resp(SM::ControlBlock& cb)
 		return ActStatus::HALT;
 	}
 
-    MmeAttachProcedureCtxt* procedure_p = dynamic_cast<MmeAttachProcedureCtxt*>(cb.getTempDataBlock());
-    if (procedure_p == NULL)
-    {
-        log_msg(LOG_DEBUG, "process_esm_info_resp: procedure context is NULL \n");
-        return ActStatus::HALT;
-    }
+    	MmeAttachProcedureCtxt* procedure_p = dynamic_cast<MmeAttachProcedureCtxt*>(cb.getTempDataBlock());
+    	if (procedure_p == NULL)
+    	{
+        	log_msg(LOG_DEBUG, "process_esm_info_resp: procedure context is NULL \n");
+        	return ActStatus::HALT;
+    	}
 
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
 
@@ -646,6 +649,11 @@ ActStatus ActionHandlers::process_esm_info_resp(SM::ControlBlock& cb)
 
 	const s1_incoming_msg_data_t* s1_msg_data = static_cast<const s1_incoming_msg_data_t*>(msgBuf->getDataPointer());
 	const struct esm_resp_Q_msg &esm_res =s1_msg_data->msg_data.esm_resp_Q_msg_m;
+    
+    	if (esm_res.status != SUCCESS)
+    	{
+        	log_msg(LOG_ERROR, "ESM Response failed \n");
+    	}
 
 	procedure_p->setRequestedApn(Apn_name(esm_res.apn));
 	ProcedureStats::num_of_handled_esm_info_resp++;
@@ -742,7 +750,8 @@ ActStatus ActionHandlers::cs_req_to_sgw(SM::ControlBlock& cb)
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s11AppInstanceNum_c;
 
-	mmeIpcIf_g->dispatchIpcMsg((char *) &cs_msg, sizeof(cs_msg), destAddr);
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
+	mmeIpcIf.dispatchIpcMsg((char *) &cs_msg, sizeof(cs_msg), destAddr);
 
 	ProcedureStats::num_of_cs_req_to_sgw_sent ++;
 	log_msg(LOG_DEBUG, "Leaving cs_req_to_sgw \n");
@@ -891,8 +900,9 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue(SM::ControlBlock& cb)
 
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
-
-	mmeIpcIf_g->dispatchIpcMsg((char *) &icr_msg, sizeof(icr_msg), destAddr);
+	
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
+	mmeIpcIf.dispatchIpcMsg((char *) &icr_msg, sizeof(icr_msg), destAddr);
 	
 	ProcedureStats::num_of_init_ctxt_req_to_ue_sent ++;
 	log_msg(LOG_DEBUG, "Leaving send_init_ctxt_req_to_ue_v \n");
@@ -991,7 +1001,8 @@ ActStatus ActionHandlers::send_mb_req_to_sgw(SM::ControlBlock& cb)
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s11AppInstanceNum_c;
 
-	mmeIpcIf_g->dispatchIpcMsg((char *) &mb_msg, sizeof(mb_msg), destAddr);
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
+	mmeIpcIf.dispatchIpcMsg((char *) &mb_msg, sizeof(mb_msg), destAddr);
 		
 	ProcedureStats::num_of_mb_req_to_sgw_sent ++;
 	log_msg(LOG_DEBUG, "Leaving send_mb_req_to_sgw \n");
@@ -1064,7 +1075,9 @@ ActStatus ActionHandlers::check_and_send_emm_info(SM::ControlBlock& cb)
 
     	cmn::ipc::IpcAddress destAddr;
     	destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
-    	mmeIpcIf_g->dispatchIpcMsg((char*) &temp, sizeof(temp), destAddr);
+    	
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
+	mmeIpcIf.dispatchIpcMsg((char*) &temp, sizeof(temp), destAddr);
 
     	ProcedureStats::num_of_emm_info_sent++;
     }
@@ -1131,7 +1144,9 @@ ActStatus ActionHandlers::send_attach_reject(ControlBlock& cb)
 
         cmn::ipc::IpcAddress destAddr;
         destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
-        mmeIpcIf_g->dispatchIpcMsg((char *) & attach_rej, sizeof(attach_rej), destAddr);
+        
+        MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
+        mmeIpcIf.dispatchIpcMsg((char *) & attach_rej, sizeof(attach_rej), destAddr);
 
         ProcedureStats::num_of_attach_reject_sent ++;
 

--- a/src/mme-app/actionHandlers/defaultMmeProcedureActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/defaultMmeProcedureActionHandlers.cpp
@@ -16,8 +16,12 @@
 #include <actionHandlers/actionHandlers.h>
 #include <contextManager/dataBlocks.h>
 #include <contextManager/subsDataGroupManager.h>
+#include <mme_app.h>
 #include <controlBlock.h>
 #include <event.h>
+#include <gtpCauseTypes.h>
+#include <interfaces/mmeIpcInterface.h>
+#include <ipcTypes.h>
 #include <mmeSmDefs.h>
 #include <mmeStates/attachStart.h>
 #include <mmeStates/detachStart.h>
@@ -34,13 +38,14 @@
 #include <state.h>
 #include <string.h>
 #include <sstream>
+#include <tipcTypes.h>
 #include <typeinfo>
-#include <utils/mmeProcedureTypes.h>
 #include <utils/mmeCommonUtils.h>
 #include <utils/mmeContextManagerUtils.h>
 
 using namespace mme;
 using namespace SM;
+using namespace cmn;
 
 /***************************************
 * Action handler : default_attach_req_handler
@@ -215,26 +220,25 @@ ActStatus ActionHandlers::default_detach_req_handler(ControlBlock& cb)
         return ActStatus::HALT;
     }
 
-	MmeDetachProcedureCtxt* prcdCtxt_p = SubsDataGroupManager::Instance()->getMmeDetachProcedureCtxt();
-	if( prcdCtxt_p == NULL )
-	{
-		log_msg(LOG_ERROR, "Failed to allocate procedure context for detach cbIndex %d\n", cb.getCBIndex());
+    MmeDetachProcedureCtxt* prcdCtxt_p = SubsDataGroupManager::Instance()->getMmeDetachProcedureCtxt();
+    if( prcdCtxt_p == NULL )
+    {
+	log_msg(LOG_ERROR, "Failed to allocate procedure context for detach cbIndex %d\n", cb.getCBIndex());
+	return ActStatus::HALT;
+    }
 
-		return ActStatus::HALT;
-	}
-
-	prcdCtxt_p->setCtxtType( ProcedureType::detach_c );
-	prcdCtxt_p->setDetachType( DetachType::ueInitDetach_c);
-	ueCtxt->setS1apEnbUeId(msgData_p->s1ap_enb_ue_id);
-	prcdCtxt_p->setNextState(DetachStart::Instance());
-	cb.setCurrentTempDataBlock(prcdCtxt_p);
-
-	SM::Event evt(DETACH_REQ_FROM_UE, NULL);
-	cb.addEventToProcQ(evt);
-
-	ProcedureStats::num_of_detach_req_received ++;
-
-	return ActStatus::PROCEED;
+    prcdCtxt_p->setCtxtType( ProcedureType::detach_c );
+    prcdCtxt_p->setDetachType( DetachType::ueInitDetach_c);
+    ueCtxt->setS1apEnbUeId(msgData_p->s1ap_enb_ue_id);
+    prcdCtxt_p->setNextState(DetachStart::Instance());
+    cb.setCurrentTempDataBlock(prcdCtxt_p);
+    
+    SM::Event evt(DETACH_REQ_FROM_UE, NULL);
+    cb.addEventToProcQ(evt);
+    
+    ProcedureStats::num_of_detach_req_received ++;
+    
+    return ActStatus::PROCEED;
 }
 
 /***************************************
@@ -242,97 +246,172 @@ ActStatus ActionHandlers::default_detach_req_handler(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::default_ddn_handler(ControlBlock& cb)
 {
-	MmeSvcReqProcedureCtxt* svcReqProc_p = SubsDataGroupManager::Instance()->getMmeSvcReqProcedureCtxt();
-	if (svcReqProc_p == NULL)
-	{
-		log_msg(LOG_ERROR, "Failed to allocate procedure context"
-				" for DDN handling cbIndex %d\n", cb.getCBIndex());
+    ProcedureStats::num_of_ddn_received++;
 
-		return ActStatus::HALT;
-	}
-	
-	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
+    MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
+    if (msgBuf == NULL)
+    {
+        log_msg(LOG_INFO, "default_ddn_handler: msgBuf is NULL \n");
+        return ActStatus::PROCEED;
+    }
 
-	if (msgBuf == NULL)
-	{
-	    log_msg(LOG_DEBUG,"process_ddn: msgBuf is NULL \n");
-	    return ActStatus::HALT;
-   	}
+    const gtp_incoming_msg_data_t *gtp_msg_data =
+            static_cast<const gtp_incoming_msg_data_t*>(msgBuf->getDataPointer());
+    const struct ddn_Q_msg &ddn_info =
+            gtp_msg_data->msg_data.ddn_Q_msg_m;
 
-   	const gtp_incoming_msg_data_t* gtp_msg_data= static_cast<const gtp_incoming_msg_data_t*>(msgBuf->getDataPointer());
-   	const struct ddn_Q_msg& ddn_info = gtp_msg_data->msg_data.ddn_Q_msg_m;
+    uint8_t gtpCause = GTPV2C_CAUSE_REQUEST_ACCEPTED;
+    int sgw_cp_teid = 0;
 
-	svcReqProc_p->setCtxtType(ProcedureType::serviceRequest_c);
-	svcReqProc_p->setNextState(PagingStart::Instance());
-	svcReqProc_p->setPagingTrigger(ddnInit_c);
-	svcReqProc_p->setDdnSeqNo(ddn_info.seq_no);
-	svcReqProc_p->setArp(Arp(ddn_info.arp));
-	svcReqProc_p->setEpsBearerId(ddn_info.eps_bearer_id);
+    UEContext *ueCtxt = static_cast<UEContext*>(cb.getPermDataBlock());
+    if (ueCtxt != NULL)
+    {
+        SessionContext *sess_p = ueCtxt->getSessionContext();
+        if (sess_p != NULL)
+        {
+            sgw_cp_teid = sess_p->getS11SgwCtrlFteid().fteid_m.header.teid_gre;
 
-	cb.setCurrentTempDataBlock(svcReqProc_p);
-    
-	SM::Event evt(DDN_FROM_SGW, NULL);
-	cb.addEventToProcQ(evt);
+            MmeSvcReqProcedureCtxt *svcReqProc_p =
+                    MmeContextManagerUtils::allocateServiceRequestProcedureCtxt(
+                            cb, PagingTrigger::ddnInit_c);
+            if (svcReqProc_p != NULL)
+            {
+                svcReqProc_p->setDdnSeqNo(ddn_info.seq_no);
+                svcReqProc_p->setArp(Arp(ddn_info.arp));
+                svcReqProc_p->setEpsBearerId(ddn_info.eps_bearer_id);
 
-	ProcedureStats::num_of_ddn_received ++;
+                SM::Event evt(DDN_FROM_SGW, NULL);
+                cb.addEventToProcQ(evt);
+            }
+            else
+            {
+                log_msg(LOG_INFO,
+                        "default_ddn_handler: Failed to allocate procedure context \n");
+                gtpCause = GTPV2C_CAUSE_REQUEST_REJECTED;
+            }
+        }
+        else
+        {
+            log_msg(LOG_INFO,
+                    "default_ddn_handler: Failed to find session context \n");
+            gtpCause = GTPV2C_CAUSE_REQUEST_REJECTED;
+        }
+    }
+    else
+    {
+        log_msg(LOG_INFO,
+                "default_ddn_handler: Failed to find UE context \n");
 
-	return ActStatus::PROCEED;
+        gtpCause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
+
+        MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
+    }
+
+    if (gtpCause != GTPV2C_CAUSE_REQUEST_ACCEPTED)
+    {
+        struct DDN_ACK_Q_msg ddnAck =
+        {
+                ddn_acknowledgement,
+                sgw_cp_teid,
+                ddn_info.seq_no,
+                gtpCause
+        };
+
+        cmn::ipc::IpcAddress destAddr;
+        destAddr.u32 = TipcServiceInstance::s11AppInstanceNum_c;
+        
+        MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));        
+        mmeIpcIf.dispatchIpcMsg((char *) &ddnAck, sizeof(ddnAck), destAddr);
+    }
+
+    return ActStatus::PROCEED;
 }
 
 /***************************************
 * Action handler : default_service_req_handler
 ***************************************/
 ActStatus ActionHandlers::default_service_req_handler(ControlBlock& cb)
-{	
-	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-	if (msgBuf == NULL)
-	{
-        	log_msg(LOG_ERROR, "Failed to retrieve message buffer \n");
-        	return ActStatus::HALT;
-    	}
-	const s1_incoming_msg_data_t* msgData_p =
-            static_cast<const s1_incoming_msg_data_t*>(msgBuf->getDataPointer());
-    	if (msgData_p == NULL)
-    	{
-        	log_msg(LOG_ERROR, "Failed to retrieve data buffer \n");
-        	return ActStatus::HALT;
-    	}
-    	MmeSvcReqProcedureCtxt* svcReqProc_p = SubsDataGroupManager::Instance()->getMmeSvcReqProcedureCtxt();
-	if (svcReqProc_p == NULL)
-	{
-		log_msg(LOG_ERROR, "Failed to allocate procedure context"
-				" for service request cbIndex %d\n", cb.getCBIndex());
+{
+    log_msg(LOG_DEBUG, "default_service_req_handler \n");
 
-		return ActStatus::HALT;
-	}
+    ProcedureStats::num_of_service_request_received++;
 
-	UEContext *ueCtxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	if (ueCtxt == NULL)
-	{
-		log_msg(LOG_DEBUG, "ue context is NULL \n");
-		return ActStatus::HALT;
-	}
+    MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
+    if (msgBuf == NULL)
+    {
+        log_msg(LOG_ERROR, "Failed to retrieve message buffer \n");
+        return ActStatus::HALT;
+    }
 
-	MmContext* mmCtxt = ueCtxt->getMmContext();
-	if (mmCtxt == NULL)
-	{
-		log_msg(LOG_DEBUG, "mm context is NULL \n");
-		return ActStatus::HALT;
-	}
-	
-	mmCtxt->setEcmState(ecmConnected_c);
-	
-	svcReqProc_p->setCtxtType(ProcedureType::serviceRequest_c);
-	svcReqProc_p->setNextState(ServiceRequestStart::Instance());
-	ueCtxt->setS1apEnbUeId(msgData_p->s1ap_enb_ue_id);
-	cb.setCurrentTempDataBlock(svcReqProc_p);
+    s1_incoming_msg_data_t *msgData_p =
+            static_cast<s1_incoming_msg_data_t*>(msgBuf->getDataPointer());
+    if (msgData_p == NULL)
+    {
+        log_msg(LOG_ERROR, "Failed to retrieve data buffer \n");
+        return ActStatus::HALT;
+    }
+    struct service_req_Q_msg &serviceReq = msgData_p->msg_data.service_req_Q_msg_m;
 
-	SM::Event evt(SERVICE_REQUEST_FROM_UE, NULL);
-	cb.addEventToProcQ(evt);
+    unsigned char emmCause = 0;
 
-    	ProcedureStats::num_of_service_request_received ++;
-	
-	return ActStatus::PROCEED;
+    UEContext *ueCtxt = static_cast<UEContext*>(cb.getPermDataBlock());
+    if (ueCtxt != NULL)
+    {
+        MmContext *mmCtxt = ueCtxt->getMmContext();
+        if (mmCtxt != NULL)
+        {
+            MmeSvcReqProcedureCtxt *srvReqProc_p =
+                    MmeContextManagerUtils::allocateServiceRequestProcedureCtxt(cb, none_c);
+            if (srvReqProc_p != NULL)
+            {
+                mmCtxt->setEcmState(ecmConnected_c);
+                ueCtxt->setS1apEnbUeId(msgData_p->s1ap_enb_ue_id);
+
+                SM::Event evt(SERVICE_REQUEST_FROM_UE, NULL);
+                cb.addEventToProcQ(evt);
+            }
+            else
+            {
+                log_msg(LOG_ERROR, "Failed to allocate procedure context \n");
+
+                emmCause = emmCause_network_failure;
+            }
+        }
+        else
+        {
+            log_msg(LOG_ERROR, "Invalid UE Context \n");
+
+            emmCause = emmCause_ue_id_not_derived_by_network;
+            MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
+        }
+    }
+    else
+    {
+        log_msg(LOG_ERROR, "UE Context is NULL \n");
+
+        emmCause = emmCause_ue_id_not_derived_by_network;
+        MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
+    }
+
+    if (emmCause != 0)
+    {
+        struct commonRej_info serviceRej =
+        {
+                service_reject,
+                msgData_p->ue_idx,
+                msgData_p->s1ap_enb_ue_id,
+                serviceReq.enb_fd,
+                emmCause
+        };
+
+        cmn::ipc::IpcAddress destAddr;
+        destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
+        
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
+	mmeIpcIf.dispatchIpcMsg((char *) &serviceRej, sizeof(struct commonRej_info), destAddr);
+    }
+
+    return ActStatus::PROCEED;
 }
 
 /***************************************
@@ -413,59 +492,87 @@ ActStatus ActionHandlers::default_s1_release_req_handler(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::default_tau_req_handler(ControlBlock& cb)
 {
-	MmeTauProcedureCtxt* tauReqProc_p = SubsDataGroupManager::Instance()->getMmeTauProcedureCtxt();
-	if (tauReqProc_p == NULL)
-	{
-		log_msg(LOG_ERROR, "Failed to allocate procedure context"
-				" for tau request cbIndex %d\n", cb.getCBIndex());
+    log_msg(LOG_DEBUG, "default_tau_req_handler: Entry \n");
 
-		return ActStatus::HALT;
-	}
+    ProcedureStats::num_of_tau_req_received++;
 
-	UEContext *ueCtxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	if (ueCtxt == NULL)
-	{
-		log_msg(LOG_DEBUG, "ue context is NULL \n");
-		return ActStatus::HALT;
-	}
+    MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
+    if (msgBuf == NULL)
+    {
+        log_msg(LOG_DEBUG, "process_tau_req: msgBuf is NULL \n");
+        return ActStatus::HALT;
+    }
 
-	MmContext* mmCtxt = ueCtxt->getMmContext();
-	if (mmCtxt == NULL)
-	{
-		log_msg(LOG_DEBUG, "mm context is NULL \n");
-		return ActStatus::HALT;
-	}
+    const s1_incoming_msg_data_t *msgData_p =
+            static_cast<const s1_incoming_msg_data_t*>(msgBuf->getDataPointer());
+    if (msgData_p == NULL)
+    {
+        log_msg(LOG_ERROR, "Failed to retrieve data buffer \n");
+        return ActStatus::HALT;
+    }
 
-	mmCtxt->setEcmState(ecmConnected_c);
-	
-	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-	if (msgBuf == NULL)
-	{	
-            log_msg(LOG_DEBUG,"process_tau_req: msgBuf is NULL \n");
-            return ActStatus::HALT;
-	}
-	
-	const s1_incoming_msg_data_t* msgData_p =
-			static_cast<const s1_incoming_msg_data_t*>(msgBuf->getDataPointer());
-	if (msgData_p == NULL)
-	{
-		log_msg(LOG_ERROR, "Failed to retrieve data buffer \n");
-		return ActStatus::HALT;
-	}
+    const struct tauReq_Q_msg &tauReq = (msgData_p->msg_data.tauReq_Q_msg_m);
+    unsigned char emmCause = 0;
 
-	const struct tauReq_Q_msg &tauReq = (msgData_p->msg_data.tauReq_Q_msg_m);	
-	
-	tauReqProc_p->setCtxtType(ProcedureType::tau_c);
-	tauReqProc_p->setNextState(TauStart::Instance());	
-	tauReqProc_p->setS1apEnbUeId(msgData_p->s1ap_enb_ue_id);
-	tauReqProc_p->setEnbFd(tauReq.enb_fd);
-	cb.setCurrentTempDataBlock(tauReqProc_p);	
+    UEContext *ueCtxt = static_cast<UEContext*>(cb.getPermDataBlock());
+    if (ueCtxt != NULL)
+    {
+        MmContext *mmCtxt = ueCtxt->getMmContext();
+        if (mmCtxt != NULL)
+        {
+            MmeTauProcedureCtxt *tauReqProc_p =
+                    MmeContextManagerUtils::allocateTauProcedureCtxt(cb);
+            if (tauReqProc_p != NULL)
+            {
+                mmCtxt->setEcmState(ecmConnected_c);
 
-	SM::Event evt(TAU_REQUEST_FROM_UE, NULL);
-	cb.addEventToProcQ(evt);
-	
-	ProcedureStats::num_of_tau_req_received ++;
-	
-	return ActStatus::PROCEED;
+                tauReqProc_p->setS1apEnbUeId(msgData_p->s1ap_enb_ue_id);
+                tauReqProc_p->setEnbFd(tauReq.enb_fd);
+
+                SM::Event evt(TAU_REQUEST_FROM_UE, NULL);
+                cb.addEventToProcQ(evt);
+            }
+            else
+            {
+                log_msg(LOG_ERROR, "Failed to allocate procedure context \n");
+
+                emmCause = emmCause_network_failure;
+            }
+        }
+        else
+        {
+            log_msg(LOG_ERROR, "Invalid UE Context \n");
+
+            emmCause = emmCause_ue_id_not_derived_by_network;
+            MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
+        }
+    }
+    else
+    {
+        log_msg(LOG_ERROR, "UE Context is NULL \n");
+
+        emmCause = emmCause_ue_id_not_derived_by_network;
+        MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
+    }
+
+    if (emmCause != 0)
+    {
+        struct commonRej_info tauRej =
+        {
+                tau_response,
+		msgData_p->ue_idx,
+                msgData_p->s1ap_enb_ue_id,
+                tauReq.enb_fd,
+                emmCause
+        };
+
+        cmn::ipc::IpcAddress destAddr;
+        destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
+        
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
+	mmeIpcIf.dispatchIpcMsg((char *) &tauRej, sizeof(tauRej), destAddr);
+    }
+
+    return ActStatus::PROCEED;
 }
 

--- a/src/mme-app/actionHandlers/networkInitDetachActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/networkInitDetachActionHandlers.cpp
@@ -6,6 +6,7 @@
 
 #include <typeinfo>
 #include "actionHandlers/actionHandlers.h"
+#include "mme_app.h"
 #include "controlBlock.h"
 #include "msgType.h"
 #include "contextManager/subsDataGroupManager.h"
@@ -26,9 +27,8 @@
 
 using namespace SM;
 using namespace mme;
+using namespace cmn;
 using namespace cmn::utils;
-
-extern MmeIpcInterface* mmeIpcIf_g;
 
 ActStatus ActionHandlers::ni_detach_req_to_ue(SM::ControlBlock& cb)
 {
@@ -59,7 +59,8 @@ ActStatus ActionHandlers::ni_detach_req_to_ue(SM::ControlBlock& cb)
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
 
-	mmeIpcIf_g->dispatchIpcMsg((char *) &ni_detach_req, sizeof(ni_detach_req), destAddr);
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
+	mmeIpcIf.dispatchIpcMsg((char *) &ni_detach_req, sizeof(ni_detach_req), destAddr);
 	
 	log_msg(LOG_DEBUG, "Leaving ni_detach_req_to_ue \n");
 	ProcedureStats::num_of_detach_req_to_ue_sent ++;
@@ -108,12 +109,14 @@ ActStatus ActionHandlers::send_s1_rel_cmd_to_ue_for_detach(ControlBlock& cb)
     s1relcmd.enb_fd = ue_ctxt->getEnbFd();
     s1relcmd.enb_s1ap_ue_id = ue_ctxt->getS1apEnbUeId();
     s1relcmd.cause.present = s1apCause_PR_nas;
-    s1relcmd.cause.choice.radioNetwork = s1apCauseNas_detach;
+    s1relcmd.cause.choice.nas = s1apCauseNas_detach;
 
     /*Send message to S1AP-APP*/
     cmn::ipc::IpcAddress destAddr;
     destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
-    mmeIpcIf_g->dispatchIpcMsg((char *) &s1relcmd, sizeof(s1relcmd), destAddr);
+    
+    MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
+    mmeIpcIf.dispatchIpcMsg((char *) &s1relcmd, sizeof(s1relcmd), destAddr);
 
     log_msg(LOG_DEBUG,"Leaving send_s1_rel_cmd_to_ue \n");
 
@@ -150,8 +153,8 @@ ActStatus ActionHandlers::process_ue_ctxt_rel_comp_for_detach(ControlBlock& cb)
     else
     {
     	mmCtxt->setMmState( EpsDetached );
-	    mmCtxt->setEcmState( ecmIdle_c );
-	    ueCtxt->setS1apEnbUeId(0);
+	mmCtxt->setEcmState( ecmIdle_c );
+	ueCtxt->setS1apEnbUeId(0);
     	MmeContextManagerUtils::deallocateProcedureCtxt(cb, detach_c);
     }
 

--- a/src/mme-app/actionHandlers/s1releaseActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/s1releaseActionHandlers.cpp
@@ -16,6 +16,7 @@
 #include <typeinfo>
 #include "actionHandlers/actionHandlers.h"
 #include "controlBlock.h"
+#include "mme_app.h"
 #include "msgType.h"
 #include "contextManager/subsDataGroupManager.h"
 #include "contextManager/dataBlocks.h"
@@ -36,9 +37,8 @@
 
 using namespace SM;
 using namespace mme;
+using namespace cmn;
 using namespace cmn::utils;
-
-extern MmeIpcInterface* mmeIpcIf_g;
 
 ActStatus ActionHandlers:: send_rel_ab_req_to_sgw(SM::ControlBlock& cb)
 {
@@ -77,7 +77,9 @@ ActStatus ActionHandlers:: send_rel_ab_req_to_sgw(SM::ControlBlock& cb)
 			
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s11AppInstanceNum_c;
-	mmeIpcIf_g->dispatchIpcMsg((char *) &rb_msg, sizeof(rb_msg), destAddr);
+	
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
+	mmeIpcIf.dispatchIpcMsg((char *) &rb_msg, sizeof(rb_msg), destAddr);
 
 	ProcedureStats::num_of_rel_access_bearer_req_sent ++;
 	
@@ -131,7 +133,9 @@ ActStatus ActionHandlers:: send_s1_rel_cmd_to_ue(SM::ControlBlock& cb)
 	/*Send message to S1AP-APP*/
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
-	mmeIpcIf_g->dispatchIpcMsg((char *) &s1relcmd, sizeof(s1relcmd), destAddr);
+
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
+	mmeIpcIf.dispatchIpcMsg((char *) &s1relcmd, sizeof(s1relcmd), destAddr);
 	
 	ProcedureStats::num_of_s1_rel_cmd_sent ++;
 	

--- a/src/mme-app/actionHandlers/tauActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/tauActionHandlers.cpp
@@ -15,6 +15,7 @@
 
 #include <typeinfo>
 #include "actionHandlers/actionHandlers.h"
+#include "mme_app.h"
 #include "controlBlock.h" 
 #include "msgType.h"
 #include "contextManager/dataBlocks.h"
@@ -36,9 +37,8 @@
 
 using namespace mme;
 using namespace SM;
+using namespace cmn;
 using namespace cmn::utils;
-
-extern MmeIpcInterface* mmeIpcIf_g;
 
 /***************************************
 * Action handler : send_tau_response_to_ue
@@ -76,7 +76,9 @@ ActStatus ActionHandlers::send_tau_response_to_ue(ControlBlock& cb)
 	
 	cmn::ipc::IpcAddress destAddr;
         destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;	
-	mmeIpcIf_g->dispatchIpcMsg((char *) &tau_resp, sizeof(tau_resp), destAddr);
+
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
+	mmeIpcIf.dispatchIpcMsg((char *) &tau_resp, sizeof(tau_resp), destAddr);
 	
 	MmeContextManagerUtils::deallocateProcedureCtxt(cb, tau_c );
 	ProcedureStats::num_of_tau_response_to_ue_sent++;

--- a/src/mme-app/actionHandlers/ueInitDetachActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/ueInitDetachActionHandlers.cpp
@@ -16,6 +16,7 @@
 #include "actionHandlers/actionHandlers.h"
 #include "contextManager/subsDataGroupManager.h"
 #include "contextManager/dataBlocks.h"
+#include "mme_app.h"
 #include "msgType.h"
 #include "controlBlock.h"
 #include "procedureStats.h"
@@ -31,9 +32,8 @@
 
 using namespace SM;
 using namespace mme;
+using namespace cmn;
 using namespace cmn::utils;
-
-extern MmeIpcInterface* mmeIpcIf_g;
 
 ActStatus ActionHandlers::del_session_req(SM::ControlBlock& cb)
 {
@@ -65,7 +65,8 @@ ActStatus ActionHandlers::del_session_req(SM::ControlBlock& cb)
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s11AppInstanceNum_c;
 
-	mmeIpcIf_g->dispatchIpcMsg((char *) &g_ds_msg, sizeof(g_ds_msg), destAddr);
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
+	mmeIpcIf.dispatchIpcMsg((char *) &g_ds_msg, sizeof(g_ds_msg), destAddr);
 	
 	log_msg(LOG_DEBUG, "Leaving delete_session_req \n");
 	ProcedureStats::num_of_del_session_req_sent ++;	
@@ -94,7 +95,8 @@ ActStatus ActionHandlers::purge_req(SM::ControlBlock& cb)
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s6AppInstanceNum_c;
 
-	mmeIpcIf_g->dispatchIpcMsg((char *) &purge_msg, sizeof(purge_msg), destAddr);
+        MmeIpcInterface &mmeIpcIf =static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));	
+	mmeIpcIf.dispatchIpcMsg((char *) &purge_msg, sizeof(purge_msg), destAddr);
 	
 	log_msg(LOG_DEBUG, "Leaving purge_req \n");
 	ProcedureStats::num_of_purge_req_sent ++;
@@ -184,7 +186,8 @@ ActStatus ActionHandlers::detach_accept_to_ue(SM::ControlBlock& cb)
 	cmn::ipc::IpcAddress destAddr;
 	destAddr.u32 = TipcServiceInstance::s1apAppInstanceNum_c;
 
-	mmeIpcIf_g->dispatchIpcMsg((char *) &detach_accpt, sizeof(detach_accpt), destAddr);
+	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
+	mmeIpcIf.dispatchIpcMsg((char *) &detach_accpt, sizeof(detach_accpt), destAddr);
 	
 	MmeContextManagerUtils::deallocateProcedureCtxt(cb, detach_c );
 

--- a/src/mme-app/interfaces/mmeIpcInterface.cpp
+++ b/src/mme-app/interfaces/mmeIpcInterface.cpp
@@ -30,6 +30,7 @@ extern "C" {
 	#include "log.h"
 }
 
+using namespace cmn;
 using namespace cmn::ipc;
 using namespace cmn::utils;
 
@@ -37,7 +38,7 @@ extern BlockingCircularFifo<cmn::IpcEventMessage, fifoQSize_c> mmeIpcEgressFifo_
 
 MmeIpcInterface::MmeIpcInterface():sender_mp(), reader_mp()
 {
-
+     compDb.registerComponent(MmeIpcInterfaceCompId, this);
 }
 
 MmeIpcInterface::~MmeIpcInterface()

--- a/src/mme-app/main.cpp
+++ b/src/mme-app/main.cpp
@@ -101,10 +101,10 @@ int main(int argc, char *argv[])
 
 	char *hp = getenv("MMERUNENV");
 	if (hp && (strcmp(hp, "container") == 0)) {
-		init_logging("container", NULL);
+		init_logging((char*)("container"), NULL);
 	}
 	else { 
-		init_logging("hostbased", "/tmp/mmelogs.txt");
+		init_logging((char*)("hostbased"), (char*)("/tmp/mmelogs.txt"));
 	}
 	
 	init_backtrace(argv[0]);
@@ -147,11 +147,11 @@ int main(int argc, char *argv[])
 
 	monitorConfigFunc_fpg = &(MonitorSubscriber::handle_monitor_processing);
 
-    /*if (init_sock() != SUCCESS)
+    if (init_sock() != SUCCESS)
     {
         log_msg(LOG_ERROR, "Error in initializing unix domain socket server.\n");
         return -E_FAIL_INIT;
-    }*/
+    }
 
 	while(1)
 	{

--- a/src/mme-app/mmeThreads.h
+++ b/src/mme-app/mmeThreads.h
@@ -25,10 +25,9 @@
 
 #define DATA_BUF_SIZE 1024
 
+using namespace cmn;
 using namespace cmn::ipc;
 using namespace cmn::utils;
-
-extern MmeIpcInterface* mmeIpcIf_g;
 
 extern cmn::utils::BlockingCircularFifo<cmn::IpcEventMessage, fifoQSize_c> mmeIpcIngressFifo_g;
 extern cmn::utils::BlockingCircularFifo<cmn::IpcEventMessage, fifoQSize_c> mmeIpcEgressFifo_g;
@@ -41,10 +40,11 @@ public:
 		uint16_t bytesRead = 0;
 		cmn::ipc::IpcAddress srcAddr;
 		unsigned char buf[DATA_BUF_SIZE] = {0};
+		MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
 
 		while(1)
 		{
-			if ((bytesRead = mmeIpcIf_g->reader()->recvMsgFrom(buf, DATA_BUF_SIZE, srcAddr)) > 0 )
+			if ((bytesRead = mmeIpcIf.reader()->recvMsgFrom(buf, DATA_BUF_SIZE, srcAddr)) > 0 )
 			{
 				cmn::IpcEventMessage *ipcMsg = new cmn::IpcEventMessage(bytesRead);
 				MsgBuffer *msgBuf = ipcMsg->getMsgBuffer();
@@ -69,7 +69,8 @@ public:
 			cmn::IpcEventMessage* eMsg = NULL;
 			while(mmeIpcIngressFifo_g.pop(eMsg) == true)
 			{
-				mmeIpcIf_g->handleIpcMsg(eMsg);
+				MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
+				mmeIpcIf.handleIpcMsg(eMsg);
 			}
 		}
 	}
@@ -91,10 +92,12 @@ public:
 					if (msgBuf != NULL)
 					{
 						cmn::ipc::IpcMsgHeader ipcHdr;
+						MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>
+										(compDb.getComponent(MmeIpcInterfaceCompId));
 						msgBuf->rewind();
 						msgBuf->readUint32(ipcHdr.destAddr.u32);
 						msgBuf->readUint32(ipcHdr.srcAddr.u32);
-						mmeIpcIf_g->sender()->sendMsgTo(msgBuf->getDataPointer(), 
+						mmeIpcIf.sender()->sendMsgTo(msgBuf->getDataPointer(), 
 								msgBuf->getLength(), ipcHdr.destAddr);
 					}
 					delete eMsg;

--- a/src/mme-app/msgHandlers/gtpMsgHandler.cpp
+++ b/src/mme-app/msgHandlers/gtpMsgHandler.cpp
@@ -18,10 +18,11 @@
 
 #include <contextManager/subsDataGroupManager.h>
 #include <event.h>
+#include <eventMessage.h>
 #include <ipcTypes.h>
 #include <log.h>
 #include <mmeSmDefs.h>
-#include <eventMessage.h>
+#include <utils/mmeCommonUtils.h>
 
 using namespace SM;
 using namespace mme;
@@ -44,26 +45,27 @@ GtpMsgHandler* GtpMsgHandler::Instance()
 
 void GtpMsgHandler::handleGtpMessage_v(IpcEventMessage* eMsg)
 {
-    	if (eMsg == NULL)
-        	return;
+    if (eMsg == NULL)
+        return;
 
-    	utils::MsgBuffer* msgBuf = eMsg->getMsgBuffer();
-   	if (msgBuf == NULL)
-    	{
-        	log_msg(LOG_INFO, "GTP Message Buffer is empty \n");
+    utils::MsgBuffer *msgBuf = eMsg->getMsgBuffer();
+    if (msgBuf == NULL)
+    {
+        log_msg(LOG_INFO, "GTP Message Buffer is empty \n");
 
-        	delete eMsg;
-        	return;
-    	}
-    	if (msgBuf->getLength() < sizeof (gtp_incoming_msg_data_t))
-    	{
-        	log_msg(LOG_INFO, "Not enough bytes in gtp message \n");
+        delete eMsg;
+        return;
+    }
+    if (msgBuf->getLength() < sizeof(gtp_incoming_msg_data_t))
+    {
+        log_msg(LOG_INFO, "Not enough bytes in gtp message \n");
 
-        	delete eMsg;
-        	return;
-    	}
+        delete eMsg;
+        return;
+    }
 
-	const gtp_incoming_msg_data_t* msgData_p = (gtp_incoming_msg_data_t*)(msgBuf->getDataPointer());
+    const gtp_incoming_msg_data_t *msgData_p =
+            (gtp_incoming_msg_data_t*) (msgBuf->getDataPointer());
 
 	switch (msgData_p->msg_type)
 	{
@@ -170,10 +172,11 @@ void GtpMsgHandler::handleDdnMsg_v(IpcEventMessage* eMsg, uint32_t ueIdx)
 {
 	log_msg(LOG_INFO,"Inside handle DDN\n");
 
-	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
+	SM::ControlBlock* controlBlk_p =
+	        MmeCommonUtils::findControlBlockForS11Msg(eMsg->getMsgBuffer());
 	if(controlBlk_p == NULL)
 	{
-		log_msg(LOG_ERROR, "handleReleaseBearerResponse_v: "
+		log_msg(LOG_ERROR, "handleDdnMsg_v: "
 							"Failed to find UE context using idx %d\n",
 							ueIdx);
 		return;

--- a/src/mme-app/utils/mmeCauseUtils.cpp
+++ b/src/mme-app/utils/mmeCauseUtils.cpp
@@ -61,6 +61,12 @@ S1apCause MmeCauseUtils::convertToS1apCause(MmeErrorCause mmeErrorCause)
 
     switch (mmeErrorCause)
     {
+         case noError_c:
+        {
+           s1apCause.s1apCause_m.present = s1apCause_PR_radioNetwork;
+           s1apCause.s1apCause_m.choice.radioNetwork = s1apCauseRadioNetwork_user_inactivity;
+           break;
+        }
         case networkTimeout_c:
         {
             s1apCause.s1apCause_m.present = s1apCause_PR_misc;

--- a/src/mme-app/utils/mmeCommonUtils.cpp
+++ b/src/mme-app/utils/mmeCommonUtils.cpp
@@ -174,16 +174,16 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 					{
 						log_msg(LOG_ERROR, "Failed to find control block with mTmsi.\n");
 
-                        // allocate new cb and proceed?
-                        cb = SubsDataGroupManager::Instance()->allocateCB();
-                        cb->setTempDataBlock(DefaultMmeProcedureCtxt::Instance());
+                                                // allocate new cb and proceed?
+                                                cb = SubsDataGroupManager::Instance()->allocateCB();
+                                                cb->setTempDataBlock(DefaultMmeProcedureCtxt::Instance());
 					}
 				}
-                else
-                {
-                    cb = SubsDataGroupManager::Instance()->allocateCB();
-                    cb->setTempDataBlock(DefaultMmeProcedureCtxt::Instance());
-                }
+				else
+                                {
+                                        cb = SubsDataGroupManager::Instance()->allocateCB();
+                    			cb->setTempDataBlock(DefaultMmeProcedureCtxt::Instance());
+                		}
 			}
 			break;
 		}
@@ -197,6 +197,16 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 			else
 			{
 				log_msg(LOG_INFO, "Failed to find control block with mTmsi.\n");
+			}
+
+			if (cb == NULL)
+			{
+                            log_msg(LOG_INFO, "Failed to find control block using mtmsi %d."
+                                              " Allocate a temporary control block\n", msgData_p->ue_idx);
+			    
+			    // Respond  with Service Reject from default Service Request event handler
+			    cb = SubsDataGroupManager::Instance()->allocateCB();
+			    cb->setTempDataBlock(DefaultMmeProcedureCtxt::Instance());
 			}
 
 			break;
@@ -221,7 +231,14 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 				cb = SubsDataGroupManager::Instance()->findControlBlock(msgData_p->ue_idx);
 			
 			if (cb == NULL)
-				log_msg(LOG_INFO, "Failed to retrieve CB using idx %d.\n", msgData_p->ue_idx);
+			{
+                            log_msg(LOG_INFO, "Failed to find control block using index %d."
+                                              " Allocate a temporary control block\n", msgData_p->ue_idx);
+
+                            // Respond  with TAU Reject from default TAU event handler
+			    cb = SubsDataGroupManager::Instance()->allocateCB();
+			    cb->setTempDataBlock(DefaultMmeProcedureCtxt::Instance());
+			}
 
 			break;
 		}
@@ -232,6 +249,46 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 	}
 
 	return cb;
+}
+
+ControlBlock* MmeCommonUtils::findControlBlockForS11Msg(cmn::utils::MsgBuffer* msg_p)
+{
+    ControlBlock* cb_p = NULL;
+
+    const gtp_incoming_msg_data_t* msgData_p = (gtp_incoming_msg_data_t*)(msg_p->getDataPointer());
+    if(msgData_p == NULL)
+    {
+        log_msg(LOG_INFO, "GTP message data is NULL .\n");
+        return cb_p;
+    }
+
+    switch (msgData_p->msg_type)
+    {
+        case downlink_data_notification:
+        {
+            if (msgData_p->ue_idx == 0)
+            {
+                log_msg(LOG_INFO, "UE Index in DDN message data is 0.\n");
+                return cb_p;
+            }
+
+            cb_p = SubsDataGroupManager::Instance()->findControlBlock(msgData_p->ue_idx);
+            if (cb_p == NULL)
+            {
+                log_msg(LOG_INFO, "Failed to find control block using index %d."
+                        " Allocate a temporary control block\n", msgData_p->ue_idx);
+
+                // Respond  with DDN failure from default DDN event handler
+                cb_p = SubsDataGroupManager::Instance()->allocateCB();
+                cb_p->setTempDataBlock(DefaultMmeProcedureCtxt::Instance());
+            }
+        }break;
+        default:
+        {
+            log_msg(LOG_INFO, "Unhandled message type\n");
+        }
+    }
+    return cb_p;
 }
 
 bool MmeCommonUtils::isEmmInfoRequired(ControlBlock& cb, UEContext& ueCtxt, MmeProcedureCtxt& procCtxt)
@@ -247,4 +304,6 @@ bool MmeCommonUtils::isEmmInfoRequired(ControlBlock& cb, UEContext& ueCtxt, MmeP
 	}
 	return rc;
 }
+
+
 

--- a/src/mme-app/utils/mmeContextManagerUtils.cpp
+++ b/src/mme-app/utils/mmeContextManagerUtils.cpp
@@ -17,9 +17,57 @@
 #include <controlBlock.h>
 #include <contextManager/subsDataGroupManager.h>
 #include <log.h>
+#include <mmeStates/pagingStart.h>
+#include <mmeStates/serviceRequestStart.h>
+#include <mmeStates/tauStart.h>
 #include <utils/mmeContextManagerUtils.h>
 
 using namespace mme;
+
+MmeSvcReqProcedureCtxt*
+MmeContextManagerUtils::allocateServiceRequestProcedureCtxt(SM::ControlBlock& cb_r, PagingTrigger pagingTrigger)
+{
+    log_msg(LOG_DEBUG, "allocateServiceRequestProcedureCtxt: Entry");
+
+    MmeSvcReqProcedureCtxt *prcdCtxt_p =
+            SubsDataGroupManager::Instance()->getMmeSvcReqProcedureCtxt();
+    if (prcdCtxt_p != NULL)
+    {
+        prcdCtxt_p->setCtxtType(ProcedureType::serviceRequest_c);
+        prcdCtxt_p->setPagingTrigger(pagingTrigger);
+
+        if (pagingTrigger == ddnInit_c)
+        {
+            prcdCtxt_p->setNextState(PagingStart::Instance());
+        }
+        else
+        {
+            prcdCtxt_p->setNextState(ServiceRequestStart::Instance());
+        }
+
+        cb_r.setCurrentTempDataBlock(prcdCtxt_p);
+
+    }
+    return prcdCtxt_p;
+}
+
+MmeTauProcedureCtxt*
+MmeContextManagerUtils::allocateTauProcedureCtxt(SM::ControlBlock& cb_r)
+{
+    log_msg(LOG_DEBUG, "allocateTauRequestProcedureCtxt: Entry");
+
+    MmeTauProcedureCtxt *prcdCtxt_p =
+            SubsDataGroupManager::Instance()->getMmeTauProcedureCtxt();
+    if (prcdCtxt_p != NULL)
+    {
+        prcdCtxt_p->setCtxtType(ProcedureType::tau_c);
+        prcdCtxt_p->setNextState(TauStart::Instance());
+
+        cb_r.setCurrentTempDataBlock(prcdCtxt_p);
+    }
+
+    return prcdCtxt_p;
+}
 
 bool MmeContextManagerUtils::deleteProcedureCtxt(MmeProcedureCtxt* procedure_p)
 {

--- a/src/s11/handlers/ddn_ack_handler.c
+++ b/src/s11/handlers/ddn_ack_handler.c
@@ -59,7 +59,7 @@ ddn_ack_processing(struct DDN_ACK_Q_msg *ddn_ack_msg)
 	gtpHeader.msgType =  GTP_DOWNLINK_DATA_NOTIFICATION_ACK;
 	gtpHeader.sequenceNumber = ddn_ack_msg->seq_no;
 	gtpHeader.teidPresent = true;
-	gtpHeader.teid = ddn_ack_msg->ue_idx;
+	gtpHeader.teid = ddn_ack_msg->s11_sgw_cp_teid;
 
 	g_s11_sequence++;
 

--- a/src/s11/handlers/ddn_ack_handler.c
+++ b/src/s11/handlers/ddn_ack_handler.c
@@ -61,8 +61,6 @@ ddn_ack_processing(struct DDN_ACK_Q_msg *ddn_ack_msg)
 	gtpHeader.teidPresent = true;
 	gtpHeader.teid = ddn_ack_msg->s11_sgw_cp_teid;
 
-	g_s11_sequence++;
-
 	DownlinkDataNotificationAcknowledgeMsgData msgData;
 	memset(&msgData, 0, sizeof(DownlinkDataNotificationAcknowledgeMsgData));
 


### PR DESCRIPTION
This activity involves the following changes:
1.Inclusion of componentDb (to eliminate the use of extern MmeIpcIf*)
2.Handling of UeCtxtNotFound error in DDN, Service Request and TAU
3.Context Manager Crash Fixes
