### PR TITLE
Change Key->cbIndex Map to Unordered Map

### DIFF
--- a/include/mme-app/contextManager/subsDataGroupManager.h
+++ b/include/mme-app/contextManager/subsDataGroupManager.h
@@ -13,7 +13,7 @@
  * All edits to be made through template source file
  * <TOP-DIR/scripts/SMCodeGen/templates/ctxtManagerTmpls/subsDataGroupManager.h.tt>
  ***************************************/
-#include <map>
+#include <unordered_map>
 #include <mutex>
 #include "dataGroupManager.h"
 
@@ -200,6 +200,12 @@ namespace mme
 			int deleteimsikey( DigitRegister15 key );
 			
 			/******************************************
+			* sizeimsiKeyMap
+			* size of imsi_cb_id_map
+			******************************************/		
+			int sizeImsiKeyMap();
+			
+			/******************************************
 			* findCBWithimsi
 			* Find cb with given imsi from imsi_cb_id_map
 			******************************************/	
@@ -215,6 +221,12 @@ namespace mme
 			* delete a mTmsi key from mTmsi_cb_id_map
 			******************************************/		
 			int deletemTmsikey( uint32_t key );
+			
+			/******************************************
+			* sizemTmsiKeyMap
+			* size of mTmsi_cb_id_map
+			******************************************/		
+			int sizeMTmsiKeyMap();
 			
 			/******************************************
 			* findCBWithmTmsi
@@ -295,7 +307,7 @@ namespace mme
 			/****************************************
 			* imsi Key Map
 			****************************************/
-			std::map<DigitRegister15,int> imsi_cb_id_map;
+			std::unordered_map<DigitRegister15, int , DigitRegister15Hash> imsi_cb_id_map;
 			
 			/****************************************
 			* imsi Key Map
@@ -304,7 +316,7 @@ namespace mme
 			/****************************************
 			* mTmsi Key Map
 			****************************************/
-			std::map<uint32_t,int> mTmsi_cb_id_map;
+			std::unordered_map<uint32_t,int> mTmsi_cb_id_map;
 			
 			/****************************************
 			* mTmsi Key Map

--- a/include/mme-app/structs.h
+++ b/include/mme-app/structs.h
@@ -276,12 +276,26 @@ class DigitRegister15
 		void operator = ( const DigitRegister15& data_i );
 		bool operator == ( const DigitRegister15& data_i )const;
 		bool operator < ( const DigitRegister15& data_i )const;
+		const uint8_t * getDigitsArray() const;
 
 		friend std::ostream& operator << ( std::ostream& os, const DigitRegister15& data_i );
 	
 	private:
 
 		uint8_t digitsArray[15];
+};
+
+struct DigitRegister15Hash {
+    std::size_t operator()(const DigitRegister15 &data_i ) const
+    {
+	std::size_t hash=0;
+	std::hash< uint8_t> hasher;
+	for (int i = 0;i<15;i++)
+	{
+		hash = hash *31+ hasher(data_i.getDigitsArray()[i]);
+	}
+        return hash;
+    }
 };
 
 #endif

--- a/include/s1ap/s1apContextManager/s1apDataGroupManager.h
+++ b/include/s1ap/s1apContextManager/s1apDataGroupManager.h
@@ -13,7 +13,7 @@
  * All edits to be made through template source file
  * <TOP-DIR/scripts/SMCodeGen/templates/ctxtManagerTmpls/subsDataGroupManager.h.tt>
  ***************************************/
-#include <map>
+#include <unordered_map>
 #include <mutex>
 #include "dataGroupManager.h"
 #include "s1apContextManager/s1apDataBlocks.h"
@@ -67,6 +67,12 @@ namespace mme
 			int deleteenbFdkey( int key );
 			
 			/******************************************
+			* sizeenbFdKeyMap
+			* size of enbFd_cb_id_map
+			******************************************/		
+			int sizeEnbFdKeyMap();
+			
+			/******************************************
 			* findCBWithenbFd
 			* Find cb with given enbFd from enbFd_cb_id_map
 			******************************************/	
@@ -82,6 +88,12 @@ namespace mme
 			* delete a enbId key from enbId_cb_id_map
 			******************************************/		
 			int deleteenbIdkey( int key );
+			
+			/******************************************
+			* sizeenbIdKeyMap
+			* size of enbId_cb_id_map
+			******************************************/		
+			int sizeEnbIdKeyMap();
 			
 			/******************************************
 			* findCBWithenbId
@@ -107,7 +119,7 @@ namespace mme
 			/****************************************
 			* enbFd Key Map
 			****************************************/
-			std::map<int,int> enbFd_cb_id_map;
+			std::unordered_map<int,int> enbFd_cb_id_map;
 			
 			/****************************************
 			* enbFd Key Map
@@ -116,7 +128,7 @@ namespace mme
 			/****************************************
 			* enbId Key Map
 			****************************************/
