### PR TITLE
Mac mismatch error

### DIFF
--- a/src/mme-app/utils/mmeNasUtils.cpp
+++ b/src/mme-app/utils/mmeNasUtils.cpp
@@ -202,8 +202,6 @@ calculate_s3g_mac(uint8_t *int_key, uint32_t seq_no, uint8_t direction,
     std::unique_lock<std::mutex> lock(mutex_m);
     log_msg(LOG_DEBUG,"count %d, bearer %d direction %d, data_len %d \n", seq_no, bearer, direction, data_len);
     f9(int_key, seq_no, bearer, direction, data, data_len * 8, mac);
-    mutex_m.unlock();
-
     return;
 }
 


### PR DESCRIPTION
2 threads were doing the mac calculation at the same time and that was and causing the mac mismatch error for 1 call out of 16k call.
This was due to coding error of combining unique variable with mutex
variable (unlock).