### PR TITLE
Bug Fix: S11 Message Mangling

### DIFF
--- a/include/common/msgType.h
+++ b/include/common/msgType.h
@@ -569,7 +569,6 @@ struct DDN_ACK_Q_msg{
 	int s11_sgw_cp_teid;
 	uint32_t seq_no;
 	uint8_t cause;
-	struct fteid s11_sgw_c_fteid;
 };
 #define S11_DDN_ACK_BUF_SIZE sizeof(struct DDN_ACK_Q_msg)
 

--- a/include/common/msgType.h
+++ b/include/common/msgType.h
@@ -566,9 +566,9 @@ struct RB_Q_msg{
 
 struct DDN_ACK_Q_msg{
 	msg_type_t msg_type;
-	int s11_sgw_cp_teid;
 	uint32_t seq_no;
 	uint8_t cause;
+	struct fteid s11_sgw_c_fteid;
 };
 #define S11_DDN_ACK_BUF_SIZE sizeof(struct DDN_ACK_Q_msg)
 
@@ -608,6 +608,7 @@ struct ddn_Q_msg {
     uint8_t cause;
     uint8_t eps_bearer_id;
     uint32_t seq_no;
+    uint32_t sgw_ip;
 };
 
 typedef union gtp_incoming_msgs_t {

--- a/include/common/s11_structs.h
+++ b/include/common/s11_structs.h
@@ -13,6 +13,8 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 
+#define S11_MSGBUF_SIZE 2048
+
 #pragma pack(1)
 typedef struct gtpv2c_header {
 	struct gtpc{

--- a/include/s11/s11.h
+++ b/include/s11/s11.h
@@ -59,11 +59,11 @@ void* modify_bearer_handler(void *);
 void* release_bearer_handler(void *); 
 void* delete_session_handler(void *);
 void* ddn_ack_handler(void *);
-int s11_CS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr);
-int s11_MB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr);
-int s11_DS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr);
-int s11_RB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr);
-int s11_DDN_handler(MsgBuffer* message, GtpV2MessageHeader* hdr);
+int s11_CS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip);
+int s11_MB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip);
+int s11_DS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip);
+int s11_RB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip);
+int s11_DDN_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip);
 
 
 void

--- a/src/gtpV2Codec/gtpV2StackWrappers.cpp
+++ b/src/gtpV2Codec/gtpV2StackWrappers.cpp
@@ -40,6 +40,17 @@ extern "C"
         	return msgBuf_p->writeBytes(data, size, append);
         }
 