-			std::map<int,int> enbId_cb_id_map;
+			std::unordered_map<int,int> enbId_cb_id_map;
 			
 			/****************************************
 			* enbId Key Map

--- a/scripts/SMCodeGen/dataModels/ctxtManagerAppModel.json
+++ b/scripts/SMCodeGen/dataModels/ctxtManagerAppModel.json
@@ -66,6 +66,7 @@
 							{
 								"Name": "imsi",
 								"Type": "DigitRegister15",
+								"Hash": "DigitRegister15Hash",
 								"Key": "Yes"
 							},
 							{

--- a/scripts/SMCodeGen/templates/ctxtManagerTmpls/commonMacro.tt
+++ b/scripts/SMCodeGen/templates/ctxtManagerTmpls/commonMacro.tt
@@ -26,7 +26,7 @@
  [%- argument = String.new() %]
  [%- dataType = String.new() %]
  [%- dataType = "" -%]
- [%- IF Data.Type.search('^(\w)+( )?\*$') %]
+ [%- IF Data.Type.search('^(((\w)+\:\:)?\w)+( )?\*$') %]
  [%-    dataType = Data.Type -%]
  [%- ELSIF primitiveTypes.grep("$Data.Type").size !=0 %]
  [%-    dataType = Data.Type -%]

--- a/scripts/SMCodeGen/templates/ctxtManagerTmpls/subsDataGroupManager.cpp.tt
+++ b/scripts/SMCodeGen/templates/ctxtManagerTmpls/subsDataGroupManager.cpp.tt
@@ -90,7 +90,7 @@ namespace mme
 
 		int rc = 1;
 
-		auto itr = [% Data.Name %]_cb_id_map.insert(std::pair<[% Data.Type %], int>( key, cb_index ));
+		auto itr = [% Data.Name %]_cb_id_map.insert({ key, cb_index });
 		if (itr.second == false)
 		{
 			rc = -1;
@@ -107,6 +107,16 @@ namespace mme
  
 		return [% Data.Name %]_cb_id_map.erase( key );
 	}
+	
+	/******************************************
+	* get size of  [% Data.Name %]_cb_id_map
+	******************************************/
+	int [% DataGroup.DgName %]DataGroupManager::size[% String.new(Data.Name).capital.text() %]KeyMap()
+	{
+		std::lock_guard<std::mutex> lock([% Data.Name %]_cb_id_map_mutex);
+ 
+		return [% Data.Name %]_cb_id_map.size();
+	}	
 	
 	/******************************************
 	* Find cb with given [% Data.Name %] from [% Data.Name %]_cb_id_map

--- a/scripts/SMCodeGen/templates/ctxtManagerTmpls/subsDataGroupManager.h.tt
+++ b/scripts/SMCodeGen/templates/ctxtManagerTmpls/subsDataGroupManager.h.tt
@@ -17,7 +17,7 @@
  * All edits to be made through template source file
  * <TOP-DIR/scripts/SMCodeGen/templates/ctxtManagerTmpls/subsDataGroupManager.h.tt>
  ***************************************/
-#include <map>
+#include <unordered_map>
 #include <mutex>
 #include "dataGroupManager.h"
 
@@ -86,6 +86,12 @@ namespace mme
 			int delete[% Data.Name %]key( [% Data.Type %] key );
 			
 			/******************************************
+			* size[% Data.Name %]KeyMap
+			* size of [% Data.Name %]_cb_id_map
+			******************************************/		
+			int size[% String.new(Data.Name).capital.text() %]KeyMap();
+			
+			/******************************************
 			* findCBWith[% Data.Name %]
 			* Find cb with given [% Data.Name %] from [% Data.Name %]_cb_id_map
 			******************************************/	
@@ -117,7 +123,11 @@ namespace mme
 			/****************************************
 			* [% Data.Name %] Key Map
 			****************************************/
