### PR TITLE
ics req qos fix

### DIFF
--- a/include/common/msgType.h
+++ b/include/common/msgType.h
@@ -392,6 +392,10 @@ struct init_ctx_req_Q_msg {
 	unsigned char sec_key[32];
 	struct fteid gtp_teid;
 	unsigned char bearer_id;
+    uint8_t qci;
+    uint8_t pl;
+    uint8_t pvi;
+    uint8_t pci;
 	bool ho_restrict_list_presence;
 	ho_restriction_list ho_restrict_list;
 	uint8_t 	nasMsgBuf[300]; 
@@ -709,6 +713,7 @@ struct csr_Q_msg {
     struct fteid s1u_sgw_fteid;
     struct fteid s5s8_pgwu_fteid;
     struct PAA pdn_addr;
+    bearer_qos_t bearerQos;
     uint16_t pco_length;
     unsigned char pco_options[MAX_PCO_OPTION_SIZE];
     uint32_t apn_ambr_ul;

--- a/include/s11/s11_options.h
+++ b/include/s11/s11_options.h
@@ -12,6 +12,7 @@
 #include <arpa/inet.h>
 #include <stdbool.h>
 
+uint64_t conv_uint8_arr_to_uint64(const uint8_t* bit_rate_array);
 uint8_t create_sock_addr(
                 struct sockaddr_in *addr, 
                 uint16_t port, uint32_t val);

--- a/src/mme-app/actionHandlers/serviceRequestActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/serviceRequestActionHandlers.cpp
@@ -593,10 +593,15 @@ ActStatus ActionHandlers::abort_service_req_procedure(ControlBlock& cb)
         MmeContextManagerUtils::deallocateProcedureCtxt(cb, procedure_p);
     }
 
-    // Fire a page failure event, so that interested procedures
-    // can take appropriate actions.
+    /* Fire a page failure event, so that interested procedures
+    * can take appropriate actions.
+    * Commenting now. Causes deleting of UE context in case of 
+    * UE initiated Service request. Paging failure should be initiated
+    * only if Paging procedure had been initiated.
+    */
+    /*
     SM::Event evt(PAGING_FAILURE, NULL);
-    cb.qInternalEvent(evt);
+    cb.qInternalEvent(evt);*/
 
     log_msg(LOG_DEBUG,"abort_service_req_procedure : Exit \n");
 

--- a/src/s11/handlers/s11_CB_req_handler.c
+++ b/src/s11/handlers/s11_CB_req_handler.c
@@ -25,14 +25,6 @@ extern int g_resp_fd;
 extern struct GtpV2Stack* gtpStack_gp;
 /*End : globals and externs*/
 
-uint64_t conv_uint8_arr_to_uint64(const uint8_t* bit_rate_array)
-{
-    uint64_t bit_rate_kbps = (*(bit_rate_array) << 32) | (*(bit_rate_array+1) << 24) | (*(bit_rate_array+2) << 16) | 
-	    			(*(bit_rate_array+3) << 8) | (*(bit_rate_array+4));
-    return bit_rate_kbps;
-}
-
-
 void build_bearer_qos(BearerQosIeData* s11_bearer_qos, bearer_qos_t* mme_bearer_qos)
 {
 	mme_bearer_qos->arp.prioLevel = s11_bearer_qos->pl;

--- a/src/s11/handlers/s11_CS_resp_handler.c
+++ b/src/s11/handlers/s11_CS_resp_handler.c
@@ -77,8 +77,16 @@ s11_CS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 	csr_info.pdn_addr.pdn_type = 1;
 	csr_info.pdn_addr.ip_type.ipv4.s_addr = msgData.pdnAddressAllocation.ipV4Address.ipValue;
 
+    csr_info.bearerQos.qci = msgData.bearerContextsCreated[0].bearerLevelQos.qci; 	
+    csr_info.bearerQos.arp.preEmptionVulnebility = msgData.bearerContextsCreated[0].bearerLevelQos.pvi;
+    csr_info.bearerQos.arp.prioLevel = msgData.bearerContextsCreated[0].bearerLevelQos.pl;
+    csr_info.bearerQos.arp.preEmptionCapab = msgData.bearerContextsCreated[0].bearerLevelQos.pci;
+    csr_info.bearerQos.mbr_ul = conv_uint8_arr_to_uint64(msgData.bearerContextsCreated[0].bearerLevelQos.maxBitRateUl.values);
+    csr_info.bearerQos.mbr_dl = conv_uint8_arr_to_uint64(msgData.bearerContextsCreated[0].bearerLevelQos.maxBitRateDl.values);
+    csr_info.bearerQos.gbr_ul = conv_uint8_arr_to_uint64(msgData.bearerContextsCreated[0].bearerLevelQos.guraranteedBitRateUl.values);
+    csr_info.bearerQos.gbr_dl = conv_uint8_arr_to_uint64(msgData.bearerContextsCreated[0].bearerLevelQos.guaranteedBitRateDl.values);
 	
-	csr_info.pco_length = 0;
+    csr_info.pco_length = 0;
 	if(msgData.protocolConfigurationOptionsIePresent == true)
 	{
 		csr_info.pco_length = msgData.protocolConfigurationOptions.pcoValue.count;

--- a/src/s11/options.c
+++ b/src/s11/options.c
@@ -11,6 +11,13 @@
 #include <string.h>
 #include "log.h"
 
+uint64_t conv_uint8_arr_to_uint64(const uint8_t* bit_rate_array)
+{
+    uint64_t bit_rate_kbps = (*(bit_rate_array) << 32) | (*(bit_rate_array+1) << 24) | (*(bit_rate_array+2) << 16) | 
+	    			(*(bit_rate_array+3) << 8) | (*(bit_rate_array+4));
+    return bit_rate_kbps;
+}
+
 uint8_t create_sock_addr(
                 struct sockaddr_in *addr, 
                 uint16_t port, uint32_t val)

--- a/src/s1ap/handlers/attach_icsreq.c
+++ b/src/s1ap/handlers/attach_icsreq.c
@@ -52,10 +52,10 @@ get_icsreq_protoie_value(struct proto_IE *value, struct init_ctx_req_Q_msg *g_ic
 	erab_setup_item *e_rab = &(value->data[ieCnt].val.erab_to_be_setup_item_ctxt_su_req);
 	/* TODO: Remove hardcoded values. */
 	e_rab->e_RAB_ID = 1;
-	e_rab->e_RAB_QoS_Params.qci = 9;
-	e_rab->e_RAB_QoS_Params.arPrio.prioLevel = 15;
-	e_rab->e_RAB_QoS_Params.arPrio.preEmptionCapab = 1;
-	e_rab->e_RAB_QoS_Params.arPrio.preEmptionVulnebility = 1;
+	e_rab->e_RAB_QoS_Params.qci = g_icsReqInfo->qci;
+	e_rab->e_RAB_QoS_Params.arPrio.prioLevel = g_icsReqInfo->pl;
+	e_rab->e_RAB_QoS_Params.arPrio.preEmptionCapab = g_icsReqInfo->pci;
+	e_rab->e_RAB_QoS_Params.arPrio.preEmptionVulnebility = g_icsReqInfo->pvi;
 
 	/*S1u information : transport layer addr and teid*/
 	e_rab->transportLayerAddress = htonl(g_icsReqInfo->gtp_teid.ip.ipv4.s_addr);


### PR DESCRIPTION
Initial context request QCI value was sent as 0 in case of service request. this has been updated to use the qos params received in car response.
Also, in case of service request failure, paging failure is initiated which causes UE context to be deleted and further Service requests fail. The Pain failure has been commented for now.