+	const uint32_t MsgBuffer_readUint32(MsgBuffer* msgBuf_p, Uint32 data)
+	{
+		msgBuf_p->readUint32(data);
+		return data;
+	}
+
+	bool MsgBuffer_writeUint32(MsgBuffer* msgBuf_p, Uint32 data, bool append)
+	{
+		return msgBuf_p->writeUint32(data, append);
+	}
+
         void MsgBuffer_rewind(MsgBuffer* msgBuf_p)
         {
         	return msgBuf_p->rewind();

--- a/src/gtpV2Codec/gtpV2StackWrappers.h
+++ b/src/gtpV2Codec/gtpV2StackWrappers.h
@@ -21,6 +21,10 @@ extern "C" {
 
 	bool MsgBuffer_writeBytes(MsgBuffer* msgBuf_p, Uint8* data, Uint16 size, bool append);
 
+	const uint32_t MsgBuffer_readUint32(MsgBuffer* msgBuf_p, Uint32 data);
+
+	bool MsgBuffer_writeUint32(MsgBuffer* msgBuf_p, Uint32 data, bool append);
+
 	void MsgBuffer_rewind(MsgBuffer* msgBuf_p);
 
 	void MsgBuffer_free(MsgBuffer* buf_p);

--- a/src/mme-app/actionHandlers/defaultMmeProcedureActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/defaultMmeProcedureActionHandlers.cpp
@@ -267,6 +267,7 @@ ActStatus ActionHandlers::default_ddn_handler(ControlBlock& cb)
         SessionContext *sess_p = ueCtxt->getSessionContext();
         if (sess_p != NULL)
         {
+	    /*We will fetch the s11_sgw_cp_teid from the session context if it's available*/
             sgw_cp_teid = sess_p->getS11SgwCtrlFteid().fteid_m.header.teid_gre;
 
             MmeSvcReqProcedureCtxt *svcReqProc_p =
@@ -307,13 +308,11 @@ ActStatus ActionHandlers::default_ddn_handler(ControlBlock& cb)
 
     if (gtpCause != GTPV2C_CAUSE_REQUEST_ACCEPTED)
     {
-        SessionContext *sess_p = ueCtxt->getSessionContext();
         struct DDN_ACK_Q_msg ddnAck;
         ddnAck.msg_type = ddn_acknowledgement;
-        ddnAck.s11_sgw_cp_teid = sess_p->getS11SgwCtrlFteid().fteid_m.header.teid_gre;
+	/*Incase of unavailability of session/UE Contexts , s11_sgw_cp_teid will be set as 0 */
+        ddnAck.s11_sgw_cp_teid = sgw_cp_teid;
         ddnAck.seq_no= ddn_info.seq_no;
-        memcpy(&(ddnAck.s11_sgw_c_fteid), 
-               &(sess_p->getS11SgwCtrlFteid().fteid_m), sizeof(struct Fteid));
         ddnAck.cause = gtpCause;
 
         cmn::ipc::IpcAddress destAddr;

--- a/src/mme-app/actionHandlers/defaultMmeProcedureActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/defaultMmeProcedureActionHandlers.cpp
@@ -311,7 +311,8 @@ ActStatus ActionHandlers::default_ddn_handler(ControlBlock& cb)
         struct DDN_ACK_Q_msg ddnAck;
         ddnAck.msg_type = ddn_acknowledgement;
 	/*Incase of unavailability of session/UE Contexts , s11_sgw_cp_teid will be set as 0 */
-        ddnAck.s11_sgw_cp_teid = sgw_cp_teid;
+        ddnAck.s11_sgw_c_fteid.header.teid_gre = sgw_cp_teid;
+	ddnAck.s11_sgw_c_fteid.ip.ipv4.s_addr = ddn_info.sgw_ip;
         ddnAck.seq_no= ddn_info.seq_no;
         ddnAck.cause = gtpCause;
 

--- a/src/mme-app/actionHandlers/serviceRequestActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/serviceRequestActionHandlers.cpp
@@ -146,9 +146,6 @@ ActStatus ActionHandlers::send_ddn_ack_to_sgw(ControlBlock& cb)
 	ddn_ack.msg_type = ddn_acknowledgement;
 	ddn_ack.s11_sgw_cp_teid = sess_p->getS11SgwCtrlFteid().fteid_m.header.teid_gre;
 	ddn_ack.seq_no= srPrcdCtxt_p->getDdnSeqNo();
-	memcpy(&(ddn_ack.s11_sgw_c_fteid), 
-               &(sess_p->getS11SgwCtrlFteid().fteid_m),
-               sizeof(struct Fteid));
 	ddn_ack.cause = GTPV2C_CAUSE_REQUEST_ACCEPTED;
 	
 	cmn::ipc::IpcAddress destAddr;

--- a/src/mme-app/actionHandlers/serviceRequestActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/serviceRequestActionHandlers.cpp
@@ -144,8 +144,9 @@ ActStatus ActionHandlers::send_ddn_ack_to_sgw(ControlBlock& cb)
 
 	DDN_ACK_Q_msg ddn_ack;
 	ddn_ack.msg_type = ddn_acknowledgement;
-	ddn_ack.s11_sgw_cp_teid = sess_p->getS11SgwCtrlFteid().fteid_m.header.teid_gre;
 	ddn_ack.seq_no= srPrcdCtxt_p->getDdnSeqNo();
+	memcpy(&(ddn_ack.s11_sgw_c_fteid), 	
+               &(sess_p->getS11SgwCtrlFteid().fteid_m), sizeof(struct Fteid));
 	ddn_ack.cause = GTPV2C_CAUSE_REQUEST_ACCEPTED;
 	
 	cmn::ipc::IpcAddress destAddr;

--- a/src/s11/handlers/create_session_handler.c
+++ b/src/s11/handlers/create_session_handler.c
@@ -93,7 +93,7 @@ convert_imsi_to_digits_array(uint8_t *src, uint8_t *dest, uint32_t len)
 static int
 create_session_processing(struct CS_Q_msg * g_csReqInfo)
 {
-	struct MsgBuffer*  csReqMsgBuf_p = createMsgBuffer(2048);
+	struct MsgBuffer*  csReqMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
 	if(csReqMsgBuf_p == NULL)
 	{
                 log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");

--- a/src/s11/handlers/create_session_handler.c
+++ b/src/s11/handlers/create_session_handler.c
@@ -52,7 +52,6 @@ volatile uint32_t g_s11_sequence = 1;
 struct CS_Q_msg *g_csReqInfo;
 
 extern struct GtpV2Stack* gtpStack_gp;
-struct MsgBuffer*  csReqMsgBuf_p = NULL;
 
 void
 bswap8_array(uint8_t *src, uint8_t *dest, uint32_t len)
@@ -94,7 +93,13 @@ convert_imsi_to_digits_array(uint8_t *src, uint8_t *dest, uint32_t len)
 static int
 create_session_processing(struct CS_Q_msg * g_csReqInfo)
 {
-    struct sockaddr_in sgw_addr = {0};
+	struct MsgBuffer*  csReqMsgBuf_p = createMsgBuffer(2048);
+	if(csReqMsgBuf_p == NULL)
+	{
+                log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+                return -1;
+        }
+    	struct sockaddr_in sgw_addr = {0};
 	GtpV2MessageHeader gtpHeader;
 	gtpHeader.msgType = GTP_CREATE_SESSION_REQ;
 	gtpHeader.sequenceNumber = g_s11_sequence;
@@ -249,7 +254,7 @@ create_session_processing(struct CS_Q_msg * g_csReqInfo)
 	log_msg(LOG_INFO,"%d bytes sent. Err : %d, %s\n",res,errno,
 			strerror(errno));
 
-	MsgBuffer_reset(csReqMsgBuf_p);
+	MsgBuffer_free(csReqMsgBuf_p);
 
 	return SUCCESS;
 }

--- a/src/s11/handlers/ddn_ack_handler.c
+++ b/src/s11/handlers/ddn_ack_handler.c
@@ -37,7 +37,6 @@ extern volatile uint32_t g_s11_sequence;
 extern struct GtpV2Stack* gtpStack_gp;
 struct thread_pool *g_tpool;
 
-struct MsgBuffer* ddnAckMsgBuf_p = NULL;
 /****Global and externs end***/
 
 /**
@@ -46,14 +45,19 @@ struct MsgBuffer* ddnAckMsgBuf_p = NULL;
 static int
 ddn_ack_processing(struct DDN_ACK_Q_msg *ddn_ack_msg)
 {
+	struct MsgBuffer* ddnAckMsgBuf_p = createMsgBuffer(1024);
+	if(ddnAckMsgBuf_p == NULL)
+	{
+	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+            return -1;
+	}
 	GtpV2MessageHeader gtpHeader;
 	gtpHeader.msgType =  GTP_DOWNLINK_DATA_NOTIFICATION_ACK;
 	gtpHeader.sequenceNumber = ddn_ack_msg->seq_no;
 	gtpHeader.teidPresent = true;
-	gtpHeader.teid = ddn_ack_msg->s11_sgw_c_fteid.header.teid_gre;
+	gtpHeader.teid = ddn_ack_msg->s11_sgw_cp_teid;
     struct sockaddr_in sgw_ip = {0};
-    create_sock_addr(&sgw_ip, g_s11_cfg.egtp_def_port,
-                    ddn_ack_msg->s11_sgw_c_fteid.ip.ipv4.s_addr);
+    create_sock_addr(&sgw_ip, g_s11_cfg.egtp_def_port, htonl(g_s11_cp_addr.sin_addr.s_addr));
 
 	DownlinkDataNotificationAcknowledgeMsgData msgData;
 	memset(&msgData, 0, sizeof(DownlinkDataNotificationAcknowledgeMsgData));
@@ -71,7 +75,7 @@ ddn_ack_processing(struct DDN_ACK_Q_msg *ddn_ack_msg)
 			(struct sockaddr*)&sgw_ip, g_s11_serv_size);
 	
 	log_msg(LOG_INFO, "DDN Ack Sent, len - %d bytes.\n", MsgBuffer_getBufLen(ddnAckMsgBuf_p));
-	MsgBuffer_reset(ddnAckMsgBuf_p);
+	MsgBuffer_free(ddnAckMsgBuf_p);
 	return SUCCESS;
 }
 

--- a/src/s11/handlers/ddn_ack_handler.c
+++ b/src/s11/handlers/ddn_ack_handler.c
@@ -45,7 +45,7 @@ struct thread_pool *g_tpool;
 static int
 ddn_ack_processing(struct DDN_ACK_Q_msg *ddn_ack_msg)
 {
-	struct MsgBuffer* ddnAckMsgBuf_p = createMsgBuffer(1024);
+	struct MsgBuffer* ddnAckMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
 	if(ddnAckMsgBuf_p == NULL)
 	{
 	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
@@ -55,9 +55,9 @@ ddn_ack_processing(struct DDN_ACK_Q_msg *ddn_ack_msg)
 	gtpHeader.msgType =  GTP_DOWNLINK_DATA_NOTIFICATION_ACK;
 	gtpHeader.sequenceNumber = ddn_ack_msg->seq_no;
 	gtpHeader.teidPresent = true;
-	gtpHeader.teid = ddn_ack_msg->s11_sgw_cp_teid;
+	gtpHeader.teid = ddn_ack_msg->s11_sgw_c_fteid.header.teid_gre;
     struct sockaddr_in sgw_ip = {0};
-    create_sock_addr(&sgw_ip, g_s11_cfg.egtp_def_port, htonl(g_s11_cp_addr.sin_addr.s_addr));
+    create_sock_addr(&sgw_ip, g_s11_cfg.egtp_def_port, ddn_ack_msg->s11_sgw_c_fteid.ip.ipv4.s_addr);
 
 	DownlinkDataNotificationAcknowledgeMsgData msgData;
 	memset(&msgData, 0, sizeof(DownlinkDataNotificationAcknowledgeMsgData));

--- a/src/s11/handlers/delete_session_handler.c
+++ b/src/s11/handlers/delete_session_handler.c
@@ -43,7 +43,6 @@ struct thread_pool *g_tpool;
 extern struct GtpV2Stack* gtpStack_gp;
 extern volatile uint32_t g_s11_sequence;
 
-struct MsgBuffer*  dsReqMsgBuf_p = NULL;
 /****Global and externs end***/
 
 /**
@@ -52,6 +51,12 @@ struct MsgBuffer*  dsReqMsgBuf_p = NULL;
 static int
 delete_session_processing(struct DS_Q_msg *ds_msg)
 {
+	struct MsgBuffer*  dsReqMsgBuf_p = createMsgBuffer(1024);
+	if(dsReqMsgBuf_p == NULL)
+	{
+	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+            return -1;
+	}
 	GtpV2MessageHeader gtpHeader;
 	gtpHeader.msgType = GTP_DELETE_SESSION_REQ;
 	gtpHeader.sequenceNumber = g_s11_sequence;
@@ -80,7 +85,7 @@ delete_session_processing(struct DS_Q_msg *ds_msg)
 			(struct sockaddr*)&sgw_ip, g_s11_serv_size);
 	log_msg(LOG_INFO, "Send delete session request\n");
 
-	MsgBuffer_reset(dsReqMsgBuf_p);
+	MsgBuffer_free(dsReqMsgBuf_p);
 
 	return SUCCESS;
 }

--- a/src/s11/handlers/delete_session_handler.c
+++ b/src/s11/handlers/delete_session_handler.c
@@ -51,7 +51,7 @@ extern volatile uint32_t g_s11_sequence;
 static int
 delete_session_processing(struct DS_Q_msg *ds_msg)
 {
-	struct MsgBuffer*  dsReqMsgBuf_p = createMsgBuffer(1024);
+	struct MsgBuffer*  dsReqMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
 	if(dsReqMsgBuf_p == NULL)
 	{
 	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");

--- a/src/s11/handlers/modify_bearer_handler.c
+++ b/src/s11/handlers/modify_bearer_handler.c
@@ -56,7 +56,7 @@ extern struct GtpV2Stack* gtpStack_gp;
 static int
 modify_bearer_processing(struct MB_Q_msg *mb_msg)
 {
-	struct MsgBuffer*  mbReqMsgBuf_p = createMsgBuffer(2048);
+	struct MsgBuffer*  mbReqMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
 	if(mbReqMsgBuf_p == NULL)
 	{
 	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");

--- a/src/s11/handlers/modify_bearer_handler.c
+++ b/src/s11/handlers/modify_bearer_handler.c
@@ -48,7 +48,6 @@ extern volatile uint32_t g_s11_sequence;
 /*TODO: S11 protocol sequence number - need to make it atomic. multiple thread to access this*/
 extern volatile uint32_t g_s11_sequence;
 
-struct MsgBuffer*  mbReqMsgBuf_p = NULL;
 extern struct GtpV2Stack* gtpStack_gp;
 /****Global and externs end***/
 /**
@@ -57,6 +56,12 @@ extern struct GtpV2Stack* gtpStack_gp;
 static int
 modify_bearer_processing(struct MB_Q_msg *mb_msg)
 {
+	struct MsgBuffer*  mbReqMsgBuf_p = createMsgBuffer(2048);
+	if(mbReqMsgBuf_p == NULL)
+	{
+	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+            return -1;
+	}
 	GtpV2MessageHeader gtpHeader;
 	gtpHeader.msgType = GTP_MODIFY_BEARER_REQ;
 	gtpHeader.sequenceNumber = g_s11_sequence;
@@ -139,7 +144,7 @@ modify_bearer_processing(struct MB_Q_msg *mb_msg)
 	//TODO " error chk, eagain etc?	
 	log_msg(LOG_INFO, "Modify bearer sent, len - %d bytes.\n", MsgBuffer_getBufLen(mbReqMsgBuf_p));
 
-	MsgBuffer_reset(mbReqMsgBuf_p);
+	MsgBuffer_free(mbReqMsgBuf_p);
 
 	return SUCCESS;
 }

--- a/src/s11/handlers/release_bearer_handler.c
+++ b/src/s11/handlers/release_bearer_handler.c
@@ -53,7 +53,7 @@ extern struct GtpV2Stack* gtpStack_gp;
 static int
 release_bearer_processing(struct RB_Q_msg *rb_msg)
 {
-    struct MsgBuffer*  rbReqMsgBuf_p = createMsgBuffer(1024);
+    struct MsgBuffer*  rbReqMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
     if(rbReqMsgBuf_p == NULL)
     {
 	log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");

--- a/src/s11/handlers/release_bearer_handler.c
+++ b/src/s11/handlers/release_bearer_handler.c
@@ -43,7 +43,6 @@ extern socklen_t g_s11_serv_size;
 /*TODO: S11 protocol sequence number - need to make it atomic. multiple thread to access this*/
 extern volatile uint32_t g_s11_sequence;
 
-struct MsgBuffer*  rbReqMsgBuf_p = NULL;
 extern struct GtpV2Stack* gtpStack_gp;
 
 
@@ -54,6 +53,12 @@ extern struct GtpV2Stack* gtpStack_gp;
 static int
 release_bearer_processing(struct RB_Q_msg *rb_msg)
 {
+    struct MsgBuffer*  rbReqMsgBuf_p = createMsgBuffer(1024);
+    if(rbReqMsgBuf_p == NULL)
+    {
+	log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+	return -1;
+    }
     GtpV2MessageHeader gtpHeader;	
     gtpHeader.msgType = GTP_RABR_REQ;
     gtpHeader.sequenceNumber = g_s11_sequence;
@@ -81,7 +86,7 @@ release_bearer_processing(struct RB_Q_msg *rb_msg)
     //TODO " error chk, eagain etc?
     log_msg(LOG_INFO, "Release Bearer sent, len - %d bytes.\n", MsgBuffer_getBufLen(rbReqMsgBuf_p));
 
-    MsgBuffer_reset(rbReqMsgBuf_p);
+    MsgBuffer_free(rbReqMsgBuf_p);
 
     return SUCCESS;
 

--- a/src/s11/handlers/s11_CS_resp_handler.c
+++ b/src/s11/handlers/s11_CS_resp_handler.c
@@ -30,7 +30,7 @@ extern struct GtpV2Stack* gtpStack_gp;
 
 
 int
-s11_CS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr)
+s11_CS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip)
 {
 
 	struct gtp_incoming_msg_data_t csr_info;

--- a/src/s11/handlers/s11_DDN_handler.c
+++ b/src/s11/handlers/s11_DDN_handler.c
@@ -26,12 +26,13 @@ extern struct GtpV2Stack* gtpStack_gp;
 
 
 int
-s11_DDN_handler(MsgBuffer* message, GtpV2MessageHeader* hdr)
+s11_DDN_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip)
 {
 	struct gtp_incoming_msg_data_t ddn_info;
 	ddn_info.msg_type = downlink_data_notification;
 	ddn_info.ue_idx = hdr->teid;
 	ddn_info.msg_data.ddn_Q_msg_m.seq_no = hdr->sequenceNumber;
+	ddn_info.msg_data.ddn_Q_msg_m.sgw_ip = sgw_ip;
 
 
 	DownlinkDataNotificationMsgData msgData;

--- a/src/s11/handlers/s11_DS_resp_handler.c
+++ b/src/s11/handlers/s11_DS_resp_handler.c
@@ -29,7 +29,7 @@ extern struct GtpV2Stack* gtpStack_gp;
 /*End : globals and externs*/
 
 int
-s11_DS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr)
+s11_DS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip)
 {
 
 

--- a/src/s11/handlers/s11_MB_resp_handler.c
+++ b/src/s11/handlers/s11_MB_resp_handler.c
@@ -29,7 +29,7 @@ extern struct GtpV2Stack* gtpStack_gp;
 /*End : globals and externs*/
 
 int
-s11_MB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr)
+s11_MB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip)
 {
 	
 	struct gtp_incoming_msg_data_t mbr_info;

--- a/src/s11/handlers/s11_RB_resp_handler.c
+++ b/src/s11/handlers/s11_RB_resp_handler.c
@@ -27,7 +27,7 @@ extern struct GtpV2Stack* gtpStack_gp;
 /*End : globals and externs*/
 
 int
-s11_RB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr)
+s11_RB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip)
 {	
 	struct gtp_incoming_msg_data_t rbr_info;
 	

--- a/src/s11/handlers/s11_msg_delegator.c
+++ b/src/s11/handlers/s11_msg_delegator.c
@@ -165,6 +165,8 @@ handle_s11_message(void *message)
 	log_msg(LOG_INFO, "S11 recv msg handler.\n");
 
 	MsgBuffer* msgBuf_p = (MsgBuffer*)(message);
+
+	uint32_t sgw_ip = MsgBuffer_readUint32(msgBuf_p, sgw_ip);
 	
 	GtpV2MessageHeader msgHeader;
 
@@ -175,23 +177,23 @@ handle_s11_message(void *message)
 
 	switch(msgHeader.msgType){
 	case S11_GTP_CREATE_SESSION_RESP:
-		s11_CS_resp_handler(msgBuf_p, &msgHeader);
+		s11_CS_resp_handler(msgBuf_p, &msgHeader, sgw_ip);
 		break;
 
 	case S11_GTP_MODIFY_BEARER_RESP:
-		s11_MB_resp_handler(msgBuf_p, &msgHeader);
+		s11_MB_resp_handler(msgBuf_p, &msgHeader, sgw_ip);
 		break;
 
 	case S11_GTP_DELETE_SESSION_RESP:
-		s11_DS_resp_handler(msgBuf_p, &msgHeader);
+		s11_DS_resp_handler(msgBuf_p, &msgHeader, sgw_ip);
 		break;
 	
 	case S11_GTP_REL_ACCESS_BEARER_RESP:
-		s11_RB_resp_handler(msgBuf_p, &msgHeader);
+		s11_RB_resp_handler(msgBuf_p, &msgHeader, sgw_ip);
 		break;
 	
 	case S11_GTP_DOWNLINK_DATA_NOTIFICATION:
-                s11_DDN_handler(msgBuf_p, &msgHeader);
+                s11_DDN_handler(msgBuf_p, &msgHeader, sgw_ip);
                 break;
 
 	}

--- a/src/s11/main.c
+++ b/src/s11/main.c
@@ -195,6 +195,8 @@ s11_reader()
 
 		if(len > 0) {
 			MsgBuffer* tmp_buf_p = createMsgBuffer(len);
+			uint32_t ip = ntohl(g_s11_cp_addr.sin_addr.s_addr);
+			MsgBuffer_writeUint32(tmp_buf_p, ip, true);
 			MsgBuffer_writeBytes(tmp_buf_p, buffer, len, true);
 			MsgBuffer_rewind(tmp_buf_p);
 

--- a/src/s11/main.c
+++ b/src/s11/main.c
@@ -97,11 +97,6 @@ void * tipc_msg_handler_s11()
 	}
 }
 struct GtpV2Stack* gtpStack_gp = NULL;
-extern struct MsgBuffer* csReqMsgBuf_p;
-extern struct MsgBuffer* mbReqMsgBuf_p;
-extern struct MsgBuffer* dsReqMsgBuf_p;
-extern struct MsgBuffer* rbReqMsgBuf_p;
-extern struct MsgBuffer* ddnAckMsgBuf_p;
 
 int
 init_s11_workers()
@@ -238,18 +233,6 @@ main(int argc, char **argv)
 	if (gtpStack_gp == NULL)
 	{
 		log_msg(LOG_ERROR, "Error in initializing ipc.\n");
-		return -1;
-	}
-
-	csReqMsgBuf_p = createMsgBuffer(4096);
-	mbReqMsgBuf_p = createMsgBuffer(4096);
-	dsReqMsgBuf_p = createMsgBuffer(4096);
-	rbReqMsgBuf_p = createMsgBuffer(4096);
-	ddnAckMsgBuf_p = createMsgBuffer(4096);
-
-	if (csReqMsgBuf_p == NULL || mbReqMsgBuf_p == NULL || dsReqMsgBuf_p == NULL || rbReqMsgBuf_p == NULL || ddnAckMsgBuf_p == NULL)
-	{
-		log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
 		return -1;
 	}
 


### PR DESCRIPTION
This bug fix deals with 
1.Localization of s11 MsgBuffers to avoid conflicts when two or more threads handle the same type of incoming message.
2.Storing the IP Address of the sending entity in the MsgBuffer, so that it can be used while responding to CONTEXT_NOT_FOUND cases.