-			std::map<[% Data.Type %],int> [% Data.Name %]_cb_id_map;
+			[%- IF Data.Hash == '' %]
+			std::unordered_map<[% Data.Type %],int> [% Data.Name %]_cb_id_map;
+			[%- ELSE %]
+			std::unordered_map<[% Data.Type %], int , [% Data.Hash %]> [% Data.Name %]_cb_id_map;
+			[%- END %]
 			
 			/****************************************
 			* [% Data.Name %] Key Map

--- a/src/mme-app/contextManager/subsDataGroupManager.cpp
+++ b/src/mme-app/contextManager/subsDataGroupManager.cpp
@@ -203,7 +203,7 @@ namespace mme
 
 		int rc = 1;
 
-		auto itr = imsi_cb_id_map.insert(std::pair<DigitRegister15, int>( key, cb_index ));
+		auto itr = imsi_cb_id_map.insert({ key, cb_index });
 		if (itr.second == false)
 		{
 			rc = -1;
@@ -220,6 +220,16 @@ namespace mme
  
 		return imsi_cb_id_map.erase( key );
 	}
+	
+	/******************************************
+	* get size of  imsi_cb_id_map
+	******************************************/
+	int SubsDataGroupManager::sizeImsiKeyMap()
+	{
+		std::lock_guard<std::mutex> lock(imsi_cb_id_map_mutex);
+ 
+		return imsi_cb_id_map.size();
+	}	
 	
 	/******************************************
 	* Find cb with given imsi from imsi_cb_id_map
@@ -245,7 +255,7 @@ namespace mme
 
 		int rc = 1;
 
-		auto itr = mTmsi_cb_id_map.insert(std::pair<uint32_t, int>( key, cb_index ));
+		auto itr = mTmsi_cb_id_map.insert({ key, cb_index });
 		if (itr.second == false)
 		{
 			rc = -1;
@@ -262,6 +272,16 @@ namespace mme
  
 		return mTmsi_cb_id_map.erase( key );
 	}
+	
+	/******************************************
+	* get size of  mTmsi_cb_id_map
+	******************************************/
+	int SubsDataGroupManager::sizeMTmsiKeyMap()
+	{
+		std::lock_guard<std::mutex> lock(mTmsi_cb_id_map_mutex);
+ 
+		return mTmsi_cb_id_map.size();
+	}	
 	
 	/******************************************
 	* Find cb with given mTmsi from mTmsi_cb_id_map

--- a/src/mme-app/mmeStates/s1ReleaseStart.cpp
+++ b/src/mme-app/mmeStates/s1ReleaseStart.cpp
@@ -70,7 +70,7 @@ void S1ReleaseStart::initialize()
         }
         {
                 ActionTable actionTable;
-				actionTable.addAction(&ActionHandlers::handle_state_guard_timeouts);
+                actionTable.addAction(&ActionHandlers::handle_state_guard_timeouts);
                 eventToActionsMap.insert(pair<uint16_t, ActionTable>(STATE_GUARD_TIMEOUT, actionTable));
         }
 }

--- a/src/mme-app/structs.cpp
+++ b/src/mme-app/structs.cpp
@@ -507,6 +507,11 @@ bool DigitRegister15::operator < ( const DigitRegister15& data_i )const
     return rc;
 }
 
+const uint8_t* DigitRegister15::getDigitsArray() const
+{
+   return digitsArray;
+}
+
 std::ostream& operator << ( std::ostream& os, const DigitRegister15& data_i )
 {
 	for( auto x : data_i.digitsArray )
@@ -517,4 +522,3 @@ std::ostream& operator << ( std::ostream& os, const DigitRegister15& data_i )
 	os << "\0";	
 	return os;
 }
-

--- a/src/s1ap/s1apContextManager/s1apDataBlocks.cpp
+++ b/src/s1ap/s1apContextManager/s1apDataBlocks.cpp
@@ -150,7 +150,7 @@ namespace mme
 	******************************************************************************/	
 	uint16_t EnbContext::getEnbnameLen() const
 	{
-		return enbnameLen_m;
+    		return enbnameLen_m;
 	}
 	
 } // mme

--- a/src/s1ap/s1apContextManager/s1apDataGroupManager.cpp
+++ b/src/s1ap/s1apContextManager/s1apDataGroupManager.cpp
@@ -71,7 +71,7 @@ namespace mme
 
 		int rc = 1;
 
-		auto itr = enbFd_cb_id_map.insert(std::pair<int, int>( key, cb_index ));
+		auto itr = enbFd_cb_id_map.insert({ key, cb_index });
 		if (itr.second == false)
 		{
 			rc = -1;
@@ -88,6 +88,16 @@ namespace mme
  
 		return enbFd_cb_id_map.erase( key );
 	}
+	
+	/******************************************
+	* get size of  enbFd_cb_id_map
+	******************************************/
+	int S1apDataGroupManager::sizeEnbFdKeyMap()
+	{
+		std::lock_guard<std::mutex> lock(enbFd_cb_id_map_mutex);
+ 
+		return enbFd_cb_id_map.size();
+	}	
 	
 	/******************************************
 	* Find cb with given enbFd from enbFd_cb_id_map
@@ -113,7 +123,7 @@ namespace mme
 
 		int rc = 1;
 
-		auto itr = enbId_cb_id_map.insert(std::pair<int, int>( key, cb_index ));
+		auto itr = enbId_cb_id_map.insert({ key, cb_index });
 		if (itr.second == false)
 		{
 			rc = -1;
@@ -130,6 +140,16 @@ namespace mme
  
 		return enbId_cb_id_map.erase( key );
 	}
+	
+	/******************************************
+	* get size of  enbId_cb_id_map
+	******************************************/
+	int S1apDataGroupManager::sizeEnbIdKeyMap()
+	{
+		std::lock_guard<std::mutex> lock(enbId_cb_id_map_mutex);
+ 
+		return enbId_cb_id_map.size();
+	}	
 	
 	/******************************************
 	* Find cb with given enbId from enbId_cb_id_map


### PR DESCRIPTION
This activity includes the following script changes:

1. Changed the key->cbIdx map maintained by the DataGroupManager to unordered_map.
2. Supported API to return the map size.