### PR TITLE
Current State NULL - Error Fixes

### DIFF
--- a/include/mme-app/actionHandlers/actionHandlers.h
+++ b/include/mme-app/actionHandlers/actionHandlers.h
@@ -239,6 +239,11 @@ namespace mme
         static SM::ActStatus handle_paging_failure(SM::ControlBlock& cb);                
 
         /**********************************************
+        * Action handler : handle_s1_rel_req_during_detach
+        ***********************************************/
+        static SM::ActStatus handle_s1_rel_req_during_detach(SM::ControlBlock& cb);                
+
+        /**********************************************
         * Action handler : handle_state_guard_timeouts
         ***********************************************/
         static SM::ActStatus handle_state_guard_timeouts(SM::ControlBlock& cb);                

--- a/scripts/SMCodeGen/dataModels/stateMachineAppModel.json
+++ b/scripts/SMCodeGen/dataModels/stateMachineAppModel.json
@@ -580,10 +580,10 @@
                                 ],
                                 "NextState":"detach_wf_purge_resp_del_session_resp"
                             },
-			    {
+                            {
                                 "Name":"ABORT_EVENT",
                                 "Actions":[
-				    "DETACH_ACCEPT_TO_UE",
+                                    "DETACH_ACCEPT_TO_UE",
                                     "ABORT_DETACH"
                                 ],
                                 "NextState":"end_state"
@@ -614,10 +614,17 @@
                                 ],
                                 "NextState":"end_state"
                             },
-			    {
+                            {
+                                "Name":"S1_REL_REQ_FROM_UE",
+                                "Actions":[
+                                    "HANDLE_S1_REL_REQ_DURING_DETACH"
+                                ],
+                                "NextState":"end_state"
+                            },                            
+                            {
                                 "Name":"ABORT_EVENT",
                                 "Actions":[
-				    "DETACH_ACCEPT_TO_UE",
+                                    "DETACH_ACCEPT_TO_UE",
                                     "ABORT_DETACH"
                                 ],
                                 "NextState":"end_state"
@@ -642,7 +649,14 @@
                                 ],
                                 "NextState":"end_state"
                             },
