### PR TITLE
Sequence number was getting reused by s11 app

### DIFF
--- a/include/s11/s11.h
+++ b/include/s11/s11.h
@@ -60,6 +60,7 @@ int s11_DS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sg
 int s11_RB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip);
 int s11_DDN_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip);
 int s11_ECHO_req_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip_val, uint16_t src_port);
+void get_sequence(uint32_t *seq);
 
 void
 bswap8_array(uint8_t *src, uint8_t *dest, uint32_t len);

--- a/src/mme-app/actionHandlers/ueInitDetachActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/ueInitDetachActionHandlers.cpp
@@ -78,6 +78,10 @@ ActStatus ActionHandlers::del_session_req(SM::ControlBlock& cb)
 
             status = true; // delete session sent success
         }
+        else
+        {
+            log_msg(LOG_DEBUG, "%s session context does not exist \n", __FUNCTION__);
+        }
     }
 
     ActStatus rc = ActStatus::PROCEED;
@@ -87,6 +91,7 @@ ActStatus ActionHandlers::del_session_req(SM::ControlBlock& cb)
     // so that abort can continue.
     if(!status)
     {
+        log_msg(LOG_DEBUG, "%s failure in handling dsreq event \n", __FUNCTION__);
         MmeProcedureCtxt *procCtxt = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
 
         if(procCtxt != NULL)
@@ -97,8 +102,10 @@ ActStatus ActionHandlers::del_session_req(SM::ControlBlock& cb)
                 {
                     // Action invoked as part of detach success path, return abort as
                     // we failed to send out delete session request to gw
+                    log_msg(LOG_DEBUG, "%s failure in handling dsreq event for detach_c procedure \n", __FUNCTION__);
                     if(procCtxt->getMmeErrorCause() == SUCCESS)
                     {
+                        log_msg(LOG_DEBUG, "%s failure in handling dsreq event. return abort \n", __FUNCTION__);
                         rc = ActStatus::ABORT;
                     }
 

--- a/src/s11/handlers/create_session_handler.c
+++ b/src/s11/handlers/create_session_handler.c
@@ -25,6 +25,7 @@
 #include "s11_config.h"
 #include <gtpV2StackWrappers.h>
 #include "gtp_cpp_wrapper.h"
+#include "s11.h"
 
 /************************************************************************
 Current file : Stage 5 handler.
@@ -46,7 +47,6 @@ extern struct sockaddr_in g_s11_cp_addr;
 extern socklen_t g_s11_serv_size;
 
 extern s11_config_t g_s11_cfg;
-volatile uint32_t g_s11_sequence = 1;
 
 /****Global and externs end***/
 struct CS_Q_msg *g_csReqInfo;
@@ -102,7 +102,9 @@ create_session_processing(struct CS_Q_msg * g_csReqInfo)
     	struct sockaddr_in sgw_addr = {0};
 	GtpV2MessageHeader gtpHeader;
 	gtpHeader.msgType = GTP_CREATE_SESSION_REQ;
-	gtpHeader.sequenceNumber = g_s11_sequence;
+    uint32_t seq = 0;
+	get_sequence(&seq);
+	gtpHeader.sequenceNumber = seq;
 	gtpHeader.teidPresent = true;
 	gtpHeader.teid = 0; 
 
@@ -113,8 +115,6 @@ create_session_processing(struct CS_Q_msg * g_csReqInfo)
     } else {
         sgw_addr = g_s11_cp_addr; 
     }
-	
-	g_s11_sequence++;
 	
 	log_msg(LOG_INFO,"In create session handler->ue_idx:%d\n",g_csReqInfo->ue_idx);
 
@@ -244,8 +244,6 @@ create_session_processing(struct CS_Q_msg * g_csReqInfo)
 
 	log_msg(LOG_INFO, "send %d bytes.\n",MsgBuffer_getBufLen(csReqMsgBuf_p));
 
-    uint32_t seq = g_s11_sequence;
- 
 	int res = sendto (
 			g_s11_fd,
 			MsgBuffer_getDataPointer(csReqMsgBuf_p),

--- a/src/s11/handlers/ddn_ack_handler.c
+++ b/src/s11/handlers/ddn_ack_handler.c
@@ -30,10 +30,6 @@ extern s11_config_t g_s11_cfg;
 extern struct sockaddr_in g_s11_cp_addr;
 extern socklen_t g_s11_serv_size;
 
-/*TODO: S11 protocol sequence number - need to make it atomic. multiple thread to access this*/
-extern volatile uint32_t g_s11_sequence;
-
-
 extern struct GtpV2Stack* gtpStack_gp;
 struct thread_pool *g_tpool;
 

--- a/src/s11/handlers/delete_session_handler.c
+++ b/src/s11/handlers/delete_session_handler.c
@@ -23,6 +23,7 @@
 #include "s11_options.h"
 #include <gtpV2StackWrappers.h>
 #include "gtp_cpp_wrapper.h"
+#include "s11.h"
 /************************************************************************
 Current file : Stage 1 handler.
 ATTACH stages :
@@ -36,14 +37,10 @@ extern int g_s11_fd;
 extern struct sockaddr_in g_s11_cp_addr;
 extern s11_config_t g_s11_cfg;
 extern socklen_t g_s11_serv_size;
-extern volatile uint32_t g_s11_sequence;
 
 struct thread_pool *g_tpool;
 
 extern struct GtpV2Stack* gtpStack_gp;
-extern volatile uint32_t g_s11_sequence;
-
-/****Global and externs end***/
 
 /**
 * Stage specific message processing.
@@ -59,7 +56,9 @@ delete_session_processing(struct DS_Q_msg *ds_msg)
 	}
 	GtpV2MessageHeader gtpHeader;
 	gtpHeader.msgType = GTP_DELETE_SESSION_REQ;
-	gtpHeader.sequenceNumber = g_s11_sequence;
+    uint32_t seq = 0;
+	get_sequence(&seq);
+	gtpHeader.sequenceNumber = seq;
 	gtpHeader.teidPresent = true;
 	gtpHeader.teid = ds_msg->s11_sgw_c_fteid.header.teid_gre;
     struct sockaddr_in sgw_ip = {0};
@@ -77,7 +76,6 @@ delete_session_processing(struct DS_Q_msg *ds_msg)
 
     add_gtp_transaction(gtpHeader.sequenceNumber, ds_msg->ue_idx); 
 	GtpV2Stack_buildGtpV2Message(gtpStack_gp, dsReqMsgBuf_p, &gtpHeader, &msgData);
-	g_s11_sequence++;
 
 	sendto(g_s11_fd,
 			MsgBuffer_getDataPointer(dsReqMsgBuf_p),

--- a/src/s11/handlers/modify_bearer_handler.c
+++ b/src/s11/handlers/modify_bearer_handler.c
@@ -23,6 +23,7 @@
 #include "s11_options.h"
 #include <gtpV2StackWrappers.h>
 #include "gtp_cpp_wrapper.h"
+#include "s11.h"
 
 /************************************************************************
 Current file : Stage 7 handler. To listen MB from mme-app and fwd to CP
@@ -42,13 +43,11 @@ extern int g_s11_fd;
 extern struct sockaddr_in g_s11_cp_addr;
 extern s11_config_t g_s11_cfg;
 extern socklen_t g_s11_serv_size;
-/*TODO: S11 protocol sequence number - need to make it atomic. multiple thread to access this*/
-extern volatile uint32_t g_s11_sequence;
-
-/*TODO: S11 protocol sequence number - need to make it atomic. multiple thread to access this*/
-extern volatile uint32_t g_s11_sequence;
 
 extern struct GtpV2Stack* gtpStack_gp;
+
+
+
 /****Global and externs end***/
 /**
 * Stage specific message processing.
@@ -64,14 +63,14 @@ modify_bearer_processing(struct MB_Q_msg *mb_msg)
 	}
 	GtpV2MessageHeader gtpHeader;
 	gtpHeader.msgType = GTP_MODIFY_BEARER_REQ;
-	gtpHeader.sequenceNumber = g_s11_sequence;
+    uint32_t seq = 0;
+	get_sequence(&seq);
+	gtpHeader.sequenceNumber = seq;
 	gtpHeader.teidPresent = true;
 	gtpHeader.teid = mb_msg->s11_sgw_c_fteid.header.teid_gre;
     struct sockaddr_in sgw_ip = {0};
     create_sock_addr(&sgw_ip, g_s11_cfg.egtp_def_port,
                     mb_msg->s11_sgw_c_fteid.ip.ipv4.s_addr);
-
-	g_s11_sequence++;
 
 	ModifyBearerRequestMsgData msgData;
 	memset(&msgData, 0, sizeof(msgData));

--- a/src/s11/handlers/release_bearer_handler.c
+++ b/src/s11/handlers/release_bearer_handler.c
@@ -20,6 +20,7 @@
 #include "s11_options.h"
 #include <gtpV2StackWrappers.h>
 #include "gtp_cpp_wrapper.h"
+#include "s11.h"
 
 /************************************************************************
 Current file : Stage 7 handler. To listen MB from mme-app and fwd to CP
@@ -40,11 +41,7 @@ extern int g_s11_fd;
 extern struct sockaddr_in g_s11_cp_addr;
 extern s11_config_t g_s11_cfg;
 extern socklen_t g_s11_serv_size;
-/*TODO: S11 protocol sequence number - need to make it atomic. multiple thread to access this*/
-extern volatile uint32_t g_s11_sequence;
-
 extern struct GtpV2Stack* gtpStack_gp;
-
 
 /****Global and externs end***/
 /**
@@ -61,13 +58,14 @@ release_bearer_processing(struct RB_Q_msg *rb_msg)
     }
     GtpV2MessageHeader gtpHeader;	
     gtpHeader.msgType = GTP_RABR_REQ;
-    gtpHeader.sequenceNumber = g_s11_sequence;
+    uint32_t seq = 0;
+	get_sequence(&seq);
+    gtpHeader.sequenceNumber = seq;
     gtpHeader.teidPresent = true;
     gtpHeader.teid = rb_msg->s11_sgw_c_fteid.header.teid_gre;
     struct sockaddr_in sgw_ip = {0};
     create_sock_addr(&sgw_ip, g_s11_cfg.egtp_def_port,
                     rb_msg->s11_sgw_c_fteid.ip.ipv4.s_addr);
-    g_s11_sequence++;
 
     ReleaseAccessBearersRequestMsgData msgData;
 	memset(&msgData, 0, sizeof(msgData));


### PR DESCRIPTION
Sequence number was getting reused by s11 app for multiple messages. and SPGW drops the message detecting it as retransmission.