-			    {
+                            {
+                                "Name":"S1_REL_REQ_FROM_UE",
+                                "Actions":[
+                                    "HANDLE_S1_REL_REQ_DURING_DETACH"
+                                ],
+                                "NextState":"end_state"
+                            },
+                            {
                                 "Name":"ABORT_EVENT",
                                 "Actions":[
                                     "DETACH_ACCEPT_TO_UE",
@@ -670,7 +684,14 @@
                                 ],
                                 "NextState":"end_state"
                             },
-			    {
+                            {
+                                "Name":"S1_REL_REQ_FROM_UE",
+                                "Actions":[
+                                    "HANDLE_S1_REL_REQ_DURING_DETACH"
+                                ],
+                                "NextState":"end_state"
+                            },                            
+                            {
                                 "Name":"ABORT_EVENT",
                                 "Actions":[
                                     "DETACH_ACCEPT_TO_UE",

--- a/src/mme-app/actionHandlers/attachActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/attachActionHandlers.cpp
@@ -1396,14 +1396,13 @@ ActStatus ActionHandlers::abort_attach(ControlBlock& cb)
     if (procCtxt != NULL)
     {
         errorCause = procCtxt->getMmeErrorCause();
+	MmeContextManagerUtils::deallocateProcedureCtxt(cb, procCtxt);
     }
 
     mmeStats::Instance()->increment(mmeStatsCounter::MME_PROCEDURES_ATTACH_PROC_FAILURE);
 
     if (errorCause == ABORT_DUE_TO_ATTACH_COLLISION)
     {
-    	MmeProcedureCtxt* procedure_p = static_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-    	MmeContextManagerUtils::deallocateProcedureCtxt(cb, procedure_p);
         MmeContextManagerUtils::deleteUEContext(cb.getCBIndex(), false); // retain control block
     }
     else

--- a/src/mme-app/actionHandlers/s1ReleaseActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/s1ReleaseActionHandlers.cpp
@@ -182,9 +182,7 @@ ActStatus ActionHandlers::abort_s1_release(ControlBlock& cb)
     if (procCtxt != NULL)
     {
         errorCause = procCtxt->getMmeErrorCause();
-
-        MmeProcedureCtxt* procedure_p = static_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-        MmeContextManagerUtils::deallocateProcedureCtxt(cb, procedure_p);
+	MmeContextManagerUtils::deallocateProcedureCtxt(cb, procCtxt);
     }
 
     mmeStats::Instance()->increment(mmeStatsCounter::MME_PROCEDURES_S1_RELEASE_PROC_FAILURE);

--- a/src/mme-app/actionHandlers/ueInitDetachActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/ueInitDetachActionHandlers.cpp
@@ -256,3 +256,20 @@ ActStatus ActionHandlers::abort_detach(ControlBlock& cb)
     return ActStatus::PROCEED;
 }
 
+/***************************************
+* Action handler : handle_s1_rel_req_during_detach
+***************************************/
+ActStatus ActionHandlers::handle_s1_rel_req_during_detach(ControlBlock& cb)
+{
+    log_msg(LOG_DEBUG, "Recevied S1 Release Request during detach for cb %d\n", cb.getCBIndex());
+
+    MmeDetachProcedureCtxt *procedure_p =
+            static_cast<MmeDetachProcedureCtxt*>(cb.getTempDataBlock());
+    if(procedure_p != NULL)
+    { 
+       procedure_p->setMmeErrorCause(DETACH_FAILED);
+    }
+
+    return ActStatus::ABORT;
+}
+

--- a/src/mme-app/mmeStates/detachWfDelSessionResp.cpp
+++ b/src/mme-app/mmeStates/detachWfDelSessionResp.cpp
@@ -69,6 +69,11 @@ void DetachWfDelSessionResp::initialize()
         }
         {
                 ActionTable actionTable;
+                actionTable.addAction(&ActionHandlers::handle_s1_rel_req_during_detach);
+                eventToActionsMap.insert(pair<uint16_t, ActionTable>(S1_REL_REQ_FROM_UE, actionTable));
+        }
+        {
+                ActionTable actionTable;
                 actionTable.addAction(&ActionHandlers::detach_accept_to_ue);
                 actionTable.addAction(&ActionHandlers::abort_detach);
                 eventToActionsMap.insert(pair<uint16_t, ActionTable>(ABORT_EVENT, actionTable));

--- a/src/mme-app/mmeStates/detachWfPurgeResp.cpp
+++ b/src/mme-app/mmeStates/detachWfPurgeResp.cpp
@@ -69,6 +69,11 @@ void DetachWfPurgeResp::initialize()
         }
         {
                 ActionTable actionTable;
+                actionTable.addAction(&ActionHandlers::handle_s1_rel_req_during_detach);
+                eventToActionsMap.insert(pair<uint16_t, ActionTable>(S1_REL_REQ_FROM_UE, actionTable));
+        }
+        {
+                ActionTable actionTable;
                 actionTable.addAction(&ActionHandlers::detach_accept_to_ue);
                 actionTable.addAction(&ActionHandlers::abort_detach);
                 eventToActionsMap.insert(pair<uint16_t, ActionTable>(ABORT_EVENT, actionTable));

--- a/src/mme-app/mmeStates/detachWfPurgeRespDelSessionResp.cpp
+++ b/src/mme-app/mmeStates/detachWfPurgeRespDelSessionResp.cpp
@@ -77,6 +77,11 @@ void DetachWfPurgeRespDelSessionResp::initialize()
         }
         {
                 ActionTable actionTable;
+                actionTable.addAction(&ActionHandlers::handle_s1_rel_req_during_detach);
+                eventToActionsMap.insert(pair<uint16_t, ActionTable>(S1_REL_REQ_FROM_UE, actionTable));
+        }
+        {
+                ActionTable actionTable;
                 actionTable.addAction(&ActionHandlers::detach_accept_to_ue);
                 actionTable.addAction(&ActionHandlers::abort_detach);
                 eventToActionsMap.insert(pair<uint16_t, ActionTable>(ABORT_EVENT, actionTable));

--- a/src/mme-app/utils/mmeContextManagerUtils.cpp
+++ b/src/mme-app/utils/mmeContextManagerUtils.cpp
@@ -359,6 +359,13 @@ bool MmeContextManagerUtils::deallocateProcedureCtxt(SM::ControlBlock& cb_r, Mme
 {
     if (procedure_p == NULL)
     {
+        log_msg(LOG_DEBUG, "procedure_p is NULL \n");
+        return true;
+    }
+
+    if (procedure_p->getCtxtType() == defaultMmeProcedure_c)
+    {
+        log_msg(LOG_ERROR, "CB %d trying to delete default procedure context \n", cb_r.getCBIndex());
         return true;
     }
 
@@ -394,9 +401,7 @@ bool MmeContextManagerUtils::deallocateAllProcedureCtxts(SM::ControlBlock& cb_r)
         if (procedure_p->getCtxtType() != defaultMmeProcedure_c)
         {
             // stop state guard timer if any running
-            MmeTimerUtils::stopTimer(procedure_p->getStateGuardTimerCtxt());
-
-            rc = deleteProcedureCtxt(procedure_p);
+            deallocateProcedureCtxt(cb_r, procedure_p);
         }
 
         procedure_p = nextProcedure_p;


### PR DESCRIPTION
**Problem Description:**

Current State becomes NULL during the collision scenarios

**Root Cause:**

Improper deallocation/deletion of procedure context(Temporary Data Block) in deallocateAllProcedureCtxts().

**Scenario:** 

IMSI Attach Completed
UE Init Detach --> when Waiting for Delete Session and Purge Response
enb sends S1 Release Request--> MME incorrectly triggers S1 Release procedure, 
when waiting for RAB Release, UE sends GUTI attach. Guti attach completes, then enb sends s1 release request

**Observations:**
S1_release Collision wasn't handled in detach, as a result of which MME incorrectly triggered S1 Release procedure.
When GUTI Attach collision occurred during s1_release_wf_rab_response, in abort_s1_release --> MmeContextManagerUtils::deleteUEContext(cb.getCBIndex(), false);
was invoked.

Here , we retained the CB and deleted the UE Context.
In deleteUEContext()--> deallocateAllProcedureCtxts(*cb_p) was invoked in which we surrendered the memory of procCtxt(TDB) without removing it from the CB,
unlike the deallocateProcedureCtxt() which had cb_r.removeTempDataBlock(procedure_p) followed by deleteProcedureCtxt(procedure_p).

This resulted in CB having a TDB (MmeDetachProcedureCtxt) with its data (Current State and next) set to NULL.

**Solution:**

s1_release_req collision is handled in detach.
deallocateAllProcedureCtxts() is modified such that it invokes deallocateProcedureCtxt(),
which has cb_r.removeTempDataBlock(procedure_p) followed by deleteProcedureCtxt(procedure_p).