### PR TITLE
Logging cleanup at MME.

### DIFF
--- a/src/cmn/timeoutManager.cpp
+++ b/src/cmn/timeoutManager.cpp
@@ -42,11 +42,11 @@ void TimeoutManager::Timer::initTimer()
     fd_m = timerfd_create(CLOCK_MONOTONIC, 0);
     if (fd_m <= 0)
     {
-        log_msg(LOG_ERROR, "Failed to create timer\n");	    
+        log_msg(LOG_ERROR, "Failed to create timer");
     }
     else
     {
-        log_msg(LOG_DEBUG, "Timer created successfully\n");
+        log_msg(LOG_DEBUG, "Timer created successfully");
     }	
 }
 
@@ -58,7 +58,7 @@ bool TimeoutManager::Timer::startTimer()
     {
         if (timerfd_settime(fd_m, 0, &tspec_m, NULL) == -1)
         {
-            log_msg(LOG_ERROR, "Failed to set timeout duration\n");
+            log_msg(LOG_ERROR, "Failed to set timeout duration");
 
             rc = false;
 
@@ -84,7 +84,7 @@ bool TimeoutManager::Timer::stopTimer()
 
         if (timerfd_settime(fd_m, 0, &next_timeout, NULL) == -1)
         {
-            log_msg(LOG_ERROR,"Failed to set timeout duration\n");
+            log_msg(LOG_ERROR,"Failed to set timeout duration");
             rc = false;
 
             // thread abort.
@@ -124,7 +124,7 @@ uint32_t TimeoutManager::cancelTimer(TimerContext* timer_p)
 
 void TimeoutManager::run()
 {
-    log_msg(LOG_DEBUG, "Run TimeoutManager\n");
+    log_msg(LOG_DEBUG, "Run TimeoutManager");
 
     timer_m.startTimer();
 

--- a/src/cmn/tipcSocket.cpp
+++ b/src/cmn/tipcSocket.cpp
@@ -61,7 +61,7 @@ bool TipcSocket::bindTipcSocket(IpcAddress myAddress)
 
     if (0 != bind(ipcHdl_m.u32, (sockaddr*)&server, sizeof(server)))
     {
-    	log_msg(LOG_ERROR, "Failed to bind TIPC socket. error: %s\n", strerror(errno));
+    	log_msg(LOG_ERROR, "Failed to bind TIPC socket. error: %s", strerror(errno));
         rc = false;
     }
     return rc;
@@ -80,11 +80,7 @@ void TipcSocket::sendMsgTo(void * buffer, uint32_t len, IpcAddress destAddress)
 
    if (0 > sendto(ipcHdl_m.u32, buffer, len, 0, (sockaddr*)&dest, sizeof(dest)))
    {
-	   log_msg(LOG_ERROR, "Failed to send message via TIPC socket. error: %s\n", strerror(errno));
-   }
-   else
-   {
-	   log_msg(LOG_INFO, "Message sent successfully to dest instance = %d \n",destAddress.u32);
+	   log_msg(LOG_ERROR, "Failed to send message via TIPC socket. error: %s", strerror(errno));
    }
 }
 

--- a/src/common/ipc_api.c
+++ b/src/common/ipc_api.c
@@ -29,7 +29,7 @@ int
 create_ipc_channel(char *name)
 {
 	if (mkfifo (name, IPC_MODE) == -1) {
-		log_msg(LOG_ERROR, "Error in create_ipc_channel %s\n", name);
+		log_msg(LOG_ERROR, "Error in create_ipc_channel %s", name);
 		perror("Error:");
 		return -1;
 	}
@@ -47,7 +47,7 @@ open_ipc_channel(char *name, enum ipc_access_mode access_mode)
 		mode = O_WRONLY;
 
 	if ((fd = open(name, mode)) == -1) {
-		log_msg(LOG_ERROR, "Error in create_ipc_channel %s\n",name);
+		log_msg(LOG_ERROR, "Error in create_ipc_channel %s",name);
 		perror("Error:");
 		return -E_FAIL;
 	}
@@ -73,7 +73,7 @@ read_ipc_channel(ipc_handle fd, char *buffer, size_t size)
             // case -1 means pipe is empty and errono
             // set EAGAIN
 		if (errno == EAGAIN) {
-		log_msg(LOG_ERROR, "pipe empty \n");
+		log_msg(LOG_ERROR, "pipe empty ");
                 usleep(5);
                 return -1;
             }
@@ -83,7 +83,7 @@ read_ipc_channel(ipc_handle fd, char *buffer, size_t size)
 
         // case 0 means all bytes are read and EOF(end of conv.)
         case 0:
-            log_msg(LOG_ERROR, "End of conversation\n");
+            log_msg(LOG_ERROR, "End of conversation");
 
             // read link
             //close(p[0]);
@@ -139,12 +139,12 @@ bind_tipc_socket(int sockFd, uint32_t instanceNum)
     int rc = 1;
     if (0 != bind(sockFd, (void *)&server, sizeof(server)))
     {
-        log_msg(LOG_ERROR, "Server: failed to bind port name %s\n", strerror(errno));
+        log_msg(LOG_ERROR, "Server: failed to bind port name %s", strerror(errno));
         rc = -1;
     }
     else
     {
-	log_msg(LOG_INFO, "Server: Success %s %d\n", strerror(errno), rc);
+	log_msg(LOG_INFO, "Server: Success %s %d", strerror(errno), rc);
     }
     return rc;
 }
@@ -163,7 +163,7 @@ send_tipc_message(int sd, uint32_t destAddr, void * buf, int len)
     int rc = 0;
     if (0 > sendto(sd, buf, len, 0, (void*)&server, sizeof(server)))
     {
-    	log_msg(LOG_ERROR, "FAILED TO SENT TIPC MESSAGE %s\n", strerror(errno));
+    	log_msg(LOG_ERROR, "FAILED TO SENT TIPC MESSAGE %s", strerror(errno));
     } else {
     	rc = 1;
     }
@@ -178,7 +178,7 @@ read_tipc_msg(int sockFd, void * buf, int len)
 
     if ((bytesRead = recv(sockFd, buf, len, 0)) <= 0)
     {
-    	log_msg(LOG_ERROR, "FAILED TO READ TIPC MESSAGE %s\n", strerror(errno));
+    	log_msg(LOG_ERROR, "FAILED TO READ TIPC MESSAGE %s", strerror(errno));
     }
     return bytesRead;
 }

--- a/src/common/json_parser.c
+++ b/src/common/json_parser.c
@@ -70,7 +70,7 @@ get_string_scalar(char *path)
 	char *value = calloc(1, 128);
 
 	if(NULL == entry) {
-		log_msg(LOG_ERROR, "%s: entry not found\n", path);
+		log_msg(LOG_ERROR, "%s: entry not found", path);
 		free(value);
 		return NULL;
 	}
@@ -82,7 +82,7 @@ get_string_scalar(char *path)
 	}
 	char *tmp = strchr(entry, ':');
 	sscanf(tmp, ": \"%[^\"]", value);
-	log_msg(LOG_INFO, "%s = %s\n", path, value);
+	log_msg(LOG_INFO, "%s = %s", path, value);
 	return value;
 }
 
@@ -93,7 +93,7 @@ get_int_scalar(char *path)
 	unsigned int i = 0;
 
 	if(NULL == entry) {
-		log_msg(LOG_ERROR, "%s: entry not found\n", path);
+		log_msg(LOG_ERROR, "%s: entry not found", path);
 		return -1;
 	}
 	char *tmp = strchr(entry, ':');
@@ -101,7 +101,7 @@ get_int_scalar(char *path)
 	i = atoi(tmp+1);
 
 	free(entry);
-	log_msg(LOG_INFO, "%s = %d\n", path, i);
+	log_msg(LOG_INFO, "%s = %d", path, i);
 	return i;
 }
 
@@ -125,7 +125,7 @@ load_json(char *filename)
 	json_fp = fopen(filename, "r");
 
 	if(NULL == json_fp) {
-		log_msg(LOG_ERROR, "Error opening json file\n");
+		log_msg(LOG_ERROR, "Error opening json file");
 		perror("Error:");
 		return -1;
 	}

--- a/src/common/log.c
+++ b/src/common/log.c
@@ -17,82 +17,24 @@
 #include "log.h"
 #include <sys/syscall.h>
 
-bool g_nolog = false;
-enum log_levels g_log_level = LOG_DEBUG;
-
 int pid = 0;
 char processName[255] = {0};
+uint8_t logging_level;
 
-static const char *log_level_name[] = { "NEVER", "ERROR", "WARN", "INFO", "DEBUG"};
-FILE *fp;
+FILE *log_fp;
 
 void init_logging(char *env, char *file)
 {
 	if(strcmp(env, "container") == 0) {
-		fp = (FILE *)stderr;
-		fprintf(fp, "\ninit_logging %s\n", env);
+		log_fp = (FILE *)stderr;
+		fprintf(log_fp, "init_logging %s", env);
 	} else {
-		fp = fopen(file, "a+");
-		if (fp == NULL)
+		log_fp = fopen(file, "a+");
+		if (log_fp == NULL)
 		{
 			printf("Could not open log file");
 			exit(0);
 		}
-		fprintf(fp, "\ninit_logging %s\n", env);
+		fprintf(log_fp, "init_logging %s", env);
 	}
 }
-
-inline void enable_logs()
-{
-    g_nolog = false;
-}
-
-inline void disable_logs()
-{
-    g_nolog = true;
-}
-
-void set_logging_level(char *log_level)
-{
-    if(strcmp(log_level, "debug") == 0)
-    {
-        g_log_level = LOG_DEBUG;
-        enable_logs();
-    }
-    else if(strcmp(log_level, "info") == 0)
-    {
-        g_log_level = LOG_INFO;
-        enable_logs();
-    }
-    else if(strcmp(log_level, "warn") == 0)
-    {
-        g_log_level = LOG_WARNING;
-        enable_logs();
-    }
-    else if(strcmp(log_level, "error") == 0)
-    {
-        g_log_level = LOG_ERROR;
-        enable_logs();
-    }
-    else
-    {
-	    log_msg(LOG_INFO, "logging disabled ");
-        disable_logs();
-        g_log_level = LOG_NEVER;
-    }
-}
-
-void log_message(int l, const char *file, int line, const char *fmt, ...)
-{
-	va_list arg;
-	if (g_nolog) return;
-	if(g_log_level < l) return;
-
-	fprintf(fp,"%s(%d:%ld):%s-%s:%d:", processName, pid, syscall(SYS_gettid), log_level_name[l], file, line);
-	va_start(arg, fmt);
-//	vfprintf(stderr, fmt, arg);
-	vfprintf(fp, fmt, arg);
-	va_end(arg);
-//	fprintf(stderr, "\n");
-}
-

--- a/src/common/monitor_config.c
+++ b/src/common/monitor_config.c
@@ -49,7 +49,7 @@ handle_events(int fd, int *wd, config_watch_t *config)
     char *ptr;
 
     /* Loop while events can be read from inotify file descriptor. */
-    log_msg(LOG_INFO,"Config - %p - Received file event for %s at time %lu \n",config, config->config_file, t);
+    log_msg(LOG_INFO,"Config - %p - Received file event for %s at time %lu ",config, config->config_file, t);
     for (;;) {
 
         /* Read some events. */
@@ -130,7 +130,7 @@ handle_events(int fd, int *wd, config_watch_t *config)
 #ifdef TEST_LOCALLY
 void config_change_callback(char *configFile, uint32_t flags)
 {
-  printf("Received config change callback %s\n",__FUNCTION__);
+  printf("Received config change callback %s",__FUNCTION__);
   return;
 }
 
@@ -152,7 +152,7 @@ config_thread_handler(void *config)
   config_watch_t *cfg = (config_watch_t *)config;
   int fd = 0 ; 
 
-  log_msg(LOG_INFO, "Thread started for monitoring config file %s - Monitoring config object  %p \n",cfg->config_file, cfg);
+  log_msg(LOG_INFO, "Thread started for monitoring config file %s - Monitoring config object  %p ",cfg->config_file, cfg);
 
   fd = inotify_init1(IN_NONBLOCK);
   if (fd == -1) 
@@ -164,10 +164,10 @@ config_thread_handler(void *config)
   wd = inotify_add_watch(fd, cfg->config_file, IN_ALL_EVENTS); //OPEN | IN_CLOSE);
   if (wd == -1) 
   {
-      log_msg(LOG_INFO, "Can not watch file. File does not exist - %s \n",cfg->config_file);
+      log_msg(LOG_INFO, "Can not watch file. File does not exist - %s ",cfg->config_file);
       return NULL;
   }
-  log_msg(LOG_INFO, "add_watch return %d \n", wd);
+  log_msg(LOG_INFO, "add_watch return %d ", wd);
 
   /* Prepare for polling */
   nfds = 1;
@@ -198,13 +198,13 @@ config_thread_handler(void *config)
         bool handled = handle_events(fd, &wd, cfg);
         if(handled == true)
         {
-          log_msg(LOG_DEBUG, "FILE change detected\n");
+          log_msg(LOG_DEBUG, "FILE change detected");
           if(cfg->always == true)
           {
             wd = inotify_add_watch(fd, cfg->config_file, IN_ALL_EVENTS); //OPEN | IN_CLOSE);
             if (wd == -1) 
             {
-              fprintf(stderr, "Cannot watch \n");
+              fprintf(stderr, "Cannot watch ");
               perror("inotify_add_watch");
               exit(1);
             }
@@ -218,7 +218,7 @@ config_thread_handler(void *config)
     }
   }
 
-  log_msg(LOG_INFO, "Thread closing for monitoring config file %s Config-%p \n",cfg->config_file, cfg);
+  log_msg(LOG_INFO, "Thread closing for monitoring config file %s Config-%p ",cfg->config_file, cfg);
   free(cfg);
   return NULL;
 }

--- a/src/common/thread_pool.c
+++ b/src/common/thread_pool.c
@@ -21,7 +21,7 @@ struct Job *create_job(JobFunction function, void *arg)
 	job = (struct Job *)malloc(sizeof(struct Job));
 	if(job == NULL) {
 #ifdef DEBUG
-		log_msg(LOG_ERROR, "failed to allocate memory\n");
+		log_msg(LOG_ERROR, "failed to allocate memory");
 #endif
 		return NULL;
 	}
@@ -125,7 +125,7 @@ struct thread_pool *thread_pool_new(int count)
 	pool = (struct thread_pool *)malloc(sizeof(struct thread_pool));
 	if(pool == NULL) {
 #ifdef DEBUG
-		log_msg(LOG_ERROR, "failed to allocate memory\n");
+		log_msg(LOG_ERROR, "failed to allocate memory");
 #endif
 		errno = ENOMEM;
 		return NULL;
@@ -140,7 +140,7 @@ struct thread_pool *thread_pool_new(int count)
 	status = pthread_create(&thread, NULL, dispatch_if_idle, pool);
 	if(status < 0) {
 #ifdef DEBUG
-		log_msg(LOG_ERROR, "failed to spawn dispatch thread, stopping\n");
+		log_msg(LOG_ERROR, "failed to spawn dispatch thread, stopping");
 #endif
 		return NULL;
 	}

--- a/src/common/tpool_queue.c
+++ b/src/common/tpool_queue.c
@@ -22,7 +22,7 @@ static struct node *createnode(void *data)
 	entry = (struct node *)malloc(sizeof(struct node));
 	if(entry == NULL) {
 #ifdef DEBUG
-		log_msg(LOG_ERROR, "failed to allocate memory\n");
+		log_msg(LOG_ERROR, "failed to allocate memory");
 #endif
 		return NULL;
 	}
@@ -96,7 +96,7 @@ struct Queue *queue_new()
 	queue = (struct Queue *)malloc(sizeof(struct Queue));
 	if(queue == NULL) {
 #ifdef DEBUG
-		log_msg(LOG_ERROR, "failed to allocate memory\n");
+		log_msg(LOG_ERROR, "failed to allocate memory");
 #endif
 		return NULL;
 	}

--- a/src/common/unix_conn.c
+++ b/src/common/unix_conn.c
@@ -28,7 +28,7 @@ int create_unix_socket()
 
 	if (fd == -1)
 	{
-		log_msg(LOG_ERROR, "Socket creation failed\n");
+		log_msg(LOG_ERROR, "Socket creation failed");
 		return -1;
 	}
 
@@ -44,13 +44,13 @@ int create_unix_socket()
 
 	if (bind(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
 		perror("Bind:");
-		log_msg(LOG_ERROR, "Bind failed \n");
+		log_msg(LOG_ERROR, "Bind failed ");
 		close(fd);
 		return -1;
 	}
 
 	if (listen(fd, MAX_PENDING_CONN) == -1) {
-		log_msg(LOG_ERROR, "listen() failed \n");
+		log_msg(LOG_ERROR, "listen() failed ");
 		close(fd);
 		return -1;
 	}

--- a/src/common/unix_sock.c
+++ b/src/common/unix_sock.c
@@ -40,7 +40,7 @@ init_sock()
 	g_unix_fd = create_unix_socket();
 
 	if (g_unix_fd == -1) {
-		log_msg(LOG_ERROR, "Error in creating unix socket. \n");
+		log_msg(LOG_ERROR, "Error in creating unix socket. ");
 		return -E_FAIL;
 	}
 
@@ -52,7 +52,7 @@ init_sock()
 
 	int ret = pthread_create(&acceptUnix_t, &attr,&accept_unix, NULL);
 	if(ret < 0) {
-		log_msg(LOG_ERROR,"UNIX ACCEPTS THREAD FAILED\n");
+		log_msg(LOG_ERROR,"UNIX ACCEPTS THREAD FAILED");
 		return -E_FAIL;
 	}
 
@@ -69,7 +69,7 @@ init_sock()
 void *
 accept_unix(void *data)
 {
-	log_msg(LOG_DEBUG, "accept connection on unix sock\n");
+	log_msg(LOG_DEBUG, "accept connection on unix sock");
 	int new_socket = 0;
 	int activity = 0;
 	int i = 0;
@@ -103,17 +103,17 @@ accept_unix(void *data)
 		activity = select(max_sd + 1, &readfds, NULL, NULL, NULL);
 
 		if ((activity < 0) && (errno != EINTR)) {
-			log_msg(LOG_ERROR, "select error.\n");
+			log_msg(LOG_ERROR, "select error.");
 		 }
 
 		if (FD_ISSET(g_unix_fd, &readfds)) {
-			log_msg(LOG_DEBUG, "stuck in accept.\n");
+			log_msg(LOG_DEBUG, "stuck in accept.");
 
 			if ((new_socket = accept_unix_socket(g_unix_fd)) == -1) {
-				log_msg(LOG_ERROR, "Error in accept on unix socket.\n");
+				log_msg(LOG_ERROR, "Error in accept on unix socket.");
 			}
 
-			log_msg(LOG_DEBUG, "New Connection Established\n.");
+			log_msg(LOG_DEBUG, "New Connection Established.");
 			FD_CLR(g_unix_fd, &readfds);
 
 			for (i = 0; i < MAX_CLIENT; i++) {
@@ -121,7 +121,7 @@ accept_unix(void *data)
 				if( client_socket[i] == 0 ) {
 
 					client_socket[i] = new_socket;
-					log_msg(LOG_DEBUG, "Adding to list of sockets at %d value %d\n" , i, new_socket);
+					log_msg(LOG_DEBUG, "Adding to list of sockets at %d value %d" , i, new_socket);
 					break;
 				}
 			}
@@ -136,14 +136,14 @@ accept_unix(void *data)
 			    if ((valread = recv_unix_msg(sd, 
 			             buffer, BUF_SIZE)) == 0) 
 				{
-                                    log_msg(LOG_INFO, "Host Disconnected\n");
+                                    log_msg(LOG_INFO, "Host Disconnected");
 				    close(sd);
 				    client_socket[i] = 0;
 
 				}
 				else if(valread == -1)
 				{
-                                    log_msg(LOG_INFO, "Host Disconnected\n");
+                                    log_msg(LOG_INFO, "Host Disconnected");
 				    //close(sd);
 				    //client_socket[i] = 0;
 				}
@@ -153,13 +153,13 @@ accept_unix(void *data)
 				    malloc((sizeof(char) * valread)+sizeof(int));
                                     if(tmpBuf == NULL)
 				    {
-                                        log_msg(LOG_ERROR, "malloc failed\n");
+                                        log_msg(LOG_ERROR, "malloc failed");
 					continue;
 				    }
 				    
 				    memcpy(tmpBuf, &sd, sizeof(int));
 			            memcpy(tmpBuf + sizeof(int), buffer, valread);
-				    log_msg(LOG_DEBUG, "Received msg len : %d \n",valread);
+				    log_msg(LOG_DEBUG, "Received msg len : %d ",valread);
 				    insert_job(g_tpool, monitorConfigFunc_fpg, tmpBuf);
 
 				}
@@ -174,6 +174,6 @@ accept_unix(void *data)
 void dummy_monitor_fn(void* msg)
 {
     log_msg(LOG_ERROR, "Unix IPC Socket callback "
-                      "not registered by the application!\n");
+                      "not registered by the application!");
     pthread_exit(NULL);
 }

--- a/src/gtpV2Codec/gtpV2StackWrappers.cpp
+++ b/src/gtpV2Codec/gtpV2StackWrappers.cpp
@@ -85,7 +85,7 @@ extern "C"
 			errorStream.printDebugStream(LOG_ERROR);
         	} else
         	{
-        		log_msg(LOG_DEBUG,"GTP Encode Success\n");
+        		log_msg(LOG_DEBUG,"GTP Encode Success");
         	}
         	return rc;
         }
@@ -107,7 +107,7 @@ extern "C"
 			errorStream.printDebugStream();
         	} else
         	{
-        		log_msg(LOG_DEBUG,"GTP Decode Success\n");
+        		log_msg(LOG_DEBUG,"GTP Decode Success");
         	}
         	return rc;
     	}

--- a/src/mme-app/actionHandlers/attachActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/attachActionHandlers.cpp
@@ -55,7 +55,7 @@ extern mmeConfig *mme_tables;
 ActStatus ActionHandlers::validate_imsi_in_ue_context(ControlBlock& cb)
 {
     UEContext* ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ueCtxt_p, "Invalid UE\n");
+    VERIFY_UE(cb, ueCtxt_p, "Invalid UE");
 
     if (ueCtxt_p->getImsi().isValid())
     {
@@ -75,10 +75,10 @@ ActStatus ActionHandlers::validate_imsi_in_ue_context(ControlBlock& cb)
 
 ActStatus ActionHandlers::send_identity_request_to_ue(ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside send_identity_request_to_ue \n");
+	log_msg(LOG_DEBUG, "Inside send_identity_request_to_ue ");
 
 	UEContext* ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ueCtxt_p, "Invalid UE\n");
+	VERIFY_UE(cb, ueCtxt_p, "Invalid UE");
 
 	struct attachIdReq_info idReqMsg;
 	idReqMsg.msg_type = id_request;
@@ -113,20 +113,20 @@ ActStatus ActionHandlers::send_identity_request_to_ue(ControlBlock& cb)
 
 ActStatus ActionHandlers::process_identity_response(ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside process_identity_response \n");
+	log_msg(LOG_DEBUG, "Inside process_identity_response ");
 
 	UEContext *ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ueCtxt_p, "Invalid UE\n");
+	VERIFY_UE(cb, ueCtxt_p, "Invalid UE");
 
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message\n")
+	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message")
 
 	const identityResp_Q_msg_t* id_resp = static_cast<const identityResp_Q_msg_t*>(msgBuf->getDataPointer());
-	VERIFY(id_resp, return ActStatus::ABORT, "Invalid id response received\n")
+	VERIFY(id_resp, return ActStatus::ABORT, "Invalid id response received")
 
 	if(SUCCESS != id_resp->status)
 	{
-		log_msg(LOG_DEBUG, "process_identity_response: ID Response Failure NULL \n");
+		log_msg(LOG_DEBUG, "process_identity_response: ID Response Failure NULL ");
 
 		return ActStatus::ABORT;
 	}
@@ -152,13 +152,13 @@ ActStatus ActionHandlers::process_identity_response(ControlBlock& cb)
 
 ActStatus ActionHandlers::send_air_to_hss(SM::ControlBlock& cb)
 {  
-	log_msg(LOG_DEBUG, "Inside send_air_to_hss \n");
+	log_msg(LOG_DEBUG, "Inside send_air_to_hss ");
 	
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	
 	MmeProcedureCtxt* procedure_p = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL\n");
+	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL");
 
 	s6a_Q_msg s6a_req; 
 	RESET_S6A_REQ_MSG(&s6a_req);
@@ -184,7 +184,7 @@ ActStatus ActionHandlers::send_air_to_hss(SM::ControlBlock& cb)
 	mmeIpcIf.dispatchIpcMsg((char *) &s6a_req, sizeof(s6a_req), destAddr);
 
 	ProcedureStats::num_of_air_sent ++;
-	log_msg(LOG_DEBUG, "Leaving send_air_to_hss \n");
+	log_msg(LOG_DEBUG, "Leaving send_air_to_hss ");
 	
 	return ActStatus::PROCEED;
 
@@ -192,10 +192,10 @@ ActStatus ActionHandlers::send_air_to_hss(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::send_ulr_to_hss(SM::ControlBlock& cb)
 {  
-	log_msg(LOG_DEBUG, "Inside send_ulr_to_hss \n");
+	log_msg(LOG_DEBUG, "Inside send_ulr_to_hss ");
 	
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	s6a_Q_msg s6a_req;
     RESET_S6A_REQ_MSG(&s6a_req);
@@ -228,7 +228,7 @@ ActStatus ActionHandlers::send_ulr_to_hss(SM::ControlBlock& cb)
 	mmeIpcIf.dispatchIpcMsg((char *) &s6a_req, sizeof(s6a_req), destAddr);
 
 	ProcedureStats::num_of_ulr_sent ++;
-	log_msg(LOG_DEBUG, "Leaving send_ulr_to_hss \n");
+	log_msg(LOG_DEBUG, "Leaving send_ulr_to_hss ");
 	
 	return ActStatus::PROCEED;
 }
@@ -236,16 +236,16 @@ ActStatus ActionHandlers::send_ulr_to_hss(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::process_aia(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside handle_aia \n");
+	log_msg(LOG_DEBUG, "Inside handle_aia ");
 
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	
 	MmeProcedureCtxt *procedure_p = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL\n");
+	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL");
 
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer \n");
+	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer ");
 
 	const aia_Q_msg_t* msgData_p = static_cast<const aia_Q_msg_t *>(msgBuf->getDataPointer());
 
@@ -260,26 +260,26 @@ ActStatus ActionHandlers::process_aia(SM::ControlBlock& cb)
 	ue_ctxt->setAiaSecInfo(E_utran_sec_vector(msgData_p->sec));
 	
 	ProcedureStats::num_of_processed_aia ++;
-	log_msg(LOG_DEBUG, "Leaving handle_aia \n");
+	log_msg(LOG_DEBUG, "Leaving handle_aia ");
 	
 	return ActStatus::PROCEED;
 }
 
 ActStatus ActionHandlers::process_ula(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside handle_ula \n");
+	log_msg(LOG_DEBUG, "Inside handle_ula ");
 
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
-	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "SessionContainer is empty \n");
+	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "SessionContainer is empty ");
 
 	SessionContext* sessionCtxt = sessionCtxtContainer.front();
-	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL \n");
+	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL ");
 	
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer \n")
+	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer ")
 
 	const ula_Q_msg_t *ula_msg = static_cast<const ula_Q_msg_t*>(msgBuf->getDataPointer());
 
@@ -297,7 +297,7 @@ ActStatus ActionHandlers::process_ula(SM::ControlBlock& cb)
     {
         if (ula_msg->supp_features_list.supp_features[i].feature_list_id == 2)
         {
-            log_msg(LOG_DEBUG,"received feature_list_id2 from hss %u %u \n",ula_msg->supp_features_list.supp_features[i].feature_list_id, ula_msg->supp_features_list.supp_features[i].feature_list);
+            log_msg(LOG_DEBUG,"received feature_list_id2 from hss %u %u ",ula_msg->supp_features_list.supp_features[i].feature_list_id, ula_msg->supp_features_list.supp_features[i].feature_list);
             ue_ctxt->setHssFeatList2(
                     ula_msg->supp_features_list.supp_features[i]);
             break;
@@ -327,7 +327,7 @@ ActStatus ActionHandlers::process_ula(SM::ControlBlock& cb)
 	ue_ctxt->setPdnAddr(Paa(pdn_addr));
 	
 	ProcedureStats::num_of_processed_ula ++;
-	log_msg(LOG_DEBUG, "Leaving handle_ula_v \n");
+	log_msg(LOG_DEBUG, "Leaving handle_ula_v ");
 	
 	return ActStatus::PROCEED;
 }
@@ -335,7 +335,7 @@ ActStatus ActionHandlers::process_ula(SM::ControlBlock& cb)
 ActStatus ActionHandlers::auth_req_to_ue(SM::ControlBlock& cb)
 {
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	authreq_info authreq;
 	authreq.msg_type = auth_request;
@@ -371,40 +371,40 @@ ActStatus ActionHandlers::auth_req_to_ue(SM::ControlBlock& cb)
 	mmeIpcIf.dispatchIpcMsg((char *) &authreq, sizeof(authreq), destAddr);
 	
 	ProcedureStats::num_of_auth_req_to_ue_sent ++;
-	log_msg(LOG_DEBUG, "Leaving auth_req_to_ue_v sent message of length %d\n",sizeof(authreq));
+	log_msg(LOG_DEBUG, "Leaving auth_req_to_ue_v sent message of length %d",sizeof(authreq));
 		
 	return ActStatus::PROCEED;
 }
 
 ActStatus ActionHandlers::auth_response_validate(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside auth_response_validate \n");
+	log_msg(LOG_DEBUG, "Inside auth_response_validate ");
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(cb.getCBIndex());
 
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	
 	MmeProcedureCtxt* procedure_p = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL \n");
+	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL ");
 		
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer \n");
+	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer ");
 
 	const authresp_Q_msg_t *auth_resp = static_cast<const authresp_Q_msg_t*>(msgBuf->getDataPointer());	
 	
 	/*Check the state*/
 	if(SUCCESS != auth_resp->status) {
-		log_msg(LOG_ERROR, "eNB authentication failure for UE-%d.\n", ue_ctxt->getContextID());
+		log_msg(LOG_ERROR, "eNB authentication failure for UE-%d.", ue_ctxt->getContextID());
 		if(auth_resp->auts.len == 0)
 		{
-			log_msg(LOG_ERROR,"No AUTS.Not Synch Failure\n");
+			log_msg(LOG_ERROR,"No AUTS.Not Synch Failure");
 			procedure_p->setMmeErrorCause(S1AP_AUTH_FAILED);
 			SM::Event evt(AUTH_RESP_FAILURE,NULL);
         		controlBlk_p->qInternalEvent(evt);
 		}
 		else
 		{
-			log_msg(LOG_INFO,"AUTS recvd.  Synch failure. send AIR\n");
+			log_msg(LOG_INFO,"AUTS recvd.  Synch failure. send AIR");
 			procedure_p->setAuthRespStatus(auth_resp->status);
 			procedure_p->setAuts(Auts(auth_resp->auts));
 			SM::Event evt(AUTH_RESP_SYNC_FAILURE,NULL);
@@ -414,7 +414,7 @@ ActStatus ActionHandlers::auth_response_validate(SM::ControlBlock& cb)
     else
     {
         log_msg(LOG_INFO,
-                "Auth response validation success. Proceeding to Sec mode Command\n");
+                "Auth response validation success. Proceeding to Sec mode Command");
         uint64_t xres = 0;
         memcpy(&xres, ue_ctxt->getAiaSecInfo().AiaSecInfo_mp->xres.val,
                 sizeof(uint64_t));
@@ -440,17 +440,17 @@ ActStatus ActionHandlers::auth_response_validate(SM::ControlBlock& cb)
 
     }
 	
-	log_msg(LOG_DEBUG, "Leaving auth_response_validate \n");
+	log_msg(LOG_DEBUG, "Leaving auth_response_validate ");
 	
 	return ActStatus::PROCEED;
 }
 
 ActStatus ActionHandlers::send_auth_reject(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside send_auth_reject \n");
+	log_msg(LOG_DEBUG, "Inside send_auth_reject ");
 
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	
 	ProcedureStats::num_of_auth_reject_sent ++;
 	return ActStatus::PROCEED;
@@ -458,10 +458,10 @@ ActStatus ActionHandlers::send_auth_reject(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::sec_mode_cmd_to_ue(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside sec_mode_cmd_to_ue \n");
+	log_msg(LOG_DEBUG, "Inside sec_mode_cmd_to_ue ");
 
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	
     E_UTRAN_sec_vector *secVect = const_cast<E_UTRAN_sec_vector*>(ue_ctxt->getAiaSecInfo().AiaSecInfo_mp);
 	secinfo& secInfo = const_cast<secinfo&>(ue_ctxt->getUeSecInfo().secinfo_m);
@@ -560,7 +560,7 @@ ActStatus ActionHandlers::sec_mode_cmd_to_ue(SM::ControlBlock& cb)
 	mmeIpcIf.dispatchIpcMsg((char *) &sec_mode_msg, sizeof(sec_mode_msg), destAddr);
 	
 	ProcedureStats::num_of_sec_mode_cmd_to_ue_sent ++;
-	log_msg(LOG_DEBUG, "Leaving sec_mode_cmd_to_ue \n");
+	log_msg(LOG_DEBUG, "Leaving sec_mode_cmd_to_ue ");
 	
 	return ActStatus::PROCEED;
 }
@@ -568,21 +568,21 @@ ActStatus ActionHandlers::sec_mode_cmd_to_ue(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::process_sec_mode_resp(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside handle_sec_mode_resp \n");
+	log_msg(LOG_DEBUG, "Inside handle_sec_mode_resp ");
 
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	MmeProcedureCtxt* procedure_p = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL \n");
+	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL ");
 
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer \n")
+	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer ")
 
 	const secmode_resp_Q_msg_t* secmode_resp = static_cast<const secmode_resp_Q_msg_t*>(msgBuf->getDataPointer());
 	if(SUCCESS == secmode_resp->status)
 	{
-		log_msg(LOG_INFO, "Sec mode complete rcv. UE - %d.\n",
+		log_msg(LOG_INFO, "Sec mode complete rcv. UE - %d.",
 				ue_ctxt->getContextID());
 		
 	}	
@@ -594,25 +594,25 @@ ActStatus ActionHandlers::process_sec_mode_resp(SM::ControlBlock& cb)
 	}
 
 	ProcedureStats::num_of_processed_sec_mode_resp ++;
-	log_msg(LOG_DEBUG, "Leaving handle_sec_mode_resp \n");
+	log_msg(LOG_DEBUG, "Leaving handle_sec_mode_resp ");
 	
 	return ActStatus::PROCEED;
 }
 
 ActStatus ActionHandlers::check_esm_info_req_required(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside check_esm_info_req_required \n");
+	log_msg(LOG_DEBUG, "Inside check_esm_info_req_required ");
 
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	
 	MmeAttachProcedureCtxt* procedure_p = dynamic_cast<MmeAttachProcedureCtxt*>(cb.getTempDataBlock());
-	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL \n");
+	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL ");
 	
 	MmeContextManagerUtils::deleteAllSessionContext(cb);
 
 	SessionContext* sessionCtxt = MmeContextManagerUtils::allocateSessionContext(cb, *ue_ctxt);
-	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL \n");
+	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL ");
 
 	sessionCtxt->setPti(procedure_p->getPti());
 	
@@ -633,15 +633,15 @@ ActStatus ActionHandlers::check_esm_info_req_required(SM::ControlBlock& cb)
 ActStatus ActionHandlers::send_esm_info_req_to_ue(SM::ControlBlock& cb)
 {
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
 	if(sessionCtxtContainer.size() < 1)
 	{
-		log_msg(LOG_ERROR, "Session context list is empty for UE IDX %d\n", cb.getCBIndex());
+		log_msg(LOG_ERROR, "Session context list is empty for UE IDX %d", cb.getCBIndex());
 		return ActStatus::HALT;
 	}
-	log_msg(LOG_DEBUG,"%s Sending ESM info request UE index %u \n", __FUNCTION__, ue_ctxt->getContextID());
+	log_msg(LOG_DEBUG,"Sending ESM info request UE index %u ", ue_ctxt->getContextID());
 
 	SessionContext* sessionCtxt = sessionCtxtContainer.front();
 	esm_req_Q_msg esmreq;
@@ -677,7 +677,7 @@ ActStatus ActionHandlers::send_esm_info_req_to_ue(SM::ControlBlock& cb)
 	MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
 	mmeIpcIf.dispatchIpcMsg((char *) &esmreq, sizeof(esmreq), destAddr);
 
-	log_msg(LOG_DEBUG, "Leaving send_esm_info_req_to_ue \n");
+	log_msg(LOG_DEBUG, "Leaving send_esm_info_req_to_ue ");
 	ProcedureStats::num_of_esm_info_req_to_ue_sent ++;
 	return ActStatus::PROCEED;
 }
@@ -685,18 +685,18 @@ ActStatus ActionHandlers::send_esm_info_req_to_ue(SM::ControlBlock& cb)
 ActStatus ActionHandlers::process_esm_info_resp(SM::ControlBlock& cb)
 {
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     	MmeAttachProcedureCtxt* procedure_p = dynamic_cast<MmeAttachProcedureCtxt*>(cb.getTempDataBlock());
-    	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL \n");
+    	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL ");
 
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer \n")
+	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer ")
 
 	const esm_resp_Q_msg_t *esm_res = static_cast<const esm_resp_Q_msg_t *>(msgBuf->getDataPointer());
     	if (esm_res->status != SUCCESS)
     	{
-        	log_msg(LOG_ERROR, "ESM Response failed \n");
+        	log_msg(LOG_ERROR, "ESM Response failed ");
     	}
 
 	procedure_p->setRequestedApn(Apn_name(esm_res->apn));
@@ -707,22 +707,22 @@ ActStatus ActionHandlers::process_esm_info_resp(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::cs_req_to_sgw(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside cs_req_to_sgw \n");
+	log_msg(LOG_DEBUG, "Inside cs_req_to_sgw ");
 
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	MmeAttachProcedureCtxt *procCtxt = dynamic_cast<MmeAttachProcedureCtxt*>(cb.getTempDataBlock());
-	VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+	VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
 	auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
-	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "Sessions Container is empty\n");
+	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "Sessions Container is empty");
 
 	SessionContext* sessionCtxt = sessionCtxtContainer.front();
-	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL \n");
+	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL ");
 
 	BearerContext* bearerCtxt_p = sessionCtxt->findBearerContextByBearerId(sessionCtxt->getLinkedBearerId());
-	VERIFY(bearerCtxt_p, return ActStatus::ABORT, "Bearer Context is NULL \n");
+	VERIFY(bearerCtxt_p, return ActStatus::ABORT, "Bearer Context is NULL ");
 
 	struct CS_Q_msg cs_msg;
     memset(&cs_msg, 0, sizeof(cs_msg));
@@ -769,19 +769,19 @@ ActStatus ActionHandlers::cs_req_to_sgw(SM::ControlBlock& cb)
     {
         //unsigned char temp_name[128];
         //strcpy(temp_name, apnName.apnname_m.val);
-        log_msg(LOG_DEBUG, "APN %s length = %d \n",apnName.apnname_m.val,apnName.apnname_m.len);
+        log_msg(LOG_DEBUG, "APN %s length = %d ",apnName.apnname_m.val,apnName.apnname_m.len);
         const unsigned char *ptr = &apnName.apnname_m.val[1]; /*BUG*/
         std::string temp_str((char *)ptr);
         apn_config *temp = mme_tables->find_apn(temp_str); 
         if(temp != NULL)
         {
-            log_msg(LOG_DEBUG, "Found APN mapping in static table %x \n",cs_msg.sgw_ip);
+            log_msg(LOG_DEBUG, "Found APN mapping in static table %x ",cs_msg.sgw_ip);
             cs_msg.sgw_ip = temp->get_sgw_addr(); 
             cs_msg.pgw_ip = temp->get_pgw_addr(); 
         } 
         else
         {
-            log_msg(LOG_DEBUG, "APN not found in static apn configuration \n");
+            log_msg(LOG_DEBUG, "APN not found in static apn configuration ");
         }
     }
 	memcpy(&(cs_msg.tai), &(ue_ctxt->getTai().tai_m), sizeof(struct TAI));
@@ -828,36 +828,36 @@ ActStatus ActionHandlers::cs_req_to_sgw(SM::ControlBlock& cb)
 	mmeIpcIf.dispatchIpcMsg((char *) &cs_msg, sizeof(cs_msg), destAddr);
 
 	ProcedureStats::num_of_cs_req_to_sgw_sent ++;
-	log_msg(LOG_DEBUG, "Leaving cs_req_to_sgw \n");
+	log_msg(LOG_DEBUG, "Leaving cs_req_to_sgw ");
 
     	return ActStatus::PROCEED;
 }
 
 ActStatus ActionHandlers::process_cs_resp(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Entering handle_cs_resp \n");
+	log_msg(LOG_DEBUG, "Entering handle_cs_resp ");
 
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	
 	MmeAttachProcedureCtxt* procedure_p = dynamic_cast<MmeAttachProcedureCtxt*>(cb.getTempDataBlock());
-	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL \n");
+	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL ");
 
 	auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
-	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "Sessions Container is empty\n");
+	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "Sessions Container is empty");
 
 	SessionContext* sessionCtxt = sessionCtxtContainer.front();
-	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL \n");
+	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL ");
 
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer \n");
-	VERIFY(msgBuf->getLength() >= sizeof(struct csr_Q_msg), return ActStatus::ABORT, "Invalid CSRsp message length \n");
+	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer ");
+	VERIFY(msgBuf->getLength() >= sizeof(struct csr_Q_msg), return ActStatus::ABORT, "Invalid CSRsp message length ");
 
 	const struct csr_Q_msg* csr_info= static_cast<const struct csr_Q_msg*>(msgBuf->getDataPointer());
 
     if(csr_info->status != GTPV2C_CAUSE_REQUEST_ACCEPTED)
     {
-		log_msg(LOG_DEBUG, "CSRsp rejected by SGW with cause %d \n",csr_info->status);
+		log_msg(LOG_DEBUG, "CSRsp rejected by SGW with cause %d ",csr_info->status);
         std::ostringstream reason;
         reason<<"CSRsp_reject_cause_"<<csr_info->status;
         mmeStats::Instance()->increment(mmeStatsCounter::MME_PROCEDURES_ATTACH_PROC_FAILURE, {{"failure_reason", reason.str()}});
@@ -865,11 +865,10 @@ ActStatus ActionHandlers::process_cs_resp(SM::ControlBlock& cb)
     }
 
 	BearerContext* bearerCtxt = sessionCtxt->findBearerContextByBearerId(sessionCtxt->getLinkedBearerId());
-	VERIFY(bearerCtxt, return ActStatus::ABORT, "Bearer Context is NULL \n");
+	VERIFY(bearerCtxt, return ActStatus::ABORT, "Bearer Context is NULL ");
 
 	bearerCtxt->setBearerQos(csr_info->bearerQos);
 	procedure_p->setPcoOptions(csr_info->pco_options,csr_info->pco_length);
-	log_msg(LOG_DEBUG, "Process CSRsp - PCO length %d\n", csr_info->pco_options,csr_info->pco_length);
 	
 	sessionCtxt->setS11SgwCtrlFteid(Fteid(csr_info->s11_sgw_fteid));
 	sessionCtxt->setS5S8PgwCtrlFteid(Fteid(csr_info->s5s8_pgwc_fteid));
@@ -880,20 +879,20 @@ ActStatus ActionHandlers::process_cs_resp(SM::ControlBlock& cb)
 	sessionCtxt->setPdnAddr(Paa(csr_info->pdn_addr));
 		
 	ProcedureStats::num_of_processed_cs_resp ++;
-	log_msg(LOG_DEBUG, "Leaving handle_cs_resp \n");
+	log_msg(LOG_DEBUG, "Leaving handle_cs_resp ");
 	
 	return ActStatus::PROCEED;
 }
 
 ActStatus ActionHandlers::send_init_ctxt_req_to_ue(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside send_init_ctxt_req_to_ue \n");
+	log_msg(LOG_DEBUG, "Inside send_init_ctxt_req_to_ue ");
 
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	MmeAttachProcedureCtxt* procedure_p = dynamic_cast<MmeAttachProcedureCtxt*>(cb.getTempDataBlock());
-	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL \n");
+	VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL ");
 
 	if (procedure_p->getAttachType() == imsiAttach_c ||
 			procedure_p->getAttachType() == unknownGutiAttach_c)
@@ -901,7 +900,7 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue(SM::ControlBlock& cb)
 		uint32_t mTmsi = MmeCommonUtils::allocateMtmsi();
 		if (mTmsi == 0)
 		{
-			log_msg(LOG_DEBUG, "send_init_ctxt_req_to_ue: Failed to allocate mTmsi \n");
+			log_msg(LOG_DEBUG, "send_init_ctxt_req_to_ue: Failed to allocate mTmsi ");
 			return ActStatus::ABORT;
 		}
 
@@ -912,10 +911,10 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue(SM::ControlBlock& cb)
 	}
 
 	auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
-	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "Sessions Container is empty\n");
+	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "Sessions Container is empty");
 
 	SessionContext* sessionCtxt = sessionCtxtContainer.front();
-	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL \n");
+	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL ");
 
 	/* 33.401 7.2.6.2	Establishment of keys for cryptographically protected 
        radio bearers
@@ -944,7 +943,7 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue(SM::ControlBlock& cb)
 	icr_msg.exg_max_ul_bitrate = (ue_ctxt->getAmbr().ambr_m).max_requested_bw_ul;
 
 	BearerContext* bearerCtxt = sessionCtxt->findBearerContextByBearerId(sessionCtxt->getLinkedBearerId());
-	VERIFY(bearerCtxt, return ActStatus::ABORT, "Bearer Context is NULL \n");
+	VERIFY(bearerCtxt, return ActStatus::ABORT, "Bearer Context is NULL ");
 
 	icr_msg.bearer_id = bearerCtxt->getBearerId();
 	icr_msg.qci = bearerCtxt->getBearerQos().qci;
@@ -1051,9 +1050,8 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue(SM::ControlBlock& cb)
 	nas.elements[3].pduElement.esm_msg.eps_qos.qci = bearerCtxt->getBearerQos().qci;
 	nas.elements[3].pduElement.esm_msg.apn.len = sessionCtxt->getAccessPtName().apnname_m.len;
 	memcpy(nas.elements[3].pduElement.esm_msg.apn.val, sessionCtxt->getAccessPtName().apnname_m.val, sessionCtxt->getAccessPtName().apnname_m.len);
-    log_msg(LOG_DEBUG, "ESM apn length = %d \n",nas.elements[3].pduElement.esm_msg.apn.len);
+    log_msg(LOG_DEBUG, "ESM apn length = %d ",nas.elements[3].pduElement.esm_msg.apn.len);
 
-	log_msg(LOG_DEBUG, "PCO length %d\n", procedure_p->getPcoOptionsLen());
 	nas.elements[3].pduElement.esm_msg.pco_opt.pco_length = procedure_p->getPcoOptionsLen();
 	memcpy(nas.elements[3].pduElement.esm_msg.pco_opt.pco_options, procedure_p->getPcoOptions(), nas.elements[3].pduElement.pco_opt.pco_length);
 
@@ -1125,7 +1123,7 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue(SM::ControlBlock& cb)
 	MmeNasUtils::encode_nas_msg(&nasBuffer, &nas, ue_ctxt->getUeSecInfo());
 	memcpy(&icr_msg.nasMsgBuf[0], &nasBuffer.buf[0], nasBuffer.pos);
 	icr_msg.nasMsgSize = nasBuffer.pos;
-	log_msg(LOG_DEBUG, "nas message size %d \n",icr_msg.nasMsgSize);
+	log_msg(LOG_DEBUG, "nas message size %d ",icr_msg.nasMsgSize);
 	free(nas.elements);
 
 	cmn::ipc::IpcAddress destAddr;
@@ -1136,29 +1134,29 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue(SM::ControlBlock& cb)
 	mmeIpcIf.dispatchIpcMsg((char *) &icr_msg, sizeof(icr_msg), destAddr);
 	
 	ProcedureStats::num_of_init_ctxt_req_to_ue_sent ++;
-	log_msg(LOG_DEBUG, "Leaving send_init_ctxt_req_to_ue_v \n");
+	log_msg(LOG_DEBUG, "Leaving send_init_ctxt_req_to_ue_v ");
 		
 	return ActStatus::PROCEED;
 }
 
 ActStatus ActionHandlers::process_init_ctxt_resp(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside process_init_ctxt_resp \n");
+	log_msg(LOG_DEBUG, "Inside process_init_ctxt_resp ");
 
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	MmeAttachProcedureCtxt *procCtxt = dynamic_cast<MmeAttachProcedureCtxt*>(cb.getTempDataBlock());
-	VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+	VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
 	auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
-	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "Sessions Container is empty\n");
+	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "Sessions Container is empty");
 
 	SessionContext* sessionCtxt = sessionCtxtContainer.front();
-	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL \n");
+	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL ");
 	
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer \n")
+	VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer ")
 
 	const initctx_resp_Q_msg_t *ics_res = static_cast<const initctx_resp_Q_msg_t*>(msgBuf->getDataPointer());
 	
@@ -1169,28 +1167,28 @@ ActStatus ActionHandlers::process_init_ctxt_resp(SM::ControlBlock& cb)
 	S1uEnbUserFteid.ip.ipv4 = *(struct in_addr*)&ics_res->erab_setup_resp_list.erab_su_res_item[0].transportLayerAddress;
 	
 	BearerContext* bearerCtxt = sessionCtxt->findBearerContextByBearerId(sessionCtxt->getLinkedBearerId());
-	VERIFY(bearerCtxt, return ActStatus::ABORT, "Bearer Context is NULL \n");
+	VERIFY(bearerCtxt, return ActStatus::ABORT, "Bearer Context is NULL ");
 
 	bearerCtxt->setS1uEnbUserFteid(Fteid(S1uEnbUserFteid));
 
 	ProcedureStats::num_of_processed_init_ctxt_resp ++;
-	log_msg(LOG_DEBUG, "Leaving process_init_ctxt_resp \n");
+	log_msg(LOG_DEBUG, "Leaving process_init_ctxt_resp ");
 	
 	return ActStatus::PROCEED;
 }
 
 ActStatus ActionHandlers::send_mb_req_to_sgw(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside send_mb_req_to_sgw \n");
+	log_msg(LOG_DEBUG, "Inside send_mb_req_to_sgw ");
 
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
-	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "Sessions Container is empty\n");
+	VERIFY(sessionCtxtContainer.size() > 0, return ActStatus::ABORT, "Sessions Container is empty");
 
 	SessionContext* sessionCtxt = sessionCtxtContainer.front();
-	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL \n");
+	VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL ");
 	
 	struct MB_Q_msg mb_msg;
 	mb_msg.msg_type = modify_bearer_request;
@@ -1199,7 +1197,7 @@ ActStatus ActionHandlers::send_mb_req_to_sgw(SM::ControlBlock& cb)
 	memset(mb_msg.indication, 0, S11_MB_INDICATION_FLAG_SIZE); /*TODO : future*/
 
 	BearerContext* bearerCtxt = sessionCtxt->findBearerContextByBearerId(sessionCtxt->getLinkedBearerId());
-	VERIFY(bearerCtxt, return ActStatus::ABORT, "Bearer Context is NULL \n");
+	VERIFY(bearerCtxt, return ActStatus::ABORT, "Bearer Context is NULL ");
 
 	mb_msg.bearer_ctx_list.bearers_count = 1;
 	mb_msg.bearer_ctx_list.bearer_ctxt[0].eps_bearer_id = bearerCtxt->getBearerId();
@@ -1220,7 +1218,7 @@ ActStatus ActionHandlers::send_mb_req_to_sgw(SM::ControlBlock& cb)
 	mmeIpcIf.dispatchIpcMsg((char *) &mb_msg, sizeof(mb_msg), destAddr);
 		
 	ProcedureStats::num_of_mb_req_to_sgw_sent ++;
-	log_msg(LOG_DEBUG, "Leaving send_mb_req_to_sgw \n");
+	log_msg(LOG_DEBUG, "Leaving send_mb_req_to_sgw ");
 	
 	return ActStatus::PROCEED;
 
@@ -1228,22 +1226,22 @@ ActStatus ActionHandlers::send_mb_req_to_sgw(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::process_attach_cmp_from_ue(SM::ControlBlock& cb)
 {	
-	log_msg(LOG_DEBUG, "Inside handle_attach_cmp_from_ue \n");
+	log_msg(LOG_DEBUG, "Inside handle_attach_cmp_from_ue ");
 
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	//ue_ctxt->getUeSecInfo().increment_uplink_count();
 
 	ProcedureStats::num_of_processed_attach_cmp_from_ue ++;
-	log_msg(LOG_DEBUG, "Leaving handle_attach_cmp_from_ue \n");
+	log_msg(LOG_DEBUG, "Leaving handle_attach_cmp_from_ue ");
 	
 	return ActStatus::PROCEED;
 }
 
 ActStatus ActionHandlers::process_mb_resp(SM::ControlBlock& cb)
 {	
-	log_msg(LOG_DEBUG, "Inside handle_mb_resp \n");
+	log_msg(LOG_DEBUG, "Inside handle_mb_resp ");
 	
 	ProcedureStats::num_of_processed_mb_resp ++;
 	return ActStatus::PROCEED;
@@ -1251,13 +1249,13 @@ ActStatus ActionHandlers::process_mb_resp(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::check_and_send_emm_info(SM::ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside check_and_send_emm_info \n");
+    log_msg(LOG_DEBUG, "Inside check_and_send_emm_info ");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
     
     MmeProcedureCtxt *procCtxt = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
     if (MmeCommonUtils::isEmmInfoRequired(cb, *ue_ctxt, *procCtxt))
     {
@@ -1303,7 +1301,7 @@ ActStatus ActionHandlers::check_and_send_emm_info(SM::ControlBlock& cb)
     	ProcedureStats::num_of_emm_info_sent++;
     }
 
-    log_msg(LOG_DEBUG, "Leaving check_and_send_emm_info \n");
+    log_msg(LOG_DEBUG, "Leaving check_and_send_emm_info ");
 
     return ActStatus::PROCEED;
 
@@ -1311,13 +1309,11 @@ ActStatus ActionHandlers::check_and_send_emm_info(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::attach_done(SM::ControlBlock& cb)
 {	
-	log_msg(LOG_DEBUG, "Inside attach_done \n");
-	
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	MmContext* mmCtxt = ue_ctxt->getMmContext();
-	VERIFY(mmCtxt, return ActStatus::ABORT, "MM Context is NULL \n");
+	VERIFY(mmCtxt, return ActStatus::ABORT, "MM Context is NULL ");
 
 	mmCtxt->setMmState(EpsAttached);
 	
@@ -1329,7 +1325,7 @@ ActStatus ActionHandlers::attach_done(SM::ControlBlock& cb)
 	ProcedureStats::num_of_attach_done++;
 	ProcedureStats::num_of_subscribers_attached ++;
 
-	log_msg(LOG_DEBUG,"Leaving attach done\n");
+	log_msg(LOG_DEBUG,"Leaving attach done");
 
     mmeStats::Instance()->increment(mmeStatsCounter::MME_NUM_ACTIVE_SUBSCRIBERS);
 
@@ -1339,8 +1335,8 @@ ActStatus ActionHandlers::attach_done(SM::ControlBlock& cb)
 ActStatus ActionHandlers::send_attach_reject(ControlBlock& cb)
 {
         UEContext* ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
-        VERIFY_UE(cb, ueCtxt_p, "Invalid UE\n");
-	log_msg(LOG_DEBUG,"%s Sending attach reject UE index %u \n", __FUNCTION__, ueCtxt_p->getContextID());
+        VERIFY_UE(cb, ueCtxt_p, "Invalid UE");
+	    log_msg(LOG_DEBUG,"Sending attach reject UE index %u ", ueCtxt_p->getContextID());
 
         MmeAttachProcedureCtxt *procCtxt = dynamic_cast<MmeAttachProcedureCtxt*>(cb.getTempDataBlock());
         
@@ -1386,7 +1382,7 @@ ActStatus ActionHandlers::send_attach_reject(ControlBlock& cb)
 ActStatus ActionHandlers::abort_attach(ControlBlock& cb)
 {
     UEContext* ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ueCtxt_p, "Invalid UE\n");
+    VERIFY_UE(cb, ueCtxt_p, "Invalid UE");
 
     ERROR_CODES errorCause = SUCCESS;
     uint16_t stateId = 0;
@@ -1400,7 +1396,7 @@ ActStatus ActionHandlers::abort_attach(ControlBlock& cb)
 
         log_msg(LOG_INFO,
                 "Abort ongoing Attach for subscriber %s. "
-                "Current State %s, Error Cause %d\n, ",
+                "Current State %s, Error Cause %d, ",
                 ueCtxt_p->getImsi().getDigitsArray(),
                 procCtxt->getCurrentState()->getStateName(), errorCause);
 
@@ -1446,7 +1442,7 @@ ActStatus ActionHandlers::handle_attach_request(ControlBlock& cb)
     MmeProcedureCtxt *procCtxt = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
     if (procCtxt != NULL)
     {
-        log_msg(LOG_DEBUG, "Received Attach Req when procedure % in progress\n",
+        log_msg(LOG_DEBUG, "Received Attach Req when procedure % in progress",
                 procCtxt->getCtxtType());
 
         // abort current procedure. Set appropriate error cause for aborting the procedure
@@ -1461,7 +1457,7 @@ ActStatus ActionHandlers::handle_attach_request(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::handle_state_guard_timeouts(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG,"State guard timeout.Abort.\n");
+    log_msg(LOG_DEBUG,"State guard timeout.Abort.");
     MmeProcedureCtxt *procCtxt = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
     if (procCtxt != NULL)
     {
@@ -1476,7 +1472,7 @@ ActStatus ActionHandlers::handle_state_guard_timeouts_for_csreq_ind(ControlBlock
 {
 	UEContext* ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
     log_msg(LOG_ERROR,"CSRsp not received from SPGW, guard timer expired. "
-                      "Let's try to resolve spgw address - Ue Index %d \n", 
+                      "Let's try to resolve spgw address - Ue Index %d ", 
                       ueCtxt_p != NULL ? ueCtxt_p->getContextID():0);
     // invalidate dns entries 
     mme_tables->invalidate_dns();
@@ -1494,7 +1490,7 @@ ActStatus ActionHandlers::handle_s1_rel_req_during_attach(ControlBlock& cb)
     if (procCtxt != NULL)
     {
         log_msg(LOG_DEBUG,
-                "S1 Release Collision during Attach. Current State %s\n",
+                "S1 Release Collision during Attach. Current State %s",
                 procCtxt->getCurrentState()->getStateName());
 
         // Set appropriate error cause for aborting the procedure

--- a/src/mme-app/actionHandlers/createBearerProcedureActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/createBearerProcedureActionHandlers.cpp
@@ -48,32 +48,32 @@ using namespace cmn::utils;
  ***************************************/
 ActStatus ActionHandlers::init_ded_bearer_activation(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "init_ded_bearer_activation : Entry\n");
+    log_msg(LOG_DEBUG, "init_ded_bearer_activation : Entry");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeSmCreateBearerProcCtxt *cbReqProc_p =
             dynamic_cast<MmeSmCreateBearerProcCtxt*>(cb.getTempDataBlock());
     VERIFY(cbReqProc_p, return ActStatus::ABORT,
-            " Create Bearer Procedure Context is NULL \n");
+            " Create Bearer Procedure Context is NULL ");
 
     cmn::IpcEventMessage *ipcMsg =
             dynamic_cast<cmn::IpcEventMessage*>(cbReqProc_p->getCreateBearerReqEMsgRaw());
-    VERIFY(ipcMsg, return ActStatus::ABORT, "Invalid IPC Event Message in CBReq Procedure Context \n");
+    VERIFY(ipcMsg, return ActStatus::ABORT, "Invalid IPC Event Message in CBReq Procedure Context ");
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(ipcMsg->getMsgBuffer());
-    VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer \n");
+    VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer ");
 
     const cb_req_Q_msg *cb_req =
             static_cast<const cb_req_Q_msg*>(msgBuf->getDataPointer());
-    VERIFY(cb_req, return ActStatus::ABORT, "Invalid data buffer \n");
+    VERIFY(cb_req, return ActStatus::ABORT, "Invalid data buffer ");
 
     SessionContext *sessionCtxt = ue_ctxt->findSessionContextByLinkedBearerId(
             cb_req->linked_eps_bearer_id);
     VERIFY(sessionCtxt,
             cbReqProc_p->setMmeErrorCause(SESSION_CONTEXT_NOT_FOUND); return ActStatus::ABORT,
-            "Session Context is NULL \n");
+            "Session Context is NULL ");
 
     uint8_t bearerAllocCount = 0;
     for (int i = 0; i < cb_req->bearer_ctx_list.bearers_count; i++)
@@ -90,7 +90,7 @@ ActStatus ActionHandlers::init_ded_bearer_activation(ControlBlock &cb)
         if (bearerCtxt_p != NULL)
         {
             log_msg(LOG_DEBUG,
-                    "Allocated Bearer Context with eps_bearer_id: %d for s1u sgw teid: %d \n",
+                    "Allocated Bearer Context with eps_bearer_id: %d for s1u sgw teid: %d ",
                     bearerCtxt_p->getBearerId(),
                     cb_req->bearer_ctx_list.bearer_ctxt[i].s1u_sgw_teid.header.teid_gre);
 
@@ -127,7 +127,7 @@ ActStatus ActionHandlers::init_ded_bearer_activation(ControlBlock &cb)
         else
         {
             log_msg(LOG_ERROR,
-                    "Failed to allocate Bearer Context with teid: %d \n",
+                    "Failed to allocate Bearer Context with teid: %d ",
                     cb_req->bearer_ctx_list.bearer_ctxt[i].s1u_sgw_teid.header.teid_gre);
 
             brStatus.cause.cause = GTPV2C_CAUSE_REQUEST_REJECTED;
@@ -154,15 +154,15 @@ ActStatus ActionHandlers::init_ded_bearer_activation(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::send_bearer_setup_and_sess_mgmt_req(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "send_bearer_setup_and_sess_mgmt_req : Entry\n");
+    log_msg(LOG_DEBUG, "send_bearer_setup_and_sess_mgmt_req : Entry");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeSmCreateBearerProcCtxt *cbReqProc_p = 
             dynamic_cast<MmeSmCreateBearerProcCtxt*>(cb.getTempDataBlock());
     VERIFY(cbReqProc_p, return ActStatus::ABORT,
-            "Create Bearer Procedure Context is NULL \n");
+            "Create Bearer Procedure Context is NULL ");
 
     erabsu_ctx_req_Q_msg erab_su_req;
     memset(&erab_su_req, 0, sizeof(erabsu_ctx_req_Q_msg));
@@ -191,7 +191,7 @@ ActStatus ActionHandlers::send_bearer_setup_and_sess_mgmt_req(ControlBlock &cb)
     else
     {
         log_msg(LOG_INFO, "send_bearer_setup_and_sess_mgmt_req : "
-                "Failed to populate eRAB Setup Request\n");
+                "Failed to populate eRAB Setup Request");
         actStatus = ActStatus::ABORT;
     }
     return actStatus;
@@ -234,12 +234,12 @@ ActStatus ActionHandlers::send_create_bearer_response(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::handle_ded_act_cmp_ind(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "handle_ded_act_cmp_ind : Entry\n");
+    log_msg(LOG_DEBUG, "handle_ded_act_cmp_ind : Entry");
 
     MmeSmCreateBearerProcCtxt *cbReqProc_p = 
             dynamic_cast<MmeSmCreateBearerProcCtxt*>(cb.getTempDataBlock());
     VERIFY(cbReqProc_p, return ActStatus::ABORT,
-            "Create Bearer Procedure Context is NULL \n");
+            "Create Bearer Procedure Context is NULL ");
 
     ActStatus actStatus = ActStatus::PROCEED;
 
@@ -279,10 +279,10 @@ ActStatus ActionHandlers::handle_ded_act_cmp_ind(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::abort_create_bearer_procedure(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "abort_create_bearer_procedure : Entry\n");
+    log_msg(LOG_DEBUG, "abort_create_bearer_procedure : Entry");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeSmCreateBearerProcCtxt *cbReqProc_p =
             dynamic_cast<MmeSmCreateBearerProcCtxt*>(cb.getTempDataBlock());
@@ -332,7 +332,7 @@ ActStatus ActionHandlers::abort_create_bearer_procedure(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::create_bearer_proc_complete(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "create_bearer_proc_complete : Entry\n");
+    log_msg(LOG_DEBUG, "create_bearer_proc_complete : Entry");
 
     MmeSmCreateBearerProcCtxt *cbReqProc_p =
             dynamic_cast<MmeSmCreateBearerProcCtxt*>(cb.getTempDataBlock());

--- a/src/mme-app/actionHandlers/dedBearerActProcedureActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/dedBearerActProcedureActionHandlers.cpp
@@ -43,29 +43,29 @@ using namespace cmn::utils;
  ***************************************/
 ActStatus ActionHandlers::process_erab_setup_response(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "process_erab_setup_response : Entry\n");
+    log_msg(LOG_DEBUG, "process_erab_setup_response : Entry");
 
     UEContext *ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ueCtxt_p, "Invalid UE\n");
+    VERIFY_UE(cb, ueCtxt_p, "Invalid UE");
 
     SmDedActProcCtxt *dedBrActProc_p =
             dynamic_cast<SmDedActProcCtxt*>(cb.getTempDataBlock());
     VERIFY(dedBrActProc_p, return ActStatus::ABORT,
-            "Ded Bearer Activation Procedure Context is NULL \n");
+            "Ded Bearer Activation Procedure Context is NULL ");
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     VERIFY(msgBuf, dedBrActProc_p->setMmeErrorCause(INVALID_MSG_BUFFER);
-    	return ActStatus::ABORT, "process_erab_setup_response : Invalid message buffer \n");
+    	return ActStatus::ABORT, "process_erab_setup_response : Invalid message buffer ");
 
     const erabSuResp_Q_msg_t *erab_su_resp =
                 static_cast<const erabSuResp_Q_msg_t*>(msgBuf->getDataPointer());
     VERIFY(erab_su_resp, dedBrActProc_p->setMmeErrorCause(INVALID_DATA_BUFFER);
-    	return ActStatus::ABORT, "process_erab_setup_response : Invalid data buffer \n");
+    	return ActStatus::ABORT, "process_erab_setup_response : Invalid data buffer ");
 
     BearerContext *bearerCtxt_p = MmeContextManagerUtils::findBearerContext(
             dedBrActProc_p->getBearerId(), ueCtxt_p);
     VERIFY(bearerCtxt_p, dedBrActProc_p->setMmeErrorCause(BEARER_CONTEXT_NOT_FOUND);
-                return ActStatus::ABORT, "Bearer Context is NULL \n");
+                return ActStatus::ABORT, "Bearer Context is NULL ");
 
     ActStatus actStatus = ActStatus::PROCEED;
     bool bearerEntryFound = false;
@@ -114,29 +114,29 @@ ActStatus ActionHandlers::process_erab_setup_response(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::process_act_ded_bearer_accept(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "process_act_ded_bearer_accept : Entry\n");
+    log_msg(LOG_DEBUG, "process_act_ded_bearer_accept : Entry");
 
     UEContext *ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ueCtxt_p, "Invalid UE\n");
+    VERIFY_UE(cb, ueCtxt_p, "Invalid UE");
 
     SmDedActProcCtxt *dedBrActProc_p =
             dynamic_cast<SmDedActProcCtxt*>(cb.getTempDataBlock());
     VERIFY(dedBrActProc_p, return ActStatus::ABORT,
-            "Ded Bearer Activation Procedure Context is NULL \n");
+            "Ded Bearer Activation Procedure Context is NULL ");
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     VERIFY(msgBuf, dedBrActProc_p->setMmeErrorCause(INVALID_MSG_BUFFER);
-    	return ActStatus::ABORT, "process_act_ded_bearer_accept : Invalid message buffer \n");
+    	return ActStatus::ABORT, "process_act_ded_bearer_accept : Invalid message buffer ");
 
     const dedicatedBearerContextAccept_Q_msg_t *dedBrAcpt =
             static_cast<const dedicatedBearerContextAccept_Q_msg_t*>(msgBuf->getDataPointer());
     VERIFY(dedBrAcpt, dedBrActProc_p->setMmeErrorCause(INVALID_DATA_BUFFER);
-    		return ActStatus::ABORT, "process_act_ded_bearer_accept : Invalid data buffer \n");
+    		return ActStatus::ABORT, "process_act_ded_bearer_accept : Invalid data buffer ");
 
     BearerContext *bearerCtxt_p = MmeContextManagerUtils::findBearerContext(
             dedBrActProc_p->getBearerId(), ueCtxt_p);
     VERIFY(bearerCtxt_p, dedBrActProc_p->setMmeErrorCause(BEARER_CONTEXT_NOT_FOUND);
-                return ActStatus::ABORT, "Bearer Context is NULL \n");
+                return ActStatus::ABORT, "Bearer Context is NULL ");
 
     if (dedBrAcpt->pco_opt.pco_length > 0)
     {
@@ -174,29 +174,29 @@ ActStatus ActionHandlers::process_act_ded_bearer_accept(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::process_act_ded_bearer_reject(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "process_act_ded_bearer_reject : Entry\n");
+    log_msg(LOG_DEBUG, "process_act_ded_bearer_reject : Entry");
 
     UEContext *ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ueCtxt_p, "Invalid UE\n");
+    VERIFY_UE(cb, ueCtxt_p, "Invalid UE");
 
     SmDedActProcCtxt *dedBrActProc_p =
             dynamic_cast<SmDedActProcCtxt*>(cb.getTempDataBlock());
     VERIFY(dedBrActProc_p, return ActStatus::ABORT,
-            "Ded Bearer Activation Procedure Context is NULL \n");
+            "Ded Bearer Activation Procedure Context is NULL ");
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     VERIFY(msgBuf, dedBrActProc_p->setMmeErrorCause(INVALID_MSG_BUFFER);
-    	return ActStatus::ABORT, "process_act_ded_bearer_reject : Invalid message buffer \n");
+    	return ActStatus::ABORT, "process_act_ded_bearer_reject : Invalid message buffer ");
 
     const dedicatedBearerContextReject_Q_msg_t *dedBrReject =
                 static_cast<const dedicatedBearerContextReject_Q_msg_t*>(msgBuf->getDataPointer());
     VERIFY(dedBrReject, dedBrActProc_p->setMmeErrorCause(INVALID_DATA_BUFFER);
-    	return ActStatus::ABORT, "process_act_ded_bearer_reject : Invalid data buffer \n");
+    	return ActStatus::ABORT, "process_act_ded_bearer_reject : Invalid data buffer ");
 
     BearerContext *bearerCtxt_p = MmeContextManagerUtils::findBearerContext(
             dedBrActProc_p->getBearerId(), ueCtxt_p);
     VERIFY(bearerCtxt_p, dedBrActProc_p->setMmeErrorCause(BEARER_CONTEXT_NOT_FOUND);
-                return ActStatus::ABORT, "Bearer Context is NULL \n");
+                return ActStatus::ABORT, "Bearer Context is NULL ");
 
     dedBrActProc_p->setMmeErrorCause(NAS_ESM_FAILURE_IND);
     dedBrActProc_p->setEsmCause(dedBrReject->esm_cause);
@@ -211,10 +211,10 @@ ActStatus ActionHandlers::process_act_ded_bearer_reject(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::abort_ded_activation(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "abort_ded_activation : Entry\n");
+    log_msg(LOG_DEBUG, "abort_ded_activation : Entry");
 
     UEContext *ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ueCtxt_p, "Invalid UE\n");
+    VERIFY_UE(cb, ueCtxt_p, "Invalid UE");
 
     SmDedActProcCtxt *dedBrActProc_p =
             dynamic_cast<SmDedActProcCtxt*>(cb.getTempDataBlock());
@@ -273,10 +273,10 @@ ActStatus ActionHandlers::abort_ded_activation(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::ded_act_complete(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "ded_act_complete : Entry\n");
+    log_msg(LOG_DEBUG, "ded_act_complete : Entry");
 
     UEContext *ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ueCtxt_p, "Invalid UE\n");
+    VERIFY_UE(cb, ueCtxt_p, "Invalid UE");
 
     SmDedActProcCtxt *dedBrActProc_p =
             dynamic_cast<SmDedActProcCtxt*>(cb.getTempDataBlock());

--- a/src/mme-app/actionHandlers/defaultMmeProcedureActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/defaultMmeProcedureActionHandlers.cpp
@@ -53,7 +53,7 @@ using namespace cmn;
 ***************************************/
 ActStatus ActionHandlers::default_attach_req_handler(ControlBlock& cb)
 {
-	log_msg(LOG_ERROR, "default_attach_req_handler \n");
+	log_msg(LOG_ERROR, "default_attach_req_handler ");
 
 	UEContext* ueCtxt_p = NULL;
 	MmContext* mmCtxt = NULL;
@@ -65,7 +65,7 @@ ActStatus ActionHandlers::default_attach_req_handler(ControlBlock& cb)
 	MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
 	if (msgBuf == NULL)
 	{
-		log_msg(LOG_ERROR, "Failed to retrieve message buffer \n");
+		log_msg(LOG_ERROR, "Failed to retrieve message buffer ");
 
 		// Invalid message. Cannot proceed further.
 		MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
@@ -79,7 +79,7 @@ ActStatus ActionHandlers::default_attach_req_handler(ControlBlock& cb)
 	AttachType attachType = MmeCommonUtils::getAttachType(ueCtxt_p, *ue_info);
 	if (attachType == maxAttachType_c)
 	{
-		log_msg(LOG_ERROR, "Failed to identify attach type \n");
+		log_msg(LOG_ERROR, "Failed to identify attach type ");
 
         MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
 		return ActStatus::HALT;
@@ -90,7 +90,7 @@ ActStatus ActionHandlers::default_attach_req_handler(ControlBlock& cb)
 		ueCtxt_p = SubsDataGroupManager::Instance()->getUEContext();
 		if (ueCtxt_p == NULL)
 		{
-			log_msg(LOG_ERROR, "Failed to allocate UE context \n");
+			log_msg(LOG_ERROR, "Failed to allocate UE context ");
 
 	        MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
 			return ActStatus::HALT;
@@ -99,7 +99,7 @@ ActStatus ActionHandlers::default_attach_req_handler(ControlBlock& cb)
 		mmCtxt = SubsDataGroupManager::Instance()->getMmContext();
 		if( mmCtxt == NULL )
 		{
-			log_msg(LOG_ERROR, "Failed to allocate MM Context \n");
+			log_msg(LOG_ERROR, "Failed to allocate MM Context ");
 
 			MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
 			return ActStatus::HALT;
@@ -117,7 +117,7 @@ ActStatus ActionHandlers::default_attach_req_handler(ControlBlock& cb)
 	MmeAttachProcedureCtxt* prcdCtxt_p = SubsDataGroupManager::Instance()->getMmeAttachProcedureCtxt();
 	if( prcdCtxt_p == NULL )
 	{
-		log_msg(LOG_ERROR, "Failed to allocate Procedure Context \n");
+		log_msg(LOG_ERROR, "Failed to allocate Procedure Context ");
 
 		MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
 		return ActStatus::HALT;
@@ -207,19 +207,19 @@ ActStatus ActionHandlers::default_attach_req_handler(ControlBlock& cb)
 ActStatus ActionHandlers::default_detach_req_handler(ControlBlock& cb)
 {
     MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
-    VERIFY(msgBuf, return ActStatus::PROCEED, "Detach Hdlr: message buffer is NULL \n");
+    VERIFY(msgBuf, return ActStatus::PROCEED, "Detach Hdlr: message buffer is NULL ");
 
     const s1_incoming_msg_header_t* msgData_p =
             static_cast<const s1_incoming_msg_header_t*>(msgBuf->getDataPointer());
-    VERIFY(msgBuf, return ActStatus::PROCEED, "Detach Hdlr: message data buffer is NULL \n");
+    VERIFY(msgBuf, return ActStatus::PROCEED, "Detach Hdlr: message data buffer is NULL ");
 
     UEContext *ueCtxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ueCtxt, "Detach Hdlr: UE Context is NULL \n");
+    VERIFY_UE(cb, ueCtxt, "Detach Hdlr: UE Context is NULL ");
 
     MmeDetachProcedureCtxt* prcdCtxt_p = MmeContextManagerUtils::allocateDetachProcedureCtxt(cb, ueInitDetach_c);
     if( prcdCtxt_p == NULL )
     {
-        log_msg(LOG_ERROR, "Failed to allocate procedure context for detach cbIndex %d\n", cb.getCBIndex());
+        log_msg(LOG_ERROR, "Failed to allocate procedure context for detach cbIndex %d", cb.getCBIndex());
         MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
         return ActStatus::PROCEED;
     }
@@ -244,10 +244,10 @@ ActStatus ActionHandlers::default_ddn_handler(ControlBlock& cb)
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
 
     VERIFY(msgBuf, return ActStatus::PROCEED,
-            "default_ddn_handler: Invalid message buffer \n");
+            "default_ddn_handler: Invalid message buffer ");
 
     VERIFY(msgBuf->getLength() >= sizeof(struct ddn_Q_msg),
-            return ActStatus::PROCEED, "default_ddn_handler: Invalid DDN message length \n");
+            return ActStatus::PROCEED, "default_ddn_handler: Invalid DDN message length ");
 
     const struct ddn_Q_msg *ddn_info =
     		static_cast<const ddn_Q_msg*>(msgBuf->getDataPointer());
@@ -280,21 +280,21 @@ ActStatus ActionHandlers::default_ddn_handler(ControlBlock& cb)
             else
             {
                 log_msg(LOG_INFO,
-                        "default_ddn_handler: Failed to allocate procedure context \n");
+                        "default_ddn_handler: Failed to allocate procedure context ");
                 gtpCause = GTPV2C_CAUSE_REQUEST_REJECTED;
             }
         }
         else
         {
             log_msg(LOG_INFO,
-                    "default_ddn_handler: Failed to find session context \n");
+                    "default_ddn_handler: Failed to find session context ");
             gtpCause = GTPV2C_CAUSE_REQUEST_REJECTED;
         }
     }
     else
     {
         log_msg(LOG_INFO,
-                "default_ddn_handler: Failed to find UE context \n");
+                "default_ddn_handler: Failed to find UE context ");
 
         gtpCause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
 
@@ -327,14 +327,14 @@ ActStatus ActionHandlers::default_ddn_handler(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::default_service_req_handler(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "default_service_req_handler \n");
+    log_msg(LOG_DEBUG, "default_service_req_handler ");
 
     ProcedureStats::num_of_service_request_received++;
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve message buffer \n");
+        log_msg(LOG_ERROR, "Failed to retrieve message buffer ");
         return ActStatus::HALT;
     }
 
@@ -353,7 +353,7 @@ ActStatus ActionHandlers::default_service_req_handler(ControlBlock& cb)
                     MmeContextManagerUtils::allocateServiceRequestProcedureCtxt(cb, none_c);
             if (srvReqProc_p != NULL)
             {
-                log_msg(LOG_ERROR, "Allocated service request procedure context \n");
+                log_msg(LOG_ERROR, "Allocated service request procedure context ");
                 mmCtxt->setEcmState(ecmConnected_c);
                 ueCtxt->setS1apEnbUeId(serviceReq->header.s1ap_enb_ue_id);
 
@@ -362,14 +362,14 @@ ActStatus ActionHandlers::default_service_req_handler(ControlBlock& cb)
             }
             else
             {
-                log_msg(LOG_ERROR, "Failed to allocate procedure context \n");
+                log_msg(LOG_ERROR, "Failed to allocate procedure context ");
 
                 emmCause = emmCause_network_failure;
             }
         }
         else
         {
-            log_msg(LOG_ERROR, "Invalid UE Context in service request handling\n");
+            log_msg(LOG_ERROR, "Invalid UE Context in service request handling");
 
             emmCause = emmCause_ue_id_not_derived_by_network;
             MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
@@ -377,7 +377,7 @@ ActStatus ActionHandlers::default_service_req_handler(ControlBlock& cb)
     }
     else
     {
-        log_msg(LOG_ERROR, "UE Context is NULL in service request handling\n");
+        log_msg(LOG_ERROR, "UE Context is NULL in service request handling");
 
         emmCause = emmCause_ue_id_not_derived_by_network;
         MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
@@ -385,7 +385,7 @@ ActStatus ActionHandlers::default_service_req_handler(ControlBlock& cb)
 
     if (emmCause != 0)
     {
-        log_msg(LOG_INFO, "Send service request reject for enb context %u \n", serviceReq->enb_fd);
+        log_msg(LOG_INFO, "Send service request reject for enb context %u ", serviceReq->enb_fd);
         struct commonRej_info serviceRej =
         {
                 service_reject,
@@ -412,10 +412,10 @@ ActStatus ActionHandlers::default_service_req_handler(ControlBlock& cb)
 ActStatus ActionHandlers::default_cancel_loc_req_handler(ControlBlock& cb)
 {
 	UEContext *ueCtxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ueCtxt, "CLR Hdlr: UE Context is NULL \n");
+	VERIFY_UE(cb, ueCtxt, "CLR Hdlr: UE Context is NULL ");
 
 	MmContext* mmCtxt = ueCtxt->getMmContext();
-    	VERIFY_UE(cb, mmCtxt, "CLR Hdlr: MmContext is NULL \n");
+    	VERIFY_UE(cb, mmCtxt, "CLR Hdlr: MmContext is NULL ");
 	
 	ProcedureStats::num_of_clr_received ++;
 	ProcedureStats::num_of_cla_sent ++;
@@ -423,7 +423,7 @@ ActStatus ActionHandlers::default_cancel_loc_req_handler(ControlBlock& cb)
 	if (mmCtxt->getMmState() == EpsDetached)
 	{
 		log_msg(LOG_INFO, "Subscriber is already detached. "
-				"Cleaning up the contexts. UE IDx %d\n", cb.getCBIndex());
+				"Cleaning up the contexts. UE IDx %d", cb.getCBIndex());
 		
 		MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());		
 		return ActStatus::PROCEED;
@@ -434,7 +434,7 @@ ActStatus ActionHandlers::default_cancel_loc_req_handler(ControlBlock& cb)
 	if(prcdCtxt_p == NULL)
 	{
         	log_msg(LOG_ERROR,
-                	"Failed to allocate procedure context for detach cbIndex %d\n",
+                	"Failed to allocate procedure context for detach cbIndex %d",
                 	cb.getCBIndex());
         	MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
         	return ActStatus::PROCEED;
@@ -456,7 +456,7 @@ ActStatus ActionHandlers::default_s1_release_req_handler(ControlBlock& cb)
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve message buffer \n");
+        log_msg(LOG_ERROR, "Failed to retrieve message buffer ");
 	// Wait for UE to retry.
         return ActStatus::PROCEED;
     }
@@ -465,7 +465,7 @@ ActStatus ActionHandlers::default_s1_release_req_handler(ControlBlock& cb)
             static_cast<s1_incoming_msg_header_t*>(msgBuf->getDataPointer());
     if (msgData_p == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve data buffer \n");
+        log_msg(LOG_ERROR, "Failed to retrieve data buffer ");
 	// Wait for UE to retry.
         return ActStatus::PROCEED;
     }
@@ -473,7 +473,7 @@ ActStatus ActionHandlers::default_s1_release_req_handler(ControlBlock& cb)
     MmeS1RelProcedureCtxt* prcdCtxt_p = SubsDataGroupManager::Instance()->getMmeS1RelProcedureCtxt();
     if( prcdCtxt_p == NULL )
     {
-	log_msg(LOG_ERROR, "Failed to allocate procedure Ctxt \n");
+	log_msg(LOG_ERROR, "Failed to allocate procedure Ctxt ");
 	// Wait for UE to retry.
 	return ActStatus::PROCEED;
     }
@@ -496,14 +496,14 @@ ActStatus ActionHandlers::default_s1_release_req_handler(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::default_tau_req_handler(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "default_tau_req_handler: Entry \n");
+    log_msg(LOG_DEBUG, "default_tau_req_handler: Entry ");
 
     ProcedureStats::num_of_tau_req_received++;
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_DEBUG, "process_tau_req: msgBuf is NULL \n");
+        log_msg(LOG_DEBUG, "process_tau_req: msgBuf is NULL ");
         return ActStatus::HALT;
     }
 
@@ -548,14 +548,14 @@ ActStatus ActionHandlers::default_tau_req_handler(ControlBlock& cb)
             }
             else
             {
-                log_msg(LOG_ERROR, "Failed to allocate procedure context \n");
+                log_msg(LOG_ERROR, "Failed to allocate procedure context ");
 
                 emmCause = emmCause_network_failure;
             }
         }
         else
         {
-            log_msg(LOG_ERROR, "Invalid UE Context \n");
+            log_msg(LOG_ERROR, "Invalid UE Context ");
 
             emmCause = emmCause_ue_id_not_derived_by_network;
             MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
@@ -563,7 +563,7 @@ ActStatus ActionHandlers::default_tau_req_handler(ControlBlock& cb)
     }
     else
     {
-        log_msg(LOG_ERROR, "UE Context is NULL \n");
+        log_msg(LOG_ERROR, "UE Context is NULL ");
 
         emmCause = emmCause_ue_id_not_derived_by_network;
         MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
@@ -599,7 +599,7 @@ ActStatus ActionHandlers::default_s1_ho_handler(ControlBlock& cb)
     MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_DEBUG,"process_handover_required: msgBuf is NULL \n");
+        log_msg(LOG_DEBUG,"process_handover_required: msgBuf is NULL ");
         return ActStatus::HALT;
     }
 
@@ -607,7 +607,7 @@ ActStatus ActionHandlers::default_s1_ho_handler(ControlBlock& cb)
             static_cast<const handover_required_Q_msg_t*>(msgBuf->getDataPointer());
     if (hoReq == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve data buffer \n");
+        log_msg(LOG_ERROR, "Failed to retrieve data buffer ");
         return ActStatus::HALT;
     }
 
@@ -615,14 +615,14 @@ ActStatus ActionHandlers::default_s1_ho_handler(ControlBlock& cb)
 	if (hoReqProc_p == NULL)
 	{
 		log_msg(LOG_ERROR, "Failed to allocate procedure context"
-				" for ho required cbIndex %d\n", cb.getCBIndex());
+				" for ho required cbIndex %d", cb.getCBIndex());
 		return ActStatus::HALT;
 	}
 
 	UEContext *ueCtxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
 	if (ueCtxt == NULL)
 	{
-		log_msg(LOG_DEBUG, "ue context is NULL \n");
+		log_msg(LOG_DEBUG, "ue context is NULL ");
 		return ActStatus::HALT;
 	}
 
@@ -645,14 +645,14 @@ ActStatus ActionHandlers::default_s1_ho_handler(ControlBlock& cb)
 *******************************************************/
 ActStatus ActionHandlers::default_erab_mod_indication_handler(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "default_erab_mod_indication_handler: Entry \n");
+    log_msg(LOG_DEBUG, "default_erab_mod_indication_handler: Entry ");
 
     ProcedureStats::num_of_erab_mod_ind_received++;
 
     UEContext *ueCtxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ueCtxt == NULL)
     {
-        log_msg(LOG_ERROR, "UE Context is NULL \n");
+        log_msg(LOG_ERROR, "UE Context is NULL ");
 
         MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
         return ActStatus::HALT;
@@ -661,14 +661,14 @@ ActStatus ActionHandlers::default_erab_mod_indication_handler(ControlBlock& cb)
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_DEBUG, "process_erab_mod_indication: msgBuf is NULL \n");
+        log_msg(LOG_DEBUG, "process_erab_mod_indication: msgBuf is NULL ");
         return ActStatus::PROCEED;
     }
 
     const erab_mod_ind_Q_msg_t *erabModInd = static_cast<const erab_mod_ind_Q_msg_t*>(msgBuf->getDataPointer());
     if (erabModInd == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve data buffer \n");
+        log_msg(LOG_ERROR, "Failed to retrieve data buffer ");
         return ActStatus::PROCEED;
     }
 
@@ -685,7 +685,7 @@ ActStatus ActionHandlers::default_erab_mod_indication_handler(ControlBlock& cb)
     }
     else
     {
-        log_msg(LOG_INFO, "Failed to allocate procedure context \n");
+        log_msg(LOG_INFO, "Failed to allocate procedure context ");
     }
 
     return ActStatus::PROCEED;
@@ -696,18 +696,18 @@ ActStatus ActionHandlers::default_erab_mod_indication_handler(ControlBlock& cb)
  ***************************************/
 ActStatus ActionHandlers::default_create_bearer_req_handler(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "default_create_bearer_req_handler: Entry \n");
+    log_msg(LOG_DEBUG, "default_create_bearer_req_handler: Entry ");
     ProcedureStats::num_of_create_bearer_req_received++;
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     // Invalid buffer. Nothing to do, wait for gw to retry.
     VERIFY(msgBuf, return ActStatus::PROCEED,
-            "Invalid create bearer request msg buffer\n");
+            "Invalid create bearer request msg buffer");
 
     const cb_req_Q_msg *cb_req =
             static_cast<const cb_req_Q_msg*>(msgBuf->getDataPointer());
     VERIFY(cb_req, return ActStatus::PROCEED,
-            "Invalid create bearer request data\n");
+            "Invalid create bearer request data");
 
     uint8_t gtpCause = 0;
     int sgw_cp_teid = 0;
@@ -754,7 +754,7 @@ ActStatus ActionHandlers::default_create_bearer_req_handler(ControlBlock &cb)
                     else
                     {
                         log_msg(LOG_ERROR,
-                                "Failed to allocate context for paging procedure.\n");
+                                "Failed to allocate context for paging procedure.");
                         gtpCause = GTPV2C_CAUSE_UNABLE_TO_PAGE_UE;
                     }
 
@@ -768,19 +768,19 @@ ActStatus ActionHandlers::default_create_bearer_req_handler(ControlBlock &cb)
             else
             {
                 log_msg(LOG_INFO,
-                        "Failed to allocate context for create bearer procedure.\n");
+                        "Failed to allocate context for create bearer procedure.");
                 gtpCause = GTPV2C_CAUSE_REQUEST_REJECTED;
             }
         }
         else
         {
-            log_msg(LOG_ERROR, "Invalid UE Context. MmContext is NULL \n");
+            log_msg(LOG_ERROR, "Invalid UE Context. MmContext is NULL ");
             gtpCause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
         }
     }
     else
     {
-        log_msg(LOG_ERROR, "UE Context is NULL \n");
+        log_msg(LOG_ERROR, "UE Context is NULL ");
 
         gtpCause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
         MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
@@ -816,7 +816,7 @@ ActStatus ActionHandlers::default_create_bearer_req_handler(ControlBlock &cb)
 ***************************************/
 ActStatus ActionHandlers::handle_paging_failure(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "handle_paging_failure: Entry \n");
+    log_msg(LOG_DEBUG, "handle_paging_failure: Entry ");
 
     ActStatus rc = ActStatus::PROCEED;
 
@@ -844,7 +844,7 @@ ActStatus ActionHandlers::handle_paging_failure(ControlBlock& cb)
         }
     }
 
-    log_msg(LOG_DEBUG, "handle_paging_failure: Exit \n");
+    log_msg(LOG_DEBUG, "handle_paging_failure: Exit ");
 
     return rc;
 }
@@ -854,17 +854,17 @@ ActStatus ActionHandlers::handle_paging_failure(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::default_delete_bearer_req_handler(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "default_delete_bearer_req_handler: Entry \n");
+    log_msg(LOG_DEBUG, "default_delete_bearer_req_handler: Entry ");
 	
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     // Invalid buffer. Nothing to do, wait for gw to retry.
     VERIFY(msgBuf, return ActStatus::PROCEED,
-            "Invalid delete bearer request msg buffer\n");
+            "Invalid delete bearer request msg buffer");
 
     const db_req_Q_msg *db_req =
             static_cast<const db_req_Q_msg*>(msgBuf->getDataPointer());
     VERIFY(db_req, return ActStatus::PROCEED,
-            "Invalid delete bearer request data\n");
+            "Invalid delete bearer request data");
 
     uint8_t gtpCause = 0;
     int sgw_cp_teid = 0;
@@ -912,7 +912,7 @@ ActStatus ActionHandlers::default_delete_bearer_req_handler(ControlBlock& cb)
                     }
                     else if (mmCtxt->getEcmState() == ecmIdle_c)
                     {
-                        log_msg(LOG_DEBUG,"UE is IDLE\n");
+                        log_msg(LOG_DEBUG,"UE is IDLE");
                         if (db_req->linked_bearer_id == 0 && db_req->cause != GTPV2C_CAUSE_REACTIVATION_REQUESTED)
                         {
                             for (int i = 0; i < db_req->eps_bearer_ids_count; i++)
@@ -935,7 +935,7 @@ ActStatus ActionHandlers::default_delete_bearer_req_handler(ControlBlock& cb)
                             // If ECM state is ECM idle, allocate service request and set paging
                             // trigger as pgwInit_c, so that at the end of service request procedure,
                             // DBReq procedure will be informed and can proceed with the ded deactivation.
-                            log_msg(LOG_DEBUG,"In Idle\n");
+                            log_msg(LOG_DEBUG,"In Idle");
                             srvReqProc_p =
                                 MmeContextManagerUtils::allocateServiceRequestProcedureCtxt(
                                         cb, pgwInit_c);
@@ -947,7 +947,7 @@ ActStatus ActionHandlers::default_delete_bearer_req_handler(ControlBlock& cb)
                             else
                             {
                                 log_msg(LOG_ERROR,
-                                    "Failed to allocate context for paging procedure.\n");
+                                    "Failed to allocate context for paging procedure.");
                                 gtpCause = GTPV2C_CAUSE_UNABLE_TO_PAGE_UE;
                             }
                         }
@@ -971,25 +971,25 @@ ActStatus ActionHandlers::default_delete_bearer_req_handler(ControlBlock& cb)
                 else
                 {
                     log_msg(LOG_INFO,
-                            "Failed to allocate context for delete bearer procedure.\n");
+                            "Failed to allocate context for delete bearer procedure.");
                     gtpCause = GTPV2C_CAUSE_REQUEST_REJECTED;
                 }
             }
             else
             {
-                log_msg(LOG_ERROR, "Invalid UE Context. MmContext is NULL \n");
+                log_msg(LOG_ERROR, "Invalid UE Context. MmContext is NULL ");
                 gtpCause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
             }
         }
         else
         {
-            log_msg(LOG_ERROR, "Invalid UE Context. Session Context is NULL \n");
+            log_msg(LOG_ERROR, "Invalid UE Context. Session Context is NULL ");
             gtpCause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
         }
     }
     else
     {
-        log_msg(LOG_ERROR, "UE Context is NULL \n");
+        log_msg(LOG_ERROR, "UE Context is NULL ");
 
         gtpCause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
         MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
@@ -1017,7 +1017,7 @@ ActStatus ActionHandlers::default_delete_bearer_req_handler(ControlBlock& cb)
         		dispatchIpcMsg((char*) &dbRsp, sizeof(dbRsp), destAddr);
     }
 	
-    log_msg(LOG_DEBUG, "default_delete_bearer_req_handler: Exit \n");
+    log_msg(LOG_DEBUG, "default_delete_bearer_req_handler: Exit ");
 	
     return ActStatus::PROCEED;
 }
@@ -1027,7 +1027,7 @@ ActStatus ActionHandlers::default_delete_bearer_req_handler(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::handle_detach_failure(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "handle_detach_failure: Entry \n");
+    log_msg(LOG_DEBUG, "handle_detach_failure: Entry ");
 
     ActStatus rc = ActStatus::PROCEED;
 
@@ -1049,7 +1049,7 @@ ActStatus ActionHandlers::handle_detach_failure(ControlBlock& cb)
             MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
         }
     }
-    log_msg(LOG_DEBUG, "handle_detach_failure: Exit \n");
+    log_msg(LOG_DEBUG, "handle_detach_failure: Exit ");
 
     return rc;
 }

--- a/src/mme-app/actionHandlers/deleteBearerProcedureActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/deleteBearerProcedureActionHandlers.cpp
@@ -47,28 +47,28 @@ using namespace cmn::utils;
  ***************************************/
 ActStatus ActionHandlers::init_ded_bearer_deactivation(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "init_ded_bearer_deactivation : Entry\n");
+    log_msg(LOG_DEBUG, "init_ded_bearer_deactivation : Entry");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeSmDeleteBearerProcCtxt *dbReqProc_p =
             dynamic_cast<MmeSmDeleteBearerProcCtxt*>(cb.getTempDataBlock());
     VERIFY(dbReqProc_p, return ActStatus::ABORT,
-            " Delete Bearer Procedure Context is NULL \n");
+            " Delete Bearer Procedure Context is NULL ");
 
     const cmn::IpcEventMessage *eMsg =
             dynamic_cast<const cmn::IpcEventMessage*>(dbReqProc_p->getDeleteBearerReqEMsgRaw());
     cmn::IpcEventMessage *ipcMsg = const_cast<cmn::IpcEventMessage*>(eMsg);
     VERIFY(ipcMsg, return ActStatus::ABORT,
-            "Invalid IPC Event Message in DBReq Procedure Context \n");
+            "Invalid IPC Event Message in DBReq Procedure Context ");
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(ipcMsg->getMsgBuffer());
-    VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer \n");
+    VERIFY(msgBuf, return ActStatus::ABORT, "Invalid message buffer ");
 
     const db_req_Q_msg *db_req =
             static_cast<const db_req_Q_msg*>(msgBuf->getDataPointer());
-    VERIFY(db_req, return ActStatus::ABORT, "Invalid data buffer \n");
+    VERIFY(db_req, return ActStatus::ABORT, "Invalid data buffer ");
 
     uint8_t bearerDeAllocCount = 0;
     for (int i = 0; i < db_req->eps_bearer_ids_count; i++)
@@ -117,7 +117,7 @@ ActStatus ActionHandlers::init_ded_bearer_deactivation(ControlBlock &cb)
         else
         {
             log_msg(LOG_ERROR,
-                    "Failed to find Bearer Context with bearer id: %d \n",
+                    "Failed to find Bearer Context with bearer id: %d ",
                     db_req->eps_bearer_ids[i]);
 
             brCtxtDbResp.cause.cause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
@@ -136,7 +136,7 @@ ActStatus ActionHandlers::init_ded_bearer_deactivation(ControlBlock &cb)
         actStatus = ABORT;
     }
 
-    log_msg(LOG_DEBUG, "init_ded_bearer_deactivation : Exit\n");
+    log_msg(LOG_DEBUG, "init_ded_bearer_deactivation : Exit");
     return actStatus;
 }
 
@@ -161,7 +161,7 @@ ActStatus ActionHandlers::init_ue_detach_procedure(ControlBlock &cb)
     }
     else
     {
-        log_msg(LOG_DEBUG, "Detach Procedure Context is NULL \n");
+        log_msg(LOG_DEBUG, "Detach Procedure Context is NULL ");
         SM::Event evt(DETACH_FAILURE, NULL);
         cb.qInternalEvent(evt);
     }
@@ -174,7 +174,7 @@ ActStatus ActionHandlers::init_ue_detach_procedure(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::send_delete_bearer_response(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "send_delete_bearer_response : Entry\n");
+    log_msg(LOG_DEBUG, "send_delete_bearer_response : Entry");
 
     MmeSmDeleteBearerProcCtxt *dbReqProc_p =
             dynamic_cast<MmeSmDeleteBearerProcCtxt*>(cb.getTempDataBlock());
@@ -199,7 +199,7 @@ ActStatus ActionHandlers::send_delete_bearer_response(ControlBlock &cb)
         }
     }
 
-    log_msg(LOG_DEBUG, "send_delete_bearer_response : Exit\n");
+    log_msg(LOG_DEBUG, "send_delete_bearer_response : Exit");
     return ActStatus::PROCEED;
 }
 
@@ -208,10 +208,10 @@ ActStatus ActionHandlers::send_delete_bearer_response(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::abort_delete_bearer_procedure(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "abort_delete_bearer_procedure : Entry\n");
+    log_msg(LOG_DEBUG, "abort_delete_bearer_procedure : Entry");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeSmDeleteBearerProcCtxt *dbReqProc_p =
             dynamic_cast<MmeSmDeleteBearerProcCtxt*>(cb.getTempDataBlock());
@@ -264,7 +264,7 @@ ActStatus ActionHandlers::abort_delete_bearer_procedure(ControlBlock &cb)
                 mmeStatsCounter::MME_PROCEDURES_DELETE_BEARER_PROC_FAILURE);
     }
 
-    log_msg(LOG_DEBUG, "abort_delete_bearer_procedure : Exit\n");
+    log_msg(LOG_DEBUG, "abort_delete_bearer_procedure : Exit");
     return ActStatus::PROCEED;
 }
 
@@ -273,10 +273,10 @@ ActStatus ActionHandlers::abort_delete_bearer_procedure(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::check_and_init_deactivation(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "check_and_init_deactivation : Entry\n");
+    log_msg(LOG_DEBUG, "check_and_init_deactivation : Entry");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeSmDeleteBearerProcCtxt *dbReqProc_p =
             dynamic_cast<MmeSmDeleteBearerProcCtxt*>(cb.getTempDataBlock());
@@ -289,7 +289,7 @@ ActStatus ActionHandlers::check_and_init_deactivation(ControlBlock &cb)
                             dbReqProc_p->getBearerId());
             VERIFY(sessionCtxt,
                     dbReqProc_p->setMmeErrorCause(SESSION_CONTEXT_NOT_FOUND); return ActStatus::ABORT,
-                    "Session Context is NULL \n");
+                    "Session Context is NULL ");
             if (ue_ctxt->getSessionContextContainer().size() == 1)
             {
                 SM::Event evt(START_UE_DETACH, NULL);
@@ -303,7 +303,7 @@ ActStatus ActionHandlers::check_and_init_deactivation(ControlBlock &cb)
         }
     }
 
-    log_msg(LOG_DEBUG, "check_and_init_deactivation : Exit\n");
+    log_msg(LOG_DEBUG, "check_and_init_deactivation : Exit");
     return ActStatus::PROCEED;
 }
 
@@ -312,12 +312,12 @@ ActStatus ActionHandlers::check_and_init_deactivation(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::handle_ded_deact_cmp_ind(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "handle_ded_deact_cmp_ind : Entry\n");
+    log_msg(LOG_DEBUG, "handle_ded_deact_cmp_ind : Entry");
 
     MmeSmDeleteBearerProcCtxt *dbReqProc_p =
             dynamic_cast<MmeSmDeleteBearerProcCtxt*>(cb.getTempDataBlock());
     VERIFY(dbReqProc_p, return ActStatus::ABORT,
-            "Delete Bearer Procedure Context is NULL \n");
+            "Delete Bearer Procedure Context is NULL ");
 
     ActStatus actStatus = ActStatus::PROCEED;
 
@@ -350,7 +350,7 @@ ActStatus ActionHandlers::handle_ded_deact_cmp_ind(ControlBlock &cb)
         }
     }
 
-    log_msg(LOG_DEBUG, "handle_ded_deact_cmp_ind : Exit\n");
+    log_msg(LOG_DEBUG, "handle_ded_deact_cmp_ind : Exit");
     return actStatus;
 }
 
@@ -359,7 +359,7 @@ ActStatus ActionHandlers::handle_ded_deact_cmp_ind(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::delete_bearer_proc_complete(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "delete_bearer_proc_complete : Entry\n");
+    log_msg(LOG_DEBUG, "delete_bearer_proc_complete : Entry");
 
     UEContext *ueCtxt_p = static_cast<UEContext*>(cb.getPermDataBlock());
     if(ueCtxt_p != NULL)
@@ -384,7 +384,7 @@ ActStatus ActionHandlers::delete_bearer_proc_complete(ControlBlock &cb)
         }
     }
 
-    log_msg(LOG_DEBUG, "delete_bearer_proc_complete : Exit\n");
+    log_msg(LOG_DEBUG, "delete_bearer_proc_complete : Exit");
     return ActStatus::PROCEED;
 }
 

--- a/src/mme-app/actionHandlers/erabModIndicationActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/erabModIndicationActionHandlers.cpp
@@ -42,12 +42,12 @@ using namespace cmn::utils;
  ***************************************/
 ActStatus ActionHandlers::send_erab_mod_conf_to_enb(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_erab_mod_conf_to_enb \n");
+    log_msg(LOG_DEBUG, "Inside send_erab_mod_conf_to_enb ");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ue_ctxt == NULL)
     {
-        log_msg(LOG_INFO, "send_erab_mod_conf_to_enb: ue context is NULL \n");
+        log_msg(LOG_INFO, "send_erab_mod_conf_to_enb: ue context is NULL ");
 
         MmeContextManagerUtils::deleteUEContext(cb.getCBIndex());
         return ActStatus::HALT;
@@ -87,11 +87,11 @@ ActStatus ActionHandlers::send_erab_mod_conf_to_enb(ControlBlock &cb)
     }
     else
     {
-        log_msg(LOG_INFO, "Procedure Context is NULL \n");
+        log_msg(LOG_INFO, "Procedure Context is NULL ");
         actStatus = ActStatus::HALT;
     }
 
-    log_msg(LOG_DEBUG, "Leaving send_erab_mod_conf_to_enb \n");
+    log_msg(LOG_DEBUG, "Leaving send_erab_mod_conf_to_enb ");
 
     return actStatus;
 }
@@ -101,7 +101,7 @@ ActStatus ActionHandlers::send_erab_mod_conf_to_enb(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::erab_mod_ind_complete(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside erab_mod_ind_complete\n");
+    log_msg(LOG_DEBUG, "Inside erab_mod_ind_complete");
 
     mmeStats::Instance()->increment(mmeStatsCounter::MME_PROCEDURES_ERAB_MOD_IND_PROC_SUCCESS);
 
@@ -117,7 +117,7 @@ ActStatus ActionHandlers::erab_mod_ind_complete(ControlBlock &cb)
 ActStatus ActionHandlers::handle_state_guard_timeouts_for_erab_mod_ind(
         ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside handle_state_guard_timeout_erab_mod_ind_proc \n");
+    log_msg(LOG_DEBUG, "Inside handle_state_guard_timeout_erab_mod_ind_proc ");
 
     ActStatus actStatus = ActStatus::PROCEED;
 
@@ -132,7 +132,7 @@ ActStatus ActionHandlers::handle_state_guard_timeouts_for_erab_mod_ind(
     {
         log_msg(LOG_DEBUG,
                 "State Guard Timer Expiry for ERAB MOD IND: "
-                "Procedure context is NULL\n");
+                "Procedure context is NULL");
         actStatus = ActStatus::HALT;
     }
 
@@ -144,7 +144,7 @@ ActStatus ActionHandlers::handle_state_guard_timeouts_for_erab_mod_ind(
  ***********************************************/
 ActStatus ActionHandlers::abort_erab_mod_indication(SM::ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside abort_erab_mod_indication \n");
+    log_msg(LOG_DEBUG, "Inside abort_erab_mod_indication ");
 
     ActStatus actStatus = ActStatus::PROCEED;
 
@@ -169,7 +169,7 @@ ActStatus ActionHandlers::abort_erab_mod_indication(SM::ControlBlock &cb)
     else
     {
         log_msg(LOG_ERROR, "Failed to allocate Detach procedure context"
-                " for abort_erab_mod_indication cbIndex %d\n", cb.getCBIndex());
+                " for abort_erab_mod_indication cbIndex %d", cb.getCBIndex());
         actStatus = ActStatus::HALT;
     }
 

--- a/src/mme-app/actionHandlers/networkInitDetachActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/networkInitDetachActionHandlers.cpp
@@ -34,13 +34,13 @@ using namespace cmn::utils;
 
 ActStatus ActionHandlers::ni_detach_req_to_ue(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside ni_detach_req_to_ue \n");
+	log_msg(LOG_DEBUG, "Inside ni_detach_req_to_ue ");
 	
 	UEContext *ue_ctxt =  dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	MmeDetachProcedureCtxt *procCtxt =  dynamic_cast<MmeDetachProcedureCtxt*>(cb.getTempDataBlock());
-	VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+	VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
 	ni_detach_request_Q_msg ni_detach_req;
 	
@@ -88,10 +88,10 @@ ActStatus ActionHandlers::ni_detach_req_to_ue(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::process_detach_accept_from_ue(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside process_detach_accept_from_ue \n");
+	log_msg(LOG_DEBUG, "Inside process_detach_accept_from_ue ");
 		
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 		
 	//ue_ctxt->getUeSecInfo().increment_uplink_count();
 
@@ -105,10 +105,10 @@ ActStatus ActionHandlers::process_detach_accept_from_ue(SM::ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::send_s1_rel_cmd_to_ue_for_detach(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_s1_rel_cmd_to_ue_for_detach\n");
+    log_msg(LOG_DEBUG, "Inside send_s1_rel_cmd_to_ue_for_detach");
 
     UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     struct s1relcmd_info s1relcmd;
 
@@ -136,15 +136,15 @@ ActStatus ActionHandlers::send_s1_rel_cmd_to_ue_for_detach(ControlBlock& cb)
 **************************************************************/
 ActStatus ActionHandlers::process_ue_ctxt_rel_comp_for_detach(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside process_ue_ctxt_rel_comp_for_detach \n");
+    log_msg(LOG_DEBUG, "Inside process_ue_ctxt_rel_comp_for_detach ");
 
     UEContext *ueCtxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ueCtxt, "Invalid UE\n");
+    VERIFY_UE(cb, ueCtxt, "Invalid UE");
     MmeDetachProcedureCtxt *procCtxt = dynamic_cast<MmeDetachProcedureCtxt*>(cb.getTempDataBlock());
-    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
     MmContext* mmCtxt = ueCtxt->getMmContext();
-    VERIFY_UE(cb, mmCtxt, "Invalid UE\n");
+    VERIFY_UE(cb, mmCtxt, "Invalid UE");
 
     if(procCtxt->getCancellationType() == SUBSCRIPTION_WITHDRAWAL)
     {

--- a/src/mme-app/actionHandlers/s1HandoverActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/s1HandoverActionHandlers.cpp
@@ -48,14 +48,14 @@ using namespace SM;
  ***************************************/
 ActStatus ActionHandlers::send_ho_request_to_target_enb(ControlBlock &cb)
 {
-    log_msg(LOG_INFO, "Inside send_ho_request_to_target_enb\n");
+    log_msg(LOG_INFO, "Inside send_ho_request_to_target_enb");
 
     UEContext *ueCtxt = static_cast<UEContext*>(cb.getPermDataBlock());
 
     if (ueCtxt == NULL)
     {
         log_msg(LOG_DEBUG,
-                "send_ho_request_to_target_enb: ue context is NULL\n");
+                "send_ho_request_to_target_enb: ue context is NULL");
         return ActStatus::HALT;
     }
 
@@ -64,7 +64,7 @@ ActStatus ActionHandlers::send_ho_request_to_target_enb(ControlBlock &cb)
     if (hoProcCtxt == NULL)
     {
         log_msg(LOG_DEBUG,
-                "send_ho_request_to_target_enb: MmeS1HandoverProcedureCtxt is NULL\n");
+                "send_ho_request_to_target_enb: MmeS1HandoverProcedureCtxt is NULL");
         return ActStatus::HALT;
     }
 
@@ -79,7 +79,7 @@ ActStatus ActionHandlers::send_ho_request_to_target_enb(ControlBlock &cb)
     MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));
     mmeIpcIf.dispatchIpcMsg((char *) &hoReq, sizeof(hoReq), destAddr);
 
-    log_msg(LOG_DEBUG, "Leaving send_ho_request_to_target_enb \n");
+    log_msg(LOG_DEBUG, "Leaving send_ho_request_to_target_enb ");
 
     ProcedureStats::num_of_ho_request_to_target_enb_sent++;
     return ActStatus::PROCEED;
@@ -90,12 +90,12 @@ ActStatus ActionHandlers::send_ho_request_to_target_enb(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::process_ho_request_ack(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside process_ho_request_ack\n");
+    log_msg(LOG_DEBUG, "Inside process_ho_request_ack");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ue_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "process_ho_request_ack: ue ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "process_ho_request_ack: ue ctxt is NULL ");
         return ActStatus::HALT;
     }
 
@@ -103,14 +103,14 @@ ActStatus ActionHandlers::process_ho_request_ack(ControlBlock &cb)
             dynamic_cast<S1HandoverProcedureContext*>(cb.getTempDataBlock());
     if (ho_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "process_ho_request_ack: procedure ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "process_ho_request_ack: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve message buffer \n");
+        log_msg(LOG_ERROR, "Failed to retrieve message buffer ");
         return ActStatus::HALT;
     }
 
@@ -135,7 +135,7 @@ ActStatus ActionHandlers::process_ho_request_ack(ControlBlock &cb)
 
     ProcedureStats::num_of_ho_request_ack_received++;
 
-    log_msg(LOG_DEBUG, "Leaving process_ho_request_ack\n");
+    log_msg(LOG_DEBUG, "Leaving process_ho_request_ack");
     return ActStatus::PROCEED;
 }
 
@@ -144,12 +144,12 @@ ActStatus ActionHandlers::process_ho_request_ack(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::send_ho_command_to_src_enb(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_ho_command_to_src_enb\n");
+    log_msg(LOG_DEBUG, "Inside send_ho_command_to_src_enb");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ue_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "send_ho_command_to_src_enb: ue ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "send_ho_command_to_src_enb: ue ctxt is NULL ");
         return ActStatus::HALT;
     }
 
@@ -158,7 +158,7 @@ ActStatus ActionHandlers::send_ho_command_to_src_enb(ControlBlock &cb)
     if (ho_ctxt == NULL)
     {
         log_msg(LOG_DEBUG,
-                "send_ho_command_to_src_enb: procedure ctxt is NULL \n");
+                "send_ho_command_to_src_enb: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
 
@@ -173,7 +173,7 @@ ActStatus ActionHandlers::send_ho_command_to_src_enb(ControlBlock &cb)
     mmeIpcIf.dispatchIpcMsg((char *) &ho_command, sizeof(ho_command), destAddr);
 
     ProcedureStats::num_of_ho_command_to_src_enb_sent++;
-    log_msg(LOG_DEBUG, "Leaving send_ho_command_to_src_enb\n");
+    log_msg(LOG_DEBUG, "Leaving send_ho_command_to_src_enb");
 
     return ActStatus::PROCEED;
 }
@@ -183,11 +183,11 @@ ActStatus ActionHandlers::send_ho_command_to_src_enb(ControlBlock &cb)
 ***************************************/
 ActStatus ActionHandlers::send_mme_status_tranfer_to_target_enb(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_mme_status_tranfer_to_target_enb\n");
+    log_msg(LOG_DEBUG, "Inside send_mme_status_tranfer_to_target_enb");
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ue_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "send_mme_status_tranfer_to_target_enb: ue ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "send_mme_status_tranfer_to_target_enb: ue ctxt is NULL ");
         return ActStatus::HALT;
     }
 
@@ -195,14 +195,14 @@ ActStatus ActionHandlers::send_mme_status_tranfer_to_target_enb(ControlBlock& cb
             dynamic_cast<S1HandoverProcedureContext*>(cb.getTempDataBlock());
     if (ho_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "send_mme_status_tranfer_to_target_enb: procedure ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "send_mme_status_tranfer_to_target_enb: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve message buffer \n");
+        log_msg(LOG_ERROR, "Failed to retrieve message buffer ");
         return ActStatus::HALT;
     }
 
@@ -233,11 +233,11 @@ ActStatus ActionHandlers::send_mme_status_tranfer_to_target_enb(ControlBlock& cb
  ***************************************/
 ActStatus ActionHandlers::process_ho_notify(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside process_ho_notify\n");
+    log_msg(LOG_DEBUG, "Inside process_ho_notify");
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ue_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "process_ho_notify: ue ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "process_ho_notify: ue ctxt is NULL ");
         return ActStatus::HALT;
     }
 
@@ -245,14 +245,14 @@ ActStatus ActionHandlers::process_ho_notify(ControlBlock &cb)
             dynamic_cast<S1HandoverProcedureContext*>(cb.getTempDataBlock());
     if (ho_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "process_ho_notify: procedure ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "process_ho_notify: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve message buffer \n");
+        log_msg(LOG_ERROR, "Failed to retrieve message buffer ");
         return ActStatus::HALT;
     }
 
@@ -272,7 +272,7 @@ ActStatus ActionHandlers::process_ho_notify(ControlBlock &cb)
     ho_ctxt->setTargetCgi(Cgi(ho_notify->utran_cgi));
 
     ProcedureStats::num_of_ho_notify_received++;
-    log_msg(LOG_DEBUG, "Leaving process_ho_notify\n");
+    log_msg(LOG_DEBUG, "Leaving process_ho_notify");
 
     return ActStatus::PROCEED;
 }
@@ -282,13 +282,13 @@ ActStatus ActionHandlers::process_ho_notify(ControlBlock &cb)
  ********************************************/
 ActStatus ActionHandlers::send_mb_req_to_sgw_for_ho(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_mb_req_to_sgw_for_ho \n");
+    log_msg(LOG_DEBUG, "Inside send_mb_req_to_sgw_for_ho ");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ue_ctxt == NULL)
     {
         log_msg(LOG_DEBUG,
-                "send_mb_req_to_sgw_for_ho: ue context or procedure ctxt is NULL \n");
+                "send_mb_req_to_sgw_for_ho: ue context or procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
 
@@ -296,13 +296,13 @@ ActStatus ActionHandlers::send_mb_req_to_sgw_for_ho(ControlBlock &cb)
             dynamic_cast<S1HandoverProcedureContext*>(cb.getTempDataBlock());
     if (ho_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "process_ho_notify: procedure ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "process_ho_notify: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
     auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
     if(sessionCtxtContainer.size() < 1)
     {
-	log_msg(LOG_DEBUG, "send_mb_req_to_sgw_for_ho:Session context list empty\n");
+	log_msg(LOG_DEBUG, "send_mb_req_to_sgw_for_ho:Session context list empty");
 	return ActStatus::HALT;
     }
 
@@ -319,7 +319,7 @@ ActStatus ActionHandlers::send_mb_req_to_sgw_for_ho(ControlBlock &cb)
     mmeIpcIf.dispatchIpcMsg((char *) &mb_msg, sizeof(mb_msg), destAddr);
 
     ProcedureStats::num_of_mb_req_to_sgw_sent++;
-    log_msg(LOG_DEBUG, "Leaving send_mb_req_to_sgw_for_ho \n");
+    log_msg(LOG_DEBUG, "Leaving send_mb_req_to_sgw_for_ho ");
     return ActStatus::PROCEED;
 }
 
@@ -328,7 +328,7 @@ ActStatus ActionHandlers::send_mb_req_to_sgw_for_ho(ControlBlock &cb)
 ***************************************/
 ActStatus ActionHandlers::process_mb_resp_for_ho(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside process_mb_resp_for_ho \n");
+    log_msg(LOG_DEBUG, "Inside process_mb_resp_for_ho ");
 
     ProcedureStats::num_of_processed_mb_resp ++;
     return ActStatus::PROCEED;
@@ -339,11 +339,11 @@ ActStatus ActionHandlers::process_mb_resp_for_ho(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::send_s1_rel_cmd_to_src_enb_for_ho(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_s1_rel_cmd_to_ue_for_ho\n");
+    log_msg(LOG_DEBUG, "Inside send_s1_rel_cmd_to_ue_for_ho");
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if(ue_ctxt == NULL)
     {
-    	log_msg(LOG_DEBUG, "send_s1_rel_cmd_to_ue_for_ho: ue context is NULL \n");
+    	log_msg(LOG_DEBUG, "send_s1_rel_cmd_to_ue_for_ho: ue context is NULL ");
     	return ActStatus::HALT;
     }
 
@@ -351,7 +351,7 @@ ActStatus ActionHandlers::send_s1_rel_cmd_to_src_enb_for_ho(ControlBlock& cb)
             dynamic_cast<S1HandoverProcedureContext*>(cb.getTempDataBlock());
     if (ho_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "send_s1_rel_cmd_to_ue_for_ho: procedure ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "send_s1_rel_cmd_to_ue_for_ho: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
     struct s1relcmd_info s1relcmd;
@@ -371,7 +371,7 @@ ActStatus ActionHandlers::send_s1_rel_cmd_to_src_enb_for_ho(ControlBlock& cb)
     mmeIpcIf.dispatchIpcMsg((char *) &s1relcmd, sizeof(s1relcmd), destAddr);
 
     ProcedureStats::num_of_s1_rel_cmd_sent ++;
-    log_msg(LOG_DEBUG,"Leaving send_s1ap_ue_ctxt_rel_command_to_src_enb \n");
+    log_msg(LOG_DEBUG,"Leaving send_s1ap_ue_ctxt_rel_command_to_src_enb ");
     return ActStatus::PROCEED;
 }
 
@@ -380,12 +380,12 @@ ActStatus ActionHandlers::send_s1_rel_cmd_to_src_enb_for_ho(ControlBlock& cb)
  ***************************************/
 ActStatus ActionHandlers::process_tau_request(ControlBlock& cb)
 {
-    log_msg(LOG_INFO, "Inside process_tau_request\n");
+    log_msg(LOG_INFO, "Inside process_tau_request");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ue_ctxt == NULL)
     {
-        log_msg(LOG_ERROR, "process_tau_request: ue context is NULL\n",
+        log_msg(LOG_ERROR, "process_tau_request: ue context is NULL",
                 cb.getCBIndex());
         return ActStatus::HALT;
     }
@@ -395,14 +395,14 @@ ActStatus ActionHandlers::process_tau_request(ControlBlock& cb)
     if (s1HoPrCtxt == NULL)
     {
         log_msg(LOG_DEBUG,
-                "process_tau_request: S1HandoverProcedureContext is NULL\n");
+                "process_tau_request: S1HandoverProcedureContext is NULL");
         return ActStatus::HALT;
     }
 
     MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_DEBUG, "process_tau_req: msgBuf is NULL \n");
+        log_msg(LOG_DEBUG, "process_tau_req: msgBuf is NULL ");
         return ActStatus::HALT;
     }
 
@@ -434,7 +434,7 @@ ActStatus ActionHandlers::process_tau_request(ControlBlock& cb)
  ***************************************/
 ActStatus ActionHandlers::ho_complete(ControlBlock &cb)
 {
-    log_msg(LOG_INFO, "Inside ho_complete\n");
+    log_msg(LOG_INFO, "Inside ho_complete");
 
     ProcedureStats::num_of_ho_complete++;
 
@@ -451,11 +451,11 @@ ActStatus ActionHandlers::ho_complete(ControlBlock &cb)
 ***************************************/
 ActStatus ActionHandlers::is_tau_required(ControlBlock& cb)
 {
-    log_msg(LOG_INFO, "Inside is_tau_required\n");
+    log_msg(LOG_INFO, "Inside is_tau_required");
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ue_ctxt == NULL)
     {
-        log_msg(LOG_ERROR, "is_tau_required: ue context is NULL\n",
+        log_msg(LOG_ERROR, "is_tau_required: ue context is NULL",
                 cb.getCBIndex());
         return ActStatus::HALT;
     }
@@ -465,19 +465,19 @@ ActStatus ActionHandlers::is_tau_required(ControlBlock& cb)
     if (s1HoPrcdCtxt_p == NULL)
     {
         log_msg(LOG_DEBUG,
-                "is_tau_required: S1HandoverProcedureContext is NULL\n");
+                "is_tau_required: S1HandoverProcedureContext is NULL");
         return ActStatus::HALT;
     }
 
     if (ue_ctxt->getTai() == s1HoPrcdCtxt_p->getTargetTai())
     {
-        log_msg(LOG_DEBUG, "TAI is same, TAU not Required\n");
+        log_msg(LOG_DEBUG, "TAI is same, TAU not Required");
         SM::Event evt(TAU_NOT_REQUIRED, NULL);
         cb.qInternalEvent(evt);
     }
     else
     {
-        log_msg(LOG_DEBUG, "TAI is not same, TAU Required\n");
+        log_msg(LOG_DEBUG, "TAI is not same, TAU Required");
         SM::Event evt(TAU_REQUIRED, NULL);
         cb.qInternalEvent(evt);
     }
@@ -494,14 +494,14 @@ ActStatus ActionHandlers::process_ho_failure(ControlBlock &cb)
             dynamic_cast<S1HandoverProcedureContext*>(cb.getTempDataBlock());
     if (ho_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "process_ho_failure: procedure ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "process_ho_failure: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve message buffer \n");
+        log_msg(LOG_ERROR, "Failed to retrieve message buffer ");
         return ActStatus::HALT;
     }
 
@@ -510,7 +510,7 @@ ActStatus ActionHandlers::process_ho_failure(ControlBlock &cb)
 
     ProcedureStats::num_of_ho_failure_received++;
 
-    log_msg(LOG_INFO, "Leaving process_ho_failure\n");
+    log_msg(LOG_INFO, "Leaving process_ho_failure");
     return ActStatus::PROCEED;
 }
 
@@ -519,13 +519,13 @@ ActStatus ActionHandlers::process_ho_failure(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::send_ho_prep_failure_to_src_enb(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_ho_prep_failure_to_src_enb\n");
+    log_msg(LOG_DEBUG, "Inside send_ho_prep_failure_to_src_enb");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ue_ctxt == NULL)
     {
         log_msg(LOG_DEBUG,
-                "send_ho_prep_failure_to_src_enb: ue ctxt is NULL \n");
+                "send_ho_prep_failure_to_src_enb: ue ctxt is NULL ");
         return ActStatus::HALT;
     }
 
@@ -534,7 +534,7 @@ ActStatus ActionHandlers::send_ho_prep_failure_to_src_enb(ControlBlock &cb)
     if (ho_ctxt == NULL)
     {
         log_msg(LOG_DEBUG,
-                "send_ho_prep_failure_to_src_enb: procedure ctxt is NULL \n");
+                "send_ho_prep_failure_to_src_enb: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
 
@@ -553,7 +553,7 @@ ActStatus ActionHandlers::send_ho_prep_failure_to_src_enb(ControlBlock &cb)
     MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
     mmeIpcIf.dispatchIpcMsg((char *) &ho_prep_failure, sizeof(ho_prep_failure), destAddr);
     ProcedureStats::num_of_ho_prep_failure_sent++;
-    log_msg(LOG_DEBUG, "Leaving send_ho_prep_failure_to_src_enb\n");
+    log_msg(LOG_DEBUG, "Leaving send_ho_prep_failure_to_src_enb");
 
     return ActStatus::PROCEED;
 }
@@ -581,7 +581,7 @@ ActStatus ActionHandlers::send_s1_rel_cmd_to_target_enb(ControlBlock &cb)
     if (ue_ctxt == NULL)
     {
         log_msg(LOG_DEBUG,
-                "send_s1_rel_cmd_to_target_enb: ue context is NULL \n");
+                "send_s1_rel_cmd_to_target_enb: ue context is NULL ");
         return ActStatus::HALT;
     }
 
@@ -590,11 +590,11 @@ ActStatus ActionHandlers::send_s1_rel_cmd_to_target_enb(ControlBlock &cb)
     if (ho_ctxt == NULL)
     {
         log_msg(LOG_DEBUG,
-                "send_s1_rel_cmd_to_target_enb: procedure ctxt is NULL \n");
+                "send_s1_rel_cmd_to_target_enb: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
    
-    log_msg(LOG_DEBUG, "Inside send_s1_rel_cmd_to_target_enb %u \n",ue_ctxt->getContextID());
+    log_msg(LOG_DEBUG, "Inside send_s1_rel_cmd_to_target_enb %u ",ue_ctxt->getContextID());
     struct s1relcmd_info s1relcmd;
     s1relcmd.msg_type = s1_release_command;
     s1relcmd.ue_idx = ue_ctxt->getContextID();
@@ -612,7 +612,7 @@ ActStatus ActionHandlers::send_s1_rel_cmd_to_target_enb(ControlBlock &cb)
     mmeIpcIf.dispatchIpcMsg((char *) &s1relcmd, sizeof(s1relcmd), destAddr);
 
     ProcedureStats::num_of_s1_rel_cmd_sent++;
-    log_msg(LOG_DEBUG, "Leaving send_s1_rel_cmd_to_target_enb \n");
+    log_msg(LOG_DEBUG, "Leaving send_s1_rel_cmd_to_target_enb ");
     return ActStatus::PROCEED;
 }
 
@@ -625,14 +625,14 @@ ActStatus ActionHandlers::process_ho_cancel_req(ControlBlock &cb)
             dynamic_cast<S1HandoverProcedureContext*>(cb.getTempDataBlock());
     if (ho_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "process_ho_cancel_req: procedure ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "process_ho_cancel_req: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     if (msgBuf == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve message buffer \n");
+        log_msg(LOG_ERROR, "Failed to retrieve message buffer ");
         return ActStatus::HALT;
     }
 
@@ -641,7 +641,7 @@ ActStatus ActionHandlers::process_ho_cancel_req(ControlBlock &cb)
 
     ProcedureStats::num_of_ho_cancel_received++;
 
-    log_msg(LOG_INFO, "Leaving process_ho_cancel_req\n");
+    log_msg(LOG_INFO, "Leaving process_ho_cancel_req");
     return ActStatus::PROCEED;
 }
 
@@ -650,12 +650,12 @@ ActStatus ActionHandlers::process_ho_cancel_req(ControlBlock &cb)
  ***************************************/
 ActStatus ActionHandlers::send_ho_cancel_ack_to_src_enb(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_ho_cancel_ack_to_src_enb\n");
+    log_msg(LOG_DEBUG, "Inside send_ho_cancel_ack_to_src_enb");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
     if (ue_ctxt == NULL)
     {
-        log_msg(LOG_DEBUG, "send_ho_cancel_ack_to_src_enb: ue ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "send_ho_cancel_ack_to_src_enb: ue ctxt is NULL ");
         return ActStatus::HALT;
     }
 
@@ -664,7 +664,7 @@ ActStatus ActionHandlers::send_ho_cancel_ack_to_src_enb(ControlBlock &cb)
     if (ho_ctxt == NULL)
     {
         log_msg(LOG_DEBUG,
-                "send_ho_cancel_ack_to_src_enb: procedure ctxt is NULL \n");
+                "send_ho_cancel_ack_to_src_enb: procedure ctxt is NULL ");
         return ActStatus::HALT;
     }
 
@@ -682,7 +682,7 @@ ActStatus ActionHandlers::send_ho_cancel_ack_to_src_enb(ControlBlock &cb)
     MmeIpcInterface &mmeIpcIf = static_cast<MmeIpcInterface&>(compDb.getComponent(MmeIpcInterfaceCompId));   
     mmeIpcIf.dispatchIpcMsg((char *) &ho_cancel_ack, sizeof(ho_cancel_ack), destAddr);
     ProcedureStats::num_of_ho_cancel_ack_sent++;
-    log_msg(LOG_DEBUG, "Leaving send_ho_cancel_ack_to_src_enb\n");
+    log_msg(LOG_DEBUG, "Leaving send_ho_cancel_ack_to_src_enb");
 
     return ActStatus::PROCEED;
 }

--- a/src/mme-app/actionHandlers/s1ReleaseActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/s1ReleaseActionHandlers.cpp
@@ -43,34 +43,35 @@ using namespace cmn::utils;
 
 ActStatus ActionHandlers:: send_rel_ab_req_to_sgw(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside send_rel_ab_req_to_sgw \n");
+	log_msg(LOG_DEBUG, "Inside send_rel_ab_req_to_sgw ");
 
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	
     	MmeS1RelProcedureCtxt *procCtxt = dynamic_cast<MmeS1RelProcedureCtxt*>(cb.getTempDataBlock());
-    	VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+    	VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
 	auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
 	VERIFY(sessionCtxtContainer.size() > 0,
 	        procCtxt->setMmeErrorCause(SESSION_CONTAINER_EMPTY); return ActStatus::ABORT,
-	        "Sessions Container is empty\n");
+	        "Sessions Container is empty");
 
 	SessionContext* sessionCtxt = sessionCtxtContainer.front();
     	VERIFY(sessionCtxt,
             procCtxt->setMmeErrorCause(SESSION_CONTEXT_NOT_FOUND); return ActStatus::ABORT,
-            "Sessions Context is NULL\n");
+            "Sessions Context is NULL");
 
 	BearerContext* bearerCtxt = sessionCtxt->findBearerContextByBearerId(sessionCtxt->getLinkedBearerId());
 	VERIFY(bearerCtxt,
 	        procCtxt->setMmeErrorCause(BEARER_CONTEXT_NOT_FOUND);return ActStatus::ABORT,
-	          "Bearer Context is NULL \n");
+	          "Bearer Context is NULL ");
 
-    	if(ue_ctxt->getS1apEnbUeId() != procCtxt->getS1apEnbUeId())
-    	{
-        	log_msg(LOG_DEBUG, "S1 Release req with wrong enb_s1ap_ue_id.\n");
-		return ActStatus::ABORT;
-    	}
+    if(ue_ctxt->getS1apEnbUeId() != procCtxt->getS1apEnbUeId())
+    {
+        log_msg(LOG_DEBUG, "S1 Release req with wrong enb_s1ap_ue_id. UE Context has %u " 
+                           "and proc context has %u ",ue_ctxt->getS1apEnbUeId(), procCtxt->getS1apEnbUeId());
+        return ActStatus::ABORT;
+    }
 
 	struct RB_Q_msg rb_msg;
 	rb_msg.msg_type = release_bearer_request;
@@ -93,14 +94,14 @@ ActStatus ActionHandlers:: send_rel_ab_req_to_sgw(SM::ControlBlock& cb)
 
 	ProcedureStats::num_of_rel_access_bearer_req_sent ++;
 	
-	log_msg(LOG_DEBUG, "Inside send_rel_ab_req_to_sgw \n");
+	log_msg(LOG_DEBUG, "Inside send_rel_ab_req_to_sgw ");
 
 	return ActStatus::PROCEED;
 }
 
 ActStatus ActionHandlers:: process_rel_ab_resp_from_sgw(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "process_rel_ab_resp_from_sgw \n");
+	log_msg(LOG_DEBUG, "process_rel_ab_resp_from_sgw ");
 
 	ProcedureStats::num_of_rel_access_bearer_resp_received ++;
 
@@ -109,10 +110,10 @@ ActStatus ActionHandlers:: process_rel_ab_resp_from_sgw(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers:: send_s1_rel_cmd_to_ue(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside send_s1_rel_cmd_to_ue\n");
+	log_msg(LOG_DEBUG, "Inside send_s1_rel_cmd_to_ue");
 
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	S1apCause s1apCause;
 	MmeProcedureCtxt* prcdCtxt_p = 
 		dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
@@ -141,7 +142,7 @@ ActStatus ActionHandlers:: send_s1_rel_cmd_to_ue(SM::ControlBlock& cb)
 	
 	ProcedureStats::num_of_s1_rel_cmd_sent ++;
 	
-	log_msg(LOG_DEBUG,"Leaving send_s1_rel_cmd_to_ue \n");
+	log_msg(LOG_DEBUG,"Leaving send_s1_rel_cmd_to_ue ");
 
 	return ActStatus::PROCEED;
 }
@@ -177,13 +178,13 @@ ActStatus ActionHandlers::abort_s1_release(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::s1_release_complete(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Insidei s1_release_complete \n");
+    log_msg(LOG_DEBUG, "Insidei s1_release_complete ");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmContext *mmCtxt = ue_ctxt->getMmContext();
-    VERIFY_UE(cb, mmCtxt, "Invalid MM Context\n");
+    VERIFY_UE(cb, mmCtxt, "Invalid MM Context");
 
     mmCtxt->setEcmState(ecmIdle_c);
 
@@ -200,7 +201,7 @@ ActStatus ActionHandlers::s1_release_complete(ControlBlock& cb)
     ue_ctxt->setS1apEnbUeId(0);
     ProcedureStats::num_of_s1_rel_comp_received++;
 
-    log_msg(LOG_DEBUG, "Leaving s1_release_complete \n");
+    log_msg(LOG_DEBUG, "Leaving s1_release_complete ");
 
     return ActStatus::PROCEED;
 }

--- a/src/mme-app/actionHandlers/serviceRequestActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/serviceRequestActionHandlers.cpp
@@ -49,10 +49,10 @@ using namespace cmn::utils;
 ***************************************/
 ActStatus ActionHandlers::send_paging_req_to_ue(ControlBlock& cb)
 {
-    log_msg(LOG_INFO, "Inside send_paging_req\n");
+    log_msg(LOG_INFO, "Inside send_paging_req");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     struct paging_req_Q_msg pag_req;
     pag_req.msg_type = paging_request;
@@ -77,7 +77,7 @@ ActStatus ActionHandlers::send_paging_req_to_ue(ControlBlock& cb)
 
     ProcedureStats::num_of_paging_request_sent++;
 
-    log_msg(LOG_INFO, "Leaving send_paging_req\n");
+    log_msg(LOG_INFO, "Leaving send_paging_req");
 
     return ActStatus::PROCEED;
 }
@@ -87,23 +87,23 @@ ActStatus ActionHandlers::send_paging_req_to_ue(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::process_service_request(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside process_service_request \n");
+    log_msg(LOG_DEBUG, "Inside process_service_request ");
 	
 	UEContext *ue_ctxt = dynamic_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmContext *mmCtxt = ue_ctxt->getMmContext();
-    VERIFY_UE(cb, mmCtxt, "Invalid MM Context\n");
+    VERIFY_UE(cb, mmCtxt, "Invalid MM Context");
 
     MmeProcedureCtxt *procCtxt =
             dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
 
     MsgBuffer* msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     VERIFY(msgBuf,
             procCtxt->setMmeErrorCause(INVALID_MSG_BUFFER); return ActStatus::ABORT,
-            "process_service_request : Invalid message buffer \n");
+            "process_service_request : Invalid message buffer ");
 
 
     const service_req_Q_msg_t* msgData_p =
@@ -111,11 +111,11 @@ ActStatus ActionHandlers::process_service_request(ControlBlock& cb)
 
     VERIFY(msgData_p,
             procCtxt->setMmeErrorCause(INVALID_DATA_BUFFER); return ActStatus::ABORT,
-            "process_service_request : Invalid data buffer \n");
+            "process_service_request : Invalid data buffer ");
 
     mmCtxt->setEcmState(ecmConnected_c);
 	ue_ctxt->setS1apEnbUeId(msgData_p->header.s1ap_enb_ue_id);
-	log_msg(LOG_DEBUG, "Leaving process_service_request \n");
+	log_msg(LOG_DEBUG, "Leaving process_service_request ");
 	ProcedureStats::num_of_service_request_received ++;
 
 	return ActStatus::PROCEED;
@@ -126,25 +126,25 @@ ActStatus ActionHandlers::process_service_request(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::send_ddn_ack_to_sgw(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_ddn_ack_to_sgw \n");
+    log_msg(LOG_DEBUG, "Inside send_ddn_ack_to_sgw ");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeSvcReqProcedureCtxt* srPrcdCtxt_p =
             dynamic_cast<MmeSvcReqProcedureCtxt*>(cb.getTempDataBlock());
     VERIFY(srPrcdCtxt_p, return ActStatus::ABORT,
-            "Procedure Context is NULL \n");
+            "Procedure Context is NULL ");
 
     auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
     VERIFY(sessionCtxtContainer.size() > 0,
             srPrcdCtxt_p->setMmeErrorCause(SESSION_CONTAINER_EMPTY); return ActStatus::ABORT,
-            "Sessions Container is empty\n");
+            "Sessions Container is empty");
 
     SessionContext* sess_p = sessionCtxtContainer.front();
     VERIFY(sess_p,
             srPrcdCtxt_p->setMmeErrorCause(SESSION_CONTEXT_NOT_FOUND); return ActStatus::ABORT,
-            "Session Context is NULL \n");
+            "Session Context is NULL ");
 
     DDN_ACK_Q_msg ddn_ack;
     ddn_ack.msg_type = ddn_acknowledgement;
@@ -163,7 +163,7 @@ ActStatus ActionHandlers::send_ddn_ack_to_sgw(ControlBlock& cb)
                     MmeIpcInterfaceCompId));
     mmeIpcIf.dispatchIpcMsg((char *) &ddn_ack, sizeof(ddn_ack), destAddr);
 
-    log_msg(LOG_DEBUG, "Leaving send_ddn_ack_to_sgw \n");
+    log_msg(LOG_DEBUG, "Leaving send_ddn_ack_to_sgw ");
 
     ProcedureStats::num_of_ddn_ack_sent++;
 
@@ -176,24 +176,24 @@ ActStatus ActionHandlers::send_ddn_ack_to_sgw(ControlBlock& cb)
 ****************************************************/
 ActStatus ActionHandlers::send_init_ctxt_req_to_ue_svc_req(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_init_ctxt_req_to_ue_svc_req \n");
+    log_msg(LOG_DEBUG, "Inside send_init_ctxt_req_to_ue_svc_req ");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeProcedureCtxt *procCtxt =
             dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
     auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
     VERIFY(sessionCtxtContainer.size() > 0,
             procCtxt->setMmeErrorCause(SESSION_CONTAINER_EMPTY); return ActStatus::ABORT,
-            "Sessions Container is empty\n");
+            "Sessions Container is empty");
 
     SessionContext *sessionCtxt = sessionCtxtContainer.front();
     VERIFY(sessionCtxt,
             procCtxt->setMmeErrorCause(SESSION_CONTEXT_NOT_FOUND); return ActStatus::ABORT,
-            "Session Context is NULL \n");
+            "Session Context is NULL ");
 
     unsigned int nas_count = 0;
     E_UTRAN_sec_vector* secVect =
@@ -217,7 +217,7 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue_svc_req(ControlBlock& cb)
     auto &bearerCtxtCont = sessionCtxt->getBearerContextContainer();
     VERIFY(bearerCtxtCont.size() > 0,
             procCtxt->setMmeErrorCause(BEARER_CONTAINER_EMPTY); return ActStatus::ABORT,
-            "Bearers Container is empty\n");
+            "Bearers Container is empty");
 
     icr_msg.erab_su_list.count = bearerCtxtCont.size();
 
@@ -260,7 +260,7 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue_svc_req(ControlBlock& cb)
     mmeIpcIf.dispatchIpcMsg((char *) &icr_msg, sizeof(icr_msg), destAddr);
 
     ProcedureStats::num_of_init_ctxt_req_to_ue_sent++;
-    log_msg(LOG_DEBUG, "Leaving send_init_ctxt_req_to_ue_svc_req_ \n");
+    log_msg(LOG_DEBUG, "Leaving send_init_ctxt_req_to_ue_svc_req_ ");
 
     return ActStatus::PROCEED;
 }
@@ -270,42 +270,42 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue_svc_req(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::process_init_ctxt_resp_svc_req(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside process_init_ctxt_resp_svc_req \n");
+    log_msg(LOG_DEBUG, "Inside process_init_ctxt_resp_svc_req ");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeProcedureCtxt *procCtxt =
             dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
     auto &sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
     VERIFY(sessionCtxtContainer.size() > 0,
             procCtxt->setMmeErrorCause(SESSION_CONTAINER_EMPTY); return ActStatus::ABORT,
-            "Sessions Container is empty\n");
+            "Sessions Container is empty");
 
     SessionContext *sessionCtxt = sessionCtxtContainer.front();
     VERIFY(sessionCtxt,
             procCtxt->setMmeErrorCause(SESSION_CONTEXT_NOT_FOUND); return ActStatus::ABORT,
-            "Session Context is NULL \n");
+            "Session Context is NULL ");
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     VERIFY(msgBuf,
             procCtxt->setMmeErrorCause(INVALID_MSG_BUFFER); return ActStatus::ABORT,
-            "process_init_ctxt_resp_svc_req : Invalid message buffer \n");
+            "process_init_ctxt_resp_svc_req : Invalid message buffer ");
 
     const s1_incoming_msg_header_t *s1_msg_data =
             static_cast<const s1_incoming_msg_header_t*>(msgBuf->getDataPointer());
     VERIFY(s1_msg_data,
             procCtxt->setMmeErrorCause(INVALID_DATA_BUFFER); return ActStatus::ABORT,
-            "process_init_ctxt_resp_svc_req : Invalid data buffer \n");
+            "process_init_ctxt_resp_svc_req : Invalid data buffer ");
 
     const initctx_resp_Q_msg_t *ics_res = static_cast<const initctx_resp_Q_msg_t*>(msgBuf->getDataPointer());
 
     auto &bearerCtxtCont = sessionCtxt->getBearerContextContainer();
     VERIFY(bearerCtxtCont.size() > 0,
             procCtxt->setMmeErrorCause(BEARER_CONTAINER_EMPTY); return ActStatus::ABORT,
-            "Bearers Container is empty\n");
+            "Bearers Container is empty");
 
     uint8_t i = 0;
 
@@ -328,7 +328,7 @@ ActStatus ActionHandlers::process_init_ctxt_resp_svc_req(ControlBlock& cb)
     }
 
     ProcedureStats::num_of_processed_init_ctxt_resp++;
-    log_msg(LOG_DEBUG, "Leaving process_init_ctxt_resp_svc_req \n");
+    log_msg(LOG_DEBUG, "Leaving process_init_ctxt_resp_svc_req ");
 
     return ActStatus::PROCEED;
 }
@@ -339,31 +339,31 @@ ActStatus ActionHandlers::process_init_ctxt_resp_svc_req(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::send_mb_req_to_sgw_svc_req(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_mb_req_to_sgw_svc_req \n");
+    log_msg(LOG_DEBUG, "Inside send_mb_req_to_sgw_svc_req ");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
     ActStatus actStatus = ActStatus::PROCEED;
 
     MmeProcedureCtxt *procCtxt =
             dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
     auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
     VERIFY(sessionCtxtContainer.size() > 0,
             procCtxt->setMmeErrorCause(SESSION_CONTAINER_EMPTY); return ActStatus::ABORT,
-            "Sessions Container is empty\n");
+            "Sessions Container is empty");
 
     SessionContext* sessionCtxt = sessionCtxtContainer.front();
     VERIFY(sessionCtxt,
             procCtxt->setMmeErrorCause(SESSION_CONTEXT_NOT_FOUND); return ActStatus::ABORT,
-            "Session Context is NULL \n");
+            "Session Context is NULL ");
 
     //Support dedicated bearers
     auto& bearerCtxtCont = sessionCtxt->getBearerContextContainer();
     VERIFY(bearerCtxtCont.size() > 0,
             procCtxt->setMmeErrorCause(BEARER_CONTAINER_EMPTY); return ActStatus::ABORT,
-            "Bearers Container is empty\n");
+            "Bearers Container is empty");
 
     uint8_t i =0;
     struct MB_Q_msg mb_msg;
@@ -425,7 +425,7 @@ ActStatus ActionHandlers::send_mb_req_to_sgw_svc_req(ControlBlock& cb)
 
     ProcedureStats::num_of_mb_req_to_sgw_sent++;
 
-    log_msg(LOG_DEBUG, "Leaving send_mb_req_to_sgw_svc_req \n");
+    log_msg(LOG_DEBUG, "Leaving send_mb_req_to_sgw_svc_req ");
 
     return actStatus;
 }
@@ -435,23 +435,23 @@ ActStatus ActionHandlers::send_mb_req_to_sgw_svc_req(ControlBlock& cb)
  ***************************************/
 ActStatus ActionHandlers::process_mb_resp_svc_req(ControlBlock &cb)
 {
-    log_msg(LOG_DEBUG, "Inside process_mb_resp_svc_req \n");
+    log_msg(LOG_DEBUG, "Inside process_mb_resp_svc_req ");
 
     ProcedureStats::num_of_processed_mb_resp++;
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeProcedureCtxt *procCtxt =
             dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
-    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL \n");
+    VERIFY(procCtxt, return ActStatus::ABORT, "Procedure Context is NULL ");
 
     MsgBuffer *msgBuf = static_cast<MsgBuffer*>(cb.getMsgData());
     VERIFY(msgBuf,
             procCtxt->setMmeErrorCause(INVALID_MSG_BUFFER); return ActStatus::ABORT,
-            "process_mb_resp_svc_req : Invalid message buffer \n");
+            "process_mb_resp_svc_req : Invalid message buffer ");
     VERIFY(msgBuf->getLength() >= sizeof(struct MB_resp_Q_msg),
-            return ActStatus::ABORT, "Invalid MBResp message length \n");
+            return ActStatus::ABORT, "Invalid MBResp message length ");
 
     const struct MB_resp_Q_msg *mbr_info =
             static_cast<const MB_resp_Q_msg*>(msgBuf->getDataPointer());
@@ -460,7 +460,7 @@ ActStatus ActionHandlers::process_mb_resp_svc_req(ControlBlock &cb)
 
     if (mbr_info->cause != GTPV2C_CAUSE_REQUEST_ACCEPTED)
     {
-        log_msg(LOG_INFO, "process_mb_resp_svc_req: MB Response Failure\n");
+        log_msg(LOG_INFO, "process_mb_resp_svc_req: MB Response Failure");
 
         procCtxt->setMmeErrorCause(S11_MODIFY_BEARER_RESP_FAILURE);
         actStatus = ActStatus::ABORT;
@@ -470,25 +470,25 @@ ActStatus ActionHandlers::process_mb_resp_svc_req(ControlBlock &cb)
         auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
         VERIFY(sessionCtxtContainer.size() > 0,
                 procCtxt->setMmeErrorCause(SESSION_CONTAINER_EMPTY); return ActStatus::ABORT,
-                "Sessions Container is empty\n");
+                "Sessions Container is empty");
 
         SessionContext* sessionCtxt = sessionCtxtContainer.front();
         VERIFY(sessionCtxt,
                 procCtxt->setMmeErrorCause(SESSION_CONTEXT_NOT_FOUND); return ActStatus::ABORT,
-                "Session Context is NULL \n");
+                "Session Context is NULL ");
 
         //TODO: Support dedicated bearers
         BearerContext *bearerCtxt = sessionCtxt->findBearerContextByBearerId(
                 sessionCtxt->getLinkedBearerId());
         VERIFY(bearerCtxt,
                 procCtxt->setMmeErrorCause(BEARER_CONTEXT_NOT_FOUND); return ActStatus::ABORT,
-                "Bearer Context is NULL \n");
+                "Bearer Context is NULL ");
 
         if (procCtxt->getCtxtType() == erabModInd_c) {
             MmeErabModIndProcedureCtxt *procCtxt =
                     static_cast<MmeErabModIndProcedureCtxt*>(cb.getTempDataBlock());
             VERIFY(procCtxt, return ActStatus::ABORT,
-                    "Procedure Context is NULL \n");
+                    "Procedure Context is NULL ");
 
             uint8_t eRabsModifiedList[1] = { bearerCtxt->getBearerId() };
             procCtxt->setErabModifiedList(eRabsModifiedList, 1);
@@ -503,10 +503,10 @@ ActStatus ActionHandlers::process_mb_resp_svc_req(ControlBlock &cb)
 ***************************************/
 ActStatus ActionHandlers::send_service_reject(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_service_reject \n");
+    log_msg(LOG_DEBUG, "Inside send_service_reject ");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     struct commonRej_info service_rej;
 
@@ -567,25 +567,25 @@ ActStatus ActionHandlers::svc_req_state_guard_timeout(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::send_ddn_failure_ind(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Inside send_ddn_failure_ind \n");
+    log_msg(LOG_DEBUG, "Inside send_ddn_failure_ind ");
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
     MmeSvcReqProcedureCtxt* srPrcdCtxt_p =
             dynamic_cast<MmeSvcReqProcedureCtxt*>(cb.getTempDataBlock());
     VERIFY(srPrcdCtxt_p, return ActStatus::ABORT,
-            "Procedure Context is NULL \n");
+            "Procedure Context is NULL ");
 
     auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
     VERIFY(sessionCtxtContainer.size() > 0,
             srPrcdCtxt_p->setMmeErrorCause(SESSION_CONTAINER_EMPTY); return ActStatus::ABORT,
-            "Sessions Container is empty\n");
+            "Sessions Container is empty");
 
     SessionContext* sess_p = sessionCtxtContainer.front();
     VERIFY(sess_p,
             srPrcdCtxt_p->setMmeErrorCause(SESSION_CONTEXT_NOT_FOUND); return ActStatus::ABORT,
-            "Session Context is NULL \n");
+            "Session Context is NULL ");
 
     DDN_FAIL_Q_msg ddn_fail;
     ddn_fail.msg_type = ddn_failure_indication;
@@ -604,7 +604,7 @@ ActStatus ActionHandlers::send_ddn_failure_ind(ControlBlock& cb)
                     MmeIpcInterfaceCompId));
     mmeIpcIf.dispatchIpcMsg((char *) &ddn_fail, sizeof(ddn_fail), destAddr);
 
-    log_msg(LOG_DEBUG, "Leaving send_ddn_failure_ind \n");
+    log_msg(LOG_DEBUG, "Leaving send_ddn_failure_ind ");
 
     return ActStatus::PROCEED;
 }
@@ -614,7 +614,7 @@ ActStatus ActionHandlers::send_ddn_failure_ind(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::abort_service_req_procedure(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG,"abort_service_req_procedure : Entry \n");
+    log_msg(LOG_DEBUG,"abort_service_req_procedure : Entry ");
 
     ERROR_CODES errorCause = SUCCESS;
     PagingTrigger pagingTrigger = 0;
@@ -671,7 +671,7 @@ ActStatus ActionHandlers::service_request_complete(ControlBlock& cb)
 
     MmeSvcReqProcedureCtxt *procedure_p =
             static_cast<MmeSvcReqProcedureCtxt*>(cb.getTempDataBlock());
-    VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL \n");
+    VERIFY(procedure_p, return ActStatus::ABORT, "Procedure Context is NULL ");
 
     if (procedure_p->checkPagingTriggerBit(pgwInit_c))
     {

--- a/src/mme-app/actionHandlers/tauActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/tauActionHandlers.cpp
@@ -52,19 +52,19 @@ extern mmeConfig *mme_tables;
 ***************************************/
 ActStatus ActionHandlers::send_tau_response_to_ue(ControlBlock& cb)
 {
-	log_msg(LOG_INFO,"Inside send_tau_response_to_ue\n");
+	log_msg(LOG_INFO,"Inside send_tau_response_to_ue");
 
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
 	if (ue_ctxt == NULL)
 	{
-		log_msg(LOG_ERROR, "send_tau_response_to_ue: ue context is NULL\n",cb.getCBIndex());
+		log_msg(LOG_ERROR, "send_tau_response_to_ue: ue context is NULL",cb.getCBIndex());
 		return ActStatus::HALT;
 	}
 
 	MmeProcedureCtxt* prcdCtxt_p = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
 	if (prcdCtxt_p == NULL)
 	{
-		log_msg(LOG_DEBUG, "process_tau_request: MmeProcedureCtxt is NULL\n");
+		log_msg(LOG_DEBUG, "process_tau_request: MmeProcedureCtxt is NULL");
 		return ActStatus::HALT;
 	}
 
@@ -159,7 +159,7 @@ ActStatus ActionHandlers::send_tau_response_to_ue(ControlBlock& cb)
 	}
 	ProcedureStats::num_of_tau_response_to_ue_sent++;
 
-	log_msg(LOG_INFO,"Leaving send_tau_response_to_ue\n");
+	log_msg(LOG_INFO,"Leaving send_tau_response_to_ue");
 	return ActStatus::PROCEED;
 }
 

--- a/src/mme-app/actionHandlers/ueInitDetachActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/ueInitDetachActionHandlers.cpp
@@ -41,8 +41,8 @@ ActStatus ActionHandlers::del_session_req(SM::ControlBlock& cb)
 {
 
     UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-    VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
-    log_msg(LOG_DEBUG, "%s Inside delete_session_req %u \n", __FUNCTION__, ue_ctxt->getContextID());
+    VERIFY_UE(cb, ue_ctxt, "Invalid UE");
+    log_msg(LOG_DEBUG, "Inside delete_session_req %u ", ue_ctxt->getContextID());
 
     bool status = false;
 
@@ -80,7 +80,7 @@ ActStatus ActionHandlers::del_session_req(SM::ControlBlock& cb)
         }
         else
         {
-            log_msg(LOG_DEBUG, "%s session context does not exist \n", __FUNCTION__);
+            log_msg(LOG_DEBUG, "session context does not exist ");
         }
     }
 
@@ -91,7 +91,7 @@ ActStatus ActionHandlers::del_session_req(SM::ControlBlock& cb)
     // so that abort can continue.
     if(!status)
     {
-        log_msg(LOG_DEBUG, "%s failure in handling dsreq event \n", __FUNCTION__);
+        log_msg(LOG_DEBUG, "failure in handling dsreq event ");
         MmeProcedureCtxt *procCtxt = dynamic_cast<MmeProcedureCtxt*>(cb.getTempDataBlock());
 
         if(procCtxt != NULL)
@@ -102,10 +102,10 @@ ActStatus ActionHandlers::del_session_req(SM::ControlBlock& cb)
                 {
                     // Action invoked as part of detach success path, return abort as
                     // we failed to send out delete session request to gw
-                    log_msg(LOG_DEBUG, "%s failure in handling dsreq event for detach_c procedure \n", __FUNCTION__);
+                    log_msg(LOG_DEBUG, "failure in handling dsreq event for detach_c procedure ");
                     if(procCtxt->getMmeErrorCause() == SUCCESS)
                     {
-                        log_msg(LOG_DEBUG, "%s failure in handling dsreq event. return abort \n", __FUNCTION__);
+                        log_msg(LOG_DEBUG, "failure in handling dsreq event. return abort ");
                         rc = ActStatus::ABORT;
                     }
 
@@ -124,9 +124,9 @@ ActStatus ActionHandlers::del_session_req(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::purge_req(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside purge_req \n");
+	log_msg(LOG_DEBUG, "Inside purge_req ");
 	UEContext *ue_ctxt =  static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	
 	s6a_Q_msg purge_msg;
 	purge_msg.msg_type = purge_request;	
@@ -150,16 +150,16 @@ ActStatus ActionHandlers::purge_req(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::process_del_session_resp(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside handle_delete_session_resp \n");
+	log_msg(LOG_DEBUG, "Inside handle_delete_session_resp ");
 	
 	UEContext *ue_ctxt = static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 
 	auto& sessionCtxtContainer = ue_ctxt->getSessionContextContainer();
 	if(sessionCtxtContainer.size() > 0)
 	{
 	    SessionContext* sessionCtxt = sessionCtxtContainer.front();
-	    VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL \n");
+	    VERIFY(sessionCtxt, return ActStatus::ABORT, "Session Context is NULL ");
 	    MmeContextManagerUtils::deallocateSessionContext(cb, sessionCtxt, ue_ctxt);
 	}
 	ProcedureStats::num_of_processed_del_session_resp ++;
@@ -169,10 +169,10 @@ ActStatus ActionHandlers::process_del_session_resp(SM::ControlBlock& cb)
 
 ActStatus ActionHandlers::process_pur_resp(SM::ControlBlock& cb)
 {
-	log_msg(LOG_DEBUG, "Inside handle_purge_resp \n");
+	log_msg(LOG_DEBUG, "Inside handle_purge_resp ");
 	
 	UEContext *ue_ctxt =  static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
 	//purge_resp_Q_msg_t *purge_msg = nullptr;
 	
 	/*Nothing is been done. Only takes the UE Index
@@ -187,9 +187,9 @@ ActStatus ActionHandlers::detach_accept_to_ue(SM::ControlBlock& cb)
 {
 	
 	UEContext *ue_ctxt =  static_cast<UEContext*>(cb.getPermDataBlock());
-	VERIFY_UE(cb, ue_ctxt, "Invalid UE\n");
+	VERIFY_UE(cb, ue_ctxt, "Invalid UE");
   
-	log_msg(LOG_DEBUG, "%s - Inside send_detach_accept %u \n", __FUNCTION__,ue_ctxt->getContextID());
+	log_msg(LOG_DEBUG, "Inside send_detach_accept %u ",ue_ctxt->getContextID());
   
 	detach_accept_Q_msg detach_accpt;
 	detach_accpt.msg_type = detach_accept;
@@ -228,7 +228,7 @@ ActStatus ActionHandlers::detach_accept_to_ue(SM::ControlBlock& cb)
 	MmeContextManagerUtils::deallocateProcedureCtxt(cb, procedure_p );
 
 	MmContext* mmCtxt = ue_ctxt->getMmContext();
-	VERIFY_UE(cb, mmCtxt, "Invalid UE\n");
+	VERIFY_UE(cb, mmCtxt, "Invalid UE");
 
 	mmCtxt->setMmState(EpsDetached);
 	mmCtxt->setEcmState(ecmIdle_c);
@@ -248,7 +248,7 @@ ActStatus ActionHandlers::detach_accept_to_ue(SM::ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::abort_detach(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "abort_detach : Entry \n");
+    log_msg(LOG_DEBUG, "abort_detach : Entry ");
     MmeDetachProcedureCtxt *procedure_p =
             static_cast<MmeDetachProcedureCtxt*>(cb.getTempDataBlock());
     if(procedure_p != NULL)
@@ -268,7 +268,7 @@ ActStatus ActionHandlers::abort_detach(ControlBlock& cb)
 ***************************************/
 ActStatus ActionHandlers::handle_s1_rel_req_during_detach(ControlBlock& cb)
 {
-    log_msg(LOG_DEBUG, "Recevied S1 Release Request during detach for cb %d\n", cb.getCBIndex());
+    log_msg(LOG_DEBUG, "Recevied S1 Release Request during detach for cb %d", cb.getCBIndex());
 
     MmeDetachProcedureCtxt *procedure_p =
             static_cast<MmeDetachProcedureCtxt*>(cb.getTempDataBlock());

--- a/src/mme-app/interfaces/mmeIpcInterface.cpp
+++ b/src/mme-app/interfaces/mmeIpcInterface.cpp
@@ -47,7 +47,7 @@ bool MmeIpcInterface::setup()
 
 	if (receiver_sock->bindTipcSocket(myAddress) == false)
 	{
-		log_msg(LOG_ERROR, "MmeIpcInterface Setup Failed!!!\n");
+		log_msg(LOG_ERROR, "MmeIpcInterface Setup Failed!!!");
 
 		delete receiver_sock;
 
@@ -97,7 +97,7 @@ void MmeIpcInterface::handleIpcMsg(cmn::IpcEMsgUnqPtr eMsg)
 	msgBuf->readUint32(destAddr);
 	msgBuf->readUint32(srcAddr);
 
-	log_msg(LOG_INFO, "IPC Message received from src %u to dest %u\n", srcAddr, destAddr);
+	log_msg(LOG_INFO, "IPC Message received from src %u to dest %u", srcAddr, destAddr);
 
 	switch (srcAddr)
 
@@ -112,7 +112,7 @@ void MmeIpcInterface::handleIpcMsg(cmn::IpcEMsgUnqPtr eMsg)
 		S6MsgHandler::Instance()->handleS6Message_v(std::move(eMsg));
 		break;
 	default:
-		log_msg(LOG_INFO, "IPC Message from unsupported instance\n");
+		log_msg(LOG_INFO, "IPC Message from unsupported instance");
 	}
 }
 
@@ -131,7 +131,7 @@ bool MmeIpcInterface::dispatchIpcMsg(char* buf, uint32_t len, cmn::ipc::IpcAddre
 
 
 	bool ret = mmeIpcEgressFifo_g.push(eMsg);
-	log_msg(LOG_INFO, "Dispatch IPC msg. Len %d, result = %s \n", msgBuf->getLength(), (ret == true) ? "Queued":"Dropped");
+	log_msg(LOG_INFO, "Dispatch IPC msg. Len %d, result = %s ", msgBuf->getLength(), (ret == true) ? "Queued":"Dropped");
 	return ret;
 }
 

--- a/src/mme-app/main.cpp
+++ b/src/mme-app/main.cpp
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
 
     if (init_sock() != SUCCESS)
     {
-        log_msg(LOG_ERROR, "Error in initializing unix domain socket server.\n");
+        log_msg(LOG_ERROR, "Error in initializing unix domain socket server.");
         return -E_FAIL_INIT;
     }
 

--- a/src/mme-app/mme_config.c
+++ b/src/mme-app/mme_config.c
@@ -21,7 +21,7 @@ extern mme_config_t *mme_cfg;
 void mme_config_change_cbk(char *config_file, uint32_t flags)
 {
     // Run the script with this file. It generates new config for mme
-	log_msg(LOG_INFO, "Received %s . File %s Flags %x \n", __FUNCTION__, config_file, flags);
+	log_msg(LOG_INFO, " File %s Flags %x ", config_file, flags);
     system((char*)("sh /opt/mme/config/mme-init.sh"));
     /* We dont expect quick updates from configmap..One update per interval */
     watch_config_change((char *)("/opt/mme/config/config.json"), mme_config_change_cbk, false);

--- a/src/mme-app/monitorSubscriber.cpp
+++ b/src/mme-app/monitorSubscriber.cpp
@@ -64,7 +64,7 @@ void MonitorSubscriber::handle_monitor_imsi_req(struct monitor_imsi_req *mir, in
                             ueCtxt_p->getImsi().getImsiDigits(mia.imsi);
                             memcpy(&mia.tai, &ueCtxt_p->getTai().tai_m, sizeof(struct TAI));
                             memcpy(&mia.ambr, &ueCtxt_p->getAmbr().ambr_m, sizeof(struct AMBR));
-                            log_msg(LOG_ERROR, "IMSI: %s PAA %x \n", mia.imsi, mia.paa);
+                            log_msg(LOG_ERROR, "IMSI: %s PAA %x ", mia.imsi, mia.paa);
                         }
                     }
                     else if (mmCtxt_p->getMmState() == EpsDetached)

--- a/src/mme-app/msgHandlers/gtpMsgHandler.cpp
+++ b/src/mme-app/msgHandlers/gtpMsgHandler.cpp
@@ -42,12 +42,12 @@ void GtpMsgHandler::handleGtpMessage_v(IpcEMsgUnqPtr eMsg)
     utils::MsgBuffer *msgBuf = eMsg->getMsgBuffer();
     if (msgBuf == NULL)
     {
-        log_msg(LOG_INFO, "GTP Message Buffer is empty \n");
+        log_msg(LOG_INFO, "GTP Message Buffer is empty ");
         return;
     }
     if (msgBuf->getLength() < sizeof(gtp_incoming_msg_data_t))
     {
-        log_msg(LOG_INFO, "Not enough bytes in gtp message \n");
+        log_msg(LOG_INFO, "Not enough bytes in gtp message ");
         return;
     }
 
@@ -113,7 +113,7 @@ void GtpMsgHandler::handleGtpMessage_v(IpcEMsgUnqPtr eMsg)
                 break;
 
 		default:
-			log_msg(LOG_INFO, "Unhandled Gtp Message %d \n", msgData_p->msg_type);
+			log_msg(LOG_INFO, "Unhandled Gtp Message %d ", msgData_p->msg_type);
 	}
 
 }
@@ -126,7 +126,7 @@ void GtpMsgHandler::handleCreateSessionResponseMsg_v(IpcEMsgUnqPtr eMsg, uint32_
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleCreateSessionResponseMsg_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -144,7 +144,7 @@ void GtpMsgHandler::handleModifyBearerResponseMsg_v(IpcEMsgUnqPtr eMsg, uint32_t
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleModifyBearerResponseMsg_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -162,7 +162,7 @@ void GtpMsgHandler::handleDeleteSessionResponseMsg_v(IpcEMsgUnqPtr eMsg, uint32_
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleDeleteSessionResponse_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -179,7 +179,7 @@ void GtpMsgHandler::handleReleaseBearerResponseMsg_v(IpcEMsgUnqPtr eMsg, uint32_
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleReleaseBearerResponse_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -191,14 +191,14 @@ void GtpMsgHandler::handleReleaseBearerResponseMsg_v(IpcEMsgUnqPtr eMsg, uint32_
 
 void GtpMsgHandler::handleDdnMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO,"Inside handle DDN\n");
+	log_msg(LOG_INFO,"Inside handle DDN");
 
 	SM::ControlBlock* controlBlk_p =
 	        MmeCommonUtils::findControlBlockForS11Msg(eMsg->getMsgBuffer());
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleDdnMsg_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -210,7 +210,7 @@ void GtpMsgHandler::handleDdnMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 
 void GtpMsgHandler::handleCreateBearerRequestMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-        log_msg(LOG_INFO,"Inside handle Create Bearer Request\n");
+        log_msg(LOG_INFO,"Inside handle Create Bearer Request");
 
         SM::ControlBlock* controlBlk_p =
                 MmeCommonUtils::findControlBlockForS11Msg(eMsg->getMsgBuffer());
@@ -218,7 +218,7 @@ void GtpMsgHandler::handleCreateBearerRequestMsg_v(IpcEMsgUnqPtr eMsg, uint32_t 
         {
                    /* TODO : generate CBRsp with cause context not found */
                   log_msg(LOG_ERROR, "handleCreateBearerRequestMsg_v: "
-                                                        "Failed to find UE context using idx %d\n",
+                                                        "Failed to find UE context using idx %d",
                                                         ueIdx);
                 return;
         }
@@ -230,14 +230,14 @@ void GtpMsgHandler::handleCreateBearerRequestMsg_v(IpcEMsgUnqPtr eMsg, uint32_t 
 
 void GtpMsgHandler::handleDeleteBearerRequestMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-        log_msg(LOG_INFO,"Inside handle Delete Bearer Request\n");
+        log_msg(LOG_INFO,"Inside handle Delete Bearer Request");
 
         SM::ControlBlock* controlBlk_p =
                 MmeCommonUtils::findControlBlockForS11Msg(eMsg->getMsgBuffer());
         if(controlBlk_p == NULL)
         {
                 log_msg(LOG_ERROR, "handleDeleteBearerRequestMsg_v: "
-                                                        "Failed to find UE context using idx %d\n",
+                                                        "Failed to find UE context using idx %d",
                                                         ueIdx);
                 return;
         }

--- a/src/mme-app/msgHandlers/s1MsgHandler.cpp
+++ b/src/mme-app/msgHandlers/s1MsgHandler.cpp
@@ -39,7 +39,7 @@ S1MsgHandler* S1MsgHandler::Instance()
 // Starting point 
 void S1MsgHandler::handleS1Message_v(IpcEMsgUnqPtr eMsg)
 {
-	log_msg(LOG_INFO, "S1 - handleS1Message_v\n");
+	log_msg(LOG_INFO, "S1 - handleS1Message_v");
 
 	if (std::move(eMsg).get() == NULL)
 		return;
@@ -47,21 +47,21 @@ void S1MsgHandler::handleS1Message_v(IpcEMsgUnqPtr eMsg)
 	utils::MsgBuffer* msgBuf = eMsg->getMsgBuffer();
 	if (msgBuf == NULL)
 	{
-		log_msg(LOG_INFO, "S1 Message Buffer is empty \n");
+		log_msg(LOG_INFO, "S1 Message Buffer is empty ");
 		return;
 	}
 
-	log_msg(LOG_INFO, "message size %d in s1 ipc message \n",msgBuf->getLength());
+	log_msg(LOG_INFO, "message size %d in s1 ipc message ",msgBuf->getLength());
 	if (msgBuf->getLength() < sizeof (s1_incoming_msg_header_t))
 	{
 	    log_msg(LOG_INFO, "Not enough bytes in s1 ipc message"
-	            "Received %d but should be %d\n", msgBuf->getLength(),
+	            "Received %d but should be %d", msgBuf->getLength(),
 	            sizeof (s1_incoming_msg_header_t));
 	    return;
 	}
 
 	s1_incoming_msg_header_t* msgData_p = (s1_incoming_msg_header_t*)(msgBuf->getDataPointer());
-	log_msg(LOG_INFO, "S1 - handleS1Message_v %d\n",msgData_p->msg_type);
+	log_msg(LOG_INFO, "S1 - handleS1Message_v %d",msgData_p->msg_type);
 
 	/* Below function should take care of decryption and integrity check */
 	/* Get the control block and pass it to below function */
@@ -98,14 +98,14 @@ void S1MsgHandler::handleS1Message_v(IpcEMsgUnqPtr eMsg)
                                     nasMsgSize, &nas))
         {
             free(nas.elements);
-            log_msg(LOG_ERROR,"NAS pdu parse failed.\n");
+            log_msg(LOG_ERROR,"NAS pdu parse failed.");
             return;
         }
 	    MmeNasUtils::copy_nas_to_s1msg(&nas, msgData_p);
         free(nas.elements);
     } while(0);
 
-	log_msg(LOG_INFO, "S1 - handleS1Message_v %d\n",msgData_p->msg_type);
+	log_msg(LOG_INFO, "S1 - handleS1Message_v %d",msgData_p->msg_type);
 	switch (msgData_p->msg_type)
 	{
 		case msg_type_t::attach_request:
@@ -238,19 +238,19 @@ void S1MsgHandler::handleS1Message_v(IpcEMsgUnqPtr eMsg)
 			handleS1apEnbStatusMsg_v(std::move(eMsg));
 			break;
 		default:
-			log_msg(LOG_ERROR, "Unhandled S1 Message %d \n", msgData_p->msg_type);
+			log_msg(LOG_ERROR, "Unhandled S1 Message %d ", msgData_p->msg_type);
 	}
 }
 
 void S1MsgHandler::handleInitUeAttachRequestMsg_v(IpcEMsgUnqPtr eMsg)
 {
-	log_msg(LOG_INFO, "S1 - handleInitUeAttachRequestMsg_v\n");
+	log_msg(LOG_INFO, "S1 - handleInitUeAttachRequestMsg_v");
 
 	utils::MsgBuffer* msgData_p = eMsg->getMsgBuffer();
 	SM::ControlBlock* controlBlk_p = MmeCommonUtils::findControlBlock(msgData_p);
 	if (controlBlk_p == NULL)
 	{
-		log_msg(LOG_ERROR, "Failed to allocate ControlBlock \n");
+		log_msg(LOG_ERROR, "Failed to allocate ControlBlock ");
 
         	return;
 	}
@@ -262,13 +262,13 @@ void S1MsgHandler::handleInitUeAttachRequestMsg_v(IpcEMsgUnqPtr eMsg)
 
 void S1MsgHandler::handleIdentityResponseMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleIdentityResponseMsg_v\n");
+	log_msg(LOG_INFO, "S1 - handleIdentityResponseMsg_v");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleIdentityResponseMsg_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -280,13 +280,13 @@ void S1MsgHandler::handleIdentityResponseMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueId
 
 void S1MsgHandler::handleAuthResponseMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleAuthResponseMsg_v\n");
+	log_msg(LOG_INFO, "S1 - handleAuthResponseMsg_v");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleAuthResponseMsg_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -299,13 +299,13 @@ void S1MsgHandler::handleAuthResponseMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 
 void S1MsgHandler::handleSecurityModeResponse_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleSecurityModeResponse_v\n");
+	log_msg(LOG_INFO, "S1 - handleSecurityModeResponse_v");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleSecurityModeResponse_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -317,13 +317,13 @@ void S1MsgHandler::handleSecurityModeResponse_v(IpcEMsgUnqPtr eMsg, uint32_t ueI
 
 void S1MsgHandler::handleEsmInfoResponse_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleEsmInfoResponse_v\n");
+	log_msg(LOG_INFO, "S1 - handleEsmInfoResponse_v");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleEsmInfoResponse_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -335,13 +335,13 @@ void S1MsgHandler::handleEsmInfoResponse_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 
 void S1MsgHandler::handleInitCtxtResponse_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleInitCtxtResponse_v\n");
+	log_msg(LOG_INFO, "S1 - handleInitCtxtResponse_v");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleInitCtxtResponse_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -353,13 +353,13 @@ void S1MsgHandler::handleInitCtxtResponse_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 
 void S1MsgHandler::handleAttachComplete_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleAttachComplete_v\n");
+	log_msg(LOG_INFO, "S1 - handleAttachComplete_v");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleAttachComplete_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -371,14 +371,14 @@ void S1MsgHandler::handleAttachComplete_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 
 void S1MsgHandler::handleDetachRequest_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleDetachRequest_v\n");
+	log_msg(LOG_INFO, "S1 - handleDetachRequest_v");
 
 	utils::MsgBuffer* msgData_p = eMsg->getMsgBuffer();
 	SM::ControlBlock* controlBlk_p = MmeCommonUtils::findControlBlock(msgData_p);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleDetachRequest_v: "
-				"Failed to find UE context using idx %d\n", ueIdx);
+				"Failed to find UE context using idx %d", ueIdx);
 		return;
 	}
 
@@ -389,13 +389,13 @@ void S1MsgHandler::handleDetachRequest_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 
 void S1MsgHandler::handleS1ReleaseRequestMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleS1ReleaseRequestMsg_v\n");
+	log_msg(LOG_INFO, "S1 - handleS1ReleaseRequestMsg_v");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
     	{
 		log_msg(LOG_ERROR, ":handleS1ReleaseRequestMsg_v: "
-                		"Failed to find UE context using idx %d\n", ueIdx);
+                		"Failed to find UE context using idx %d", ueIdx);
         	return;
     	}
 
@@ -406,13 +406,13 @@ void S1MsgHandler::handleS1ReleaseRequestMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueId
 
 void S1MsgHandler::handleS1ReleaseComplete_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleS1ReleaseComplete_v\n");
+	log_msg(LOG_INFO, "S1 - handleS1ReleaseComplete_v");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
     	{
 		log_msg(LOG_ERROR, ":handleS1ReleaseComplete_v: "
-                		"Failed to find UE context using idx %d\n", ueIdx);
+                		"Failed to find UE context using idx %d", ueIdx);
         	return;
     	}
 
@@ -423,13 +423,13 @@ void S1MsgHandler::handleS1ReleaseComplete_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 
 void S1MsgHandler::handleDetachAcceptFromUE_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleDetachAcceptFromUE_v\n");
+	log_msg(LOG_INFO, "S1 - handleDetachAcceptFromUE_v");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleDetachAcceptFromUE_v: "
-				   "Failed to find UE Context using idx %d\n",
+				   "Failed to find UE Context using idx %d",
 				   ueIdx);
 		return;
 	}
@@ -441,14 +441,14 @@ void S1MsgHandler::handleDetachAcceptFromUE_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx
 
 void S1MsgHandler::handleServiceRequest_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleServiceRequest_v\n");
+	log_msg(LOG_INFO, "S1 - handleServiceRequest_v");
 
     utils::MsgBuffer* msgData_p = eMsg->getMsgBuffer();
     SM::ControlBlock* controlBlk_p = MmeCommonUtils::findControlBlock(msgData_p);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleServiceRequest_v: "
-				   "Failed to find UE Context using idx %d\n",
+				   "Failed to find UE Context using idx %d",
 				   ueIdx);
 		return;
 	}
@@ -460,14 +460,14 @@ void S1MsgHandler::handleServiceRequest_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 
 void S1MsgHandler::handleTauRequestMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleTauRequestMsg_v\n");
+	log_msg(LOG_INFO, "S1 - handleTauRequestMsg_v");
 
     utils::MsgBuffer* msgData_p = eMsg->getMsgBuffer();
     SM::ControlBlock* controlBlk_p = MmeCommonUtils::findControlBlock(msgData_p);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleTauRequestMsg_v: "
-				   "Failed to find UE Context using idx %d\n",
+				   "Failed to find UE Context using idx %d",
 				   ueIdx);
 		return;
 	}
@@ -480,14 +480,14 @@ void S1MsgHandler::handleTauRequestMsg_v(IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 void S1MsgHandler::handleHandoverRequiredMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleHandoverRequiredMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleHandoverRequiredMsg_v");
 
     SM::ControlBlock *controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if (controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleHandoverRequiredMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -499,14 +499,14 @@ void S1MsgHandler::handleHandoverRequiredMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleHandoverRequestAckMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleHandoverRequestAckMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleHandoverRequestAckMsg_v");
 
     SM::ControlBlock *controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if (controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleHandoverRequestAckMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -518,14 +518,14 @@ void S1MsgHandler::handleHandoverRequestAckMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleHandoverNotifyMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleHandoverNotifyMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleHandoverNotifyMsg_v");
 
     SM::ControlBlock *controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if (controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleHandoverNotifyMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -537,14 +537,14 @@ void S1MsgHandler::handleHandoverNotifyMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleEnbStatusTransferMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleEnbStatusTransferMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleEnbStatusTransferMsg_v");
 
     SM::ControlBlock *controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if (controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleEnbStatusTransferMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -556,14 +556,14 @@ void S1MsgHandler::handleEnbStatusTransferMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleHandoverCancelMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleHandoverCancelMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleHandoverCancelMsg_v");
 
     SM::ControlBlock *controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if (controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleHandoverCancelMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -575,14 +575,14 @@ void S1MsgHandler::handleHandoverCancelMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleHandoverFailureMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleHandoverFailureMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleHandoverFailureMsg_v");
 
     SM::ControlBlock *controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if (controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleHandoverFailureMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -594,14 +594,14 @@ void S1MsgHandler::handleHandoverFailureMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleErabModificationIndicationMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "S1 - handleErabModificationIndicationMsg_v\n");
+	log_msg(LOG_INFO, "S1 - handleErabModificationIndicationMsg_v");
 
     SM::ControlBlock* controlBlk_p = 
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleErabModificationIndicationMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -613,14 +613,14 @@ void S1MsgHandler::handleErabModificationIndicationMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleErabSetupResponseMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleErabSetupResponseMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleErabSetupResponseMsg_v");
 
     SM::ControlBlock* controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if(controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleErabSetupResponseMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -632,14 +632,14 @@ void S1MsgHandler::handleErabSetupResponseMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleActDedBearerCtxtAcceptMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleActDedBearerCtxtAcceptMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleActDedBearerCtxtAcceptMsg_v");
 
     SM::ControlBlock* controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if(controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleActDedBearerCtxtAcceptMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -651,14 +651,14 @@ void S1MsgHandler::handleActDedBearerCtxtAcceptMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleActDedBearerCtxtRejectMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleActDedBearerCtxtRejectMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleActDedBearerCtxtRejectMsg_v");
 
     SM::ControlBlock* controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if(controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleActDedBearerCtxtRejectMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -670,14 +670,14 @@ void S1MsgHandler::handleActDedBearerCtxtRejectMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleErabRelResponseMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleErabRelResponseMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleErabRelResponseMsg_v");
 
     SM::ControlBlock* controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if(controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleErabRelResponseMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -689,14 +689,14 @@ void S1MsgHandler::handleErabRelResponseMsg_v(IpcEMsgUnqPtr eMsg,
 void S1MsgHandler::handleDeActBearerCtxtAcceptMsg_v(IpcEMsgUnqPtr eMsg,
         uint32_t ueIdx)
 {
-    log_msg(LOG_INFO, "S1 - handleDeActBearerCtxtAcceptMsg_v\n");
+    log_msg(LOG_INFO, "S1 - handleDeActBearerCtxtAcceptMsg_v");
 
     SM::ControlBlock* controlBlk_p =
             SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
     if(controlBlk_p == NULL)
     {
         log_msg(LOG_ERROR, "handleDeActBearerCtxtAcceptMsg_v: "
-                "Failed to find UE Context using idx %d\n", ueIdx);
+                "Failed to find UE Context using idx %d", ueIdx);
         return;
     }
 
@@ -711,9 +711,9 @@ void S1MsgHandler::handleS1apEnbStatusMsg_v(IpcEMsgUnqPtr eMsg)
 	utils::MsgBuffer* msgBuf = eMsg->getMsgBuffer();
     assert(msgBuf != NULL);
 	s1apEnbStatus_Msg_t *enb = (s1apEnbStatus_Msg_t*)(msgBuf->getDataPointer());
-    log_msg(LOG_INFO, " Received enb Status message for %d \n",enb->context_id);
+    log_msg(LOG_INFO, " Received enb Status message for %d ",enb->context_id);
     if(enb->context_id >= 1024) {
-        log_msg(LOG_INFO, " Supported only 1024 eNBs \n");
+        log_msg(LOG_INFO, " Supported only 1024 eNBs ");
         return;
     }
      // new enb found  

--- a/src/mme-app/msgHandlers/s6MsgHandler.cpp
+++ b/src/mme-app/msgHandlers/s6MsgHandler.cpp
@@ -41,13 +41,13 @@ void S6MsgHandler::handleS6Message_v(IpcEMsgUnqPtr eMsg)
     utils::MsgBuffer *msgBuf = eMsg->getMsgBuffer();
     if (msgBuf == NULL)
     {
-        log_msg(LOG_INFO, "S6 Message Buffer is empty \n");
+        log_msg(LOG_INFO, "S6 Message Buffer is empty ");
         return;
     }
 
     if (msgBuf->getLength() < sizeof(s6_incoming_msg_header_t))
     {
-        log_msg(LOG_INFO, "Not enough bytes in s6 message \n");
+        log_msg(LOG_INFO, "Not enough bytes in s6 message ");
         return;
     }
 
@@ -75,20 +75,20 @@ void S6MsgHandler::handleS6Message_v(IpcEMsgUnqPtr eMsg)
 			break;
 
 		default:
-			log_msg(LOG_INFO, "Unhandled S6 Message %d \n", msgData_p->msg_type);
+			log_msg(LOG_INFO, "Unhandled S6 Message %d ", msgData_p->msg_type);
 	}
 
 }
 
 void S6MsgHandler::handleAuthInfoAnswer_v(cmn::IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "Inside handleAuthInfoAnswer_v \n");
+	log_msg(LOG_INFO, "Inside handleAuthInfoAnswer_v ");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleAuthInfoAnswer_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -100,13 +100,13 @@ void S6MsgHandler::handleAuthInfoAnswer_v(cmn::IpcEMsgUnqPtr eMsg, uint32_t ueId
 
 void S6MsgHandler::handleUpdateLocationAnswer_v(cmn::IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "Inside handleUpdateLocationAnswer_v \n");
+	log_msg(LOG_INFO, "Inside handleUpdateLocationAnswer_v ");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleUpdateLocationAnswer_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -117,13 +117,13 @@ void S6MsgHandler::handleUpdateLocationAnswer_v(cmn::IpcEMsgUnqPtr eMsg, uint32_
 
 void S6MsgHandler::handlePurgeAnswer_v(cmn::IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 {
-	log_msg(LOG_INFO, "Inside handlePurgeAnswer_v \n");
+	log_msg(LOG_INFO, "Inside handlePurgeAnswer_v ");
 
 	SM::ControlBlock* controlBlk_p = SubsDataGroupManager::Instance()->findControlBlock(ueIdx);
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handlePurgeAnswer_v: "
-							"Failed to find UE context using idx %d\n",
+							"Failed to find UE context using idx %d",
 							ueIdx);
 		return;
 	}
@@ -135,7 +135,7 @@ void S6MsgHandler::handlePurgeAnswer_v(cmn::IpcEMsgUnqPtr eMsg, uint32_t ueIdx)
 
 void S6MsgHandler::handleCancelLocationRequest_v(cmn::IpcEMsgUnqPtr eMsg)
 {
-	log_msg(LOG_INFO, "Inside handleCancelLocationRequest \n");
+	log_msg(LOG_INFO, "Inside handleCancelLocationRequest ");
         
 	utils::MsgBuffer* msgData_p = eMsg->getMsgBuffer();
 	void* buf = msgData_p->getDataPointer();
@@ -145,11 +145,11 @@ void S6MsgHandler::handleCancelLocationRequest_v(cmn::IpcEMsgUnqPtr eMsg)
 	IMSI.setImsiDigits((unsigned char *)msgInfo_p->imsi);
       
 	int ue_idx =  SubsDataGroupManager::Instance()->findCBWithimsi(IMSI);
-	log_msg(LOG_INFO, "UE_IDX found from map : %d \n", ue_idx);
+	log_msg(LOG_INFO, "UE_IDX found from map : %d ", ue_idx);
 
 	if (ue_idx < 1)
 	{
-		log_msg(LOG_ERROR, "Failed to find ue index using IMSI : %d\n", ue_idx);
+		log_msg(LOG_ERROR, "Failed to find ue index using IMSI : %d", ue_idx);
 		return;
 	}
 
@@ -157,7 +157,7 @@ void S6MsgHandler::handleCancelLocationRequest_v(cmn::IpcEMsgUnqPtr eMsg)
 	if(controlBlk_p == NULL)
 	{
 		log_msg(LOG_ERROR, "handleCancelLocationRequest_v: "
-				   "Failed to find UE Context using IMSI in CLR\n");
+				   "Failed to find UE Context using IMSI in CLR");
 		return;
 	}
 	//Fire CLR event, insert CB to Procedure Queue

--- a/src/mme-app/parse_config.cpp
+++ b/src/mme-app/parse_config.cpp
@@ -31,11 +31,11 @@ int
 mmeConfig::getIntAlgOrder(char *alg_list, uint8_t* alg_order)
 {
     char *subString;
-    log_msg(LOG_DEBUG, "alg_list : %s\n", alg_list); 
+    log_msg(LOG_DEBUG, "alg_list : %s", alg_list); 
     subString = strtok(alg_list,"[]");
-    log_msg(LOG_DEBUG, "substring : %s\n", subString); 
+    log_msg(LOG_DEBUG, "substring : %s", subString); 
     //subString = strtok(NULL,"]");
-    //log_msg(LOG_DEBUG, "substring : %s\n", subString); 
+    //log_msg(LOG_DEBUG, "substring : %s", subString); 
 
     char token[] = ",";
     char *saved_comma=NULL;
@@ -46,7 +46,7 @@ mmeConfig::getIntAlgOrder(char *alg_list, uint8_t* alg_order)
 
     for(int i = 0;i < 3; i++)
     {
-        log_msg(LOG_DEBUG, "algs : %s\n", alg[i]);
+        log_msg(LOG_DEBUG, "algs : %s", alg[i]);
         if(alg[i] != NULL)
         {
             if(!strcmp(alg[i],"EIA0"))
@@ -81,9 +81,9 @@ int
 mmeConfig::getSecAlgOrder(char *alg_list, uint8_t* alg_order)
 {
     char *subString;
-    log_msg(LOG_DEBUG, "alg_list : %s\n", alg_list); 
+    log_msg(LOG_DEBUG, "alg_list : %s", alg_list); 
     subString = strtok(alg_list,"[]");
-    log_msg(LOG_DEBUG, "substring : %s\n", subString); 
+    log_msg(LOG_DEBUG, "substring : %s", subString); 
 
     char token[] = ",";
     char *saved_comma=NULL;
@@ -95,7 +95,7 @@ mmeConfig::getSecAlgOrder(char *alg_list, uint8_t* alg_order)
 
     for(int i = 0;i < 3; i++)
     {
-        log_msg(LOG_DEBUG, "algs : %s\n", alg[i]);
+        log_msg(LOG_DEBUG, "algs : %s", alg[i]);
         if(alg[i] != NULL)
         {
             if(!strcmp(alg[i],"EEA0"))
@@ -248,7 +248,7 @@ mmeConfig::mme_parse_config_new(mme_config_t *config)
                 mmeConfig::get_mcc_mnc(plmn, &mcc_i, &mnc_i, &mnc_digits);
                 config->plmn_mcc_mnc[count-1].mcc = mcc_i;
                 config->plmn_mcc_mnc[count-1].mnc = mnc_i;
-                log_msg(LOG_INFO, "Parsed plmn mcc - %d mnc - %d \n", mcc_i, mnc_i);
+                log_msg(LOG_INFO, "Parsed plmn mcc - %d mnc - %d ", mcc_i, mnc_i);
                 unsigned char mcc_dig_1 = mcc_i / 100; 
                 unsigned char mcc_dig_2 = (mcc_i / 10) % 10; 
                 unsigned char mcc_dig_3 = mcc_i % 10; 
@@ -270,7 +270,7 @@ mmeConfig::mme_parse_config_new(mme_config_t *config)
                 config->plmns[count-1].idx[1] = (mnc_dig_1 << 4) | (mcc_dig_3);
                 config->plmns[count-1].idx[2] = (mnc_dig_3 << 4) | (mnc_dig_2);
                 config->plmns[count-1].mnc_digits = mnc_digits;
-                log_msg(LOG_INFO, "Configured plmn %x %x %x \n", config->plmns[count-1].idx[0], config->plmns[count-1].idx[1], config->plmns[count-1].idx[2]); 
+                log_msg(LOG_INFO, "Configured plmn %x %x %x ", config->plmns[count-1].idx[0], config->plmns[count-1].idx[1], config->plmns[count-1].idx[2]); 
             }
         }
         if(mmeSection.HasMember("security"))
@@ -318,8 +318,8 @@ mmeConfig::mme_parse_config_new(mme_config_t *config)
                 std::string apn = apnitr->name.GetString();
                 std::string spgw = apnitr->value.GetString();
 
-                log_msg(LOG_INFO, "Configured service %s\n", spgw.c_str());
-                log_msg(LOG_INFO, "Configured apn %s \n", apn.c_str()); 
+                log_msg(LOG_INFO, "Configured service %s", spgw.c_str());
+                log_msg(LOG_INFO, "Configured apn %s ", apn.c_str()); 
                 // add apn==>{ spgw service,  address, failures }  in the map 
                 apn_config *ap1 = new apn_config(apn, spgw);
                 mme_tables->add_apn(ap1);
@@ -327,15 +327,15 @@ mmeConfig::mme_parse_config_new(mme_config_t *config)
         }
     }
     /* Print parsed configuraton */
-    log_msg(LOG_DEBUG,"mme_name : %s \n", config->mme_name);
-    log_msg(LOG_DEBUG,"mme_groupid : %d \n", config->mme_group_id);
-    log_msg(LOG_DEBUG,"mme_code : %d \n", config->mme_code);
-    log_msg(LOG_DEBUG,"logging  : %s \n", config->logging);
-    log_msg(LOG_DEBUG,"MCC :    %d %d %d \n", config->mcc_dig1, config->mcc_dig2, config->mcc_dig3);
-    log_msg(LOG_DEBUG,"MNC :    %d %d %d \n", config->mnc_dig1, config->mnc_dig2, config->mnc_dig3);
+    log_msg(LOG_DEBUG,"mme_name : %s ", config->mme_name);
+    log_msg(LOG_DEBUG,"mme_groupid : %d ", config->mme_group_id);
+    log_msg(LOG_DEBUG,"mme_code : %d ", config->mme_code);
+    log_msg(LOG_DEBUG,"logging  : %s ", config->logging);
+    log_msg(LOG_DEBUG,"MCC :    %d %d %d ", config->mcc_dig1, config->mcc_dig2, config->mcc_dig3);
+    log_msg(LOG_DEBUG,"MNC :    %d %d %d ", config->mnc_dig1, config->mnc_dig2, config->mnc_dig3);
     for(int i=0; i<config->num_plmns;i++)
     {
-        log_msg(LOG_DEBUG,"PLMN(%d) :    %d %d %d \n", i, config->plmns[i].idx[0], config->plmns[i].idx[1], config->plmns[i].idx[2]);
+        log_msg(LOG_DEBUG,"PLMN(%d) :    %d %d %d ", i, config->plmns[i].idx[0], config->plmns[i].idx[1], config->plmns[i].idx[2]);
     }
     mme_tables->initiate_spgw_resolution();
     return ;
@@ -390,7 +390,7 @@ void mmeConfig::initiate_spgw_resolution()
         {
             // Keep trying ...May be SGW is not yet deployed 
             // We shall be doing this once timer library is integrated 
-            log_msg(LOG_ERROR, "%s - getaddr info failed %s\n",temp->get_spgw_srv().c_str(), gai_strerror(err));
+            log_msg(LOG_ERROR, "%s - getaddr info failed %s",temp->get_spgw_srv().c_str(), gai_strerror(err));
             if(started == false)
               MmeTimerUtils::startTimer(10000, 1 /* ue_index */, mmeConfigDnsResolve_c, 1 /*timer type*/);
             started = true;
@@ -402,7 +402,7 @@ void mmeConfig::initiate_spgw_resolution()
                 if(rp->ai_family == AF_INET)
                 {
                     struct sockaddr_in *addrV4 = (struct sockaddr_in *)rp->ai_addr;
-                    log_msg(LOG_INFO, "gw address received from DNS response %s\n", inet_ntoa(addrV4->sin_addr));
+                    log_msg(LOG_INFO, "gw address received from DNS response %s", inet_ntoa(addrV4->sin_addr));
                     temp->set_pgw_ip(addrV4->sin_addr.s_addr);
                     temp->set_sgw_ip(addrV4->sin_addr.s_addr);
                     temp->set_dns_resolved();

--- a/src/mme-app/utils/mmeCauseUtils.cpp
+++ b/src/mme-app/utils/mmeCauseUtils.cpp
@@ -16,7 +16,7 @@ using namespace mme;
 
 uint32_t MmeCauseUtils::convertToNasEmmCause(ERROR_CODES mmeErrorCause)
 {
-    log_msg(LOG_DEBUG, "MME Error Cause %d\n", mmeErrorCause);
+    log_msg(LOG_DEBUG, "MME Error Cause %d", mmeErrorCause);
 
 	uint32_t nasEmmCause = 0;
 
@@ -36,7 +36,7 @@ uint32_t MmeCauseUtils::convertToNasEmmCause(ERROR_CODES mmeErrorCause)
 
 uint32_t MmeCauseUtils::convertToGtpCause(ERROR_CODES mmeErrorCause)
 {
-    log_msg(LOG_DEBUG, "MME Error Cause %d\n", mmeErrorCause);
+    log_msg(LOG_DEBUG, "MME Error Cause %d", mmeErrorCause);
 
 	uint32_t gtpCause = 0;
 
@@ -61,7 +61,7 @@ uint32_t MmeCauseUtils::convertToGtpCause(ERROR_CODES mmeErrorCause)
 
 S1apCause MmeCauseUtils::convertToS1apCause(ERROR_CODES mmeErrorCause)
 {
-    log_msg(LOG_DEBUG, "MME Error Cause %d\n", mmeErrorCause);
+    log_msg(LOG_DEBUG, "MME Error Cause %d", mmeErrorCause);
 
     S1apCause s1apCause;
 

--- a/src/mme-app/utils/mmeCommonUtils.cpp
+++ b/src/mme-app/utils/mmeCommonUtils.cpp
@@ -79,7 +79,7 @@ uint32_t MmeCommonUtils::allocateMtmsi()
 			break;
 	}
 
-	log_msg(LOG_INFO, "MTMSI allocated is %u\n", tmsi);
+	log_msg(LOG_INFO, "MTMSI allocated is %u", tmsi);
 
 	return tmsi;
 }
@@ -131,19 +131,19 @@ void MmeCommonUtils::getS1apPlmnIdFroms11(struct PLMN* plmn_p)
 AttachType MmeCommonUtils::getAttachType(UEContext* ueContext_p,
 		const struct ue_attach_info& ue_info)
 {
-	log_msg(LOG_INFO, "deriveAttachType\n");
+	log_msg(LOG_INFO, "deriveAttachType");
 
 	AttachType attachType = maxAttachType_c;
 
 	if(UE_ID_IMSI(ue_info.flags))
 	{
-		log_msg(LOG_INFO, "IMSI attach received.\n");
+		log_msg(LOG_INFO, "IMSI attach received.");
 
 		attachType = imsiAttach_c;
 	}
 	else if (UE_ID_GUTI(ue_info.flags))
 	{
-		log_msg(LOG_INFO, "GUTI attach received. mTMSI is %u \n",
+		log_msg(LOG_INFO, "GUTI attach received. mTMSI is %u ",
 				ue_info.mi_guti.m_TMSI);
 
 		attachType = unknownGutiAttach_c;
@@ -158,19 +158,19 @@ AttachType MmeCommonUtils::getAttachType(UEContext* ueContext_p,
 			{
 				if (ueContext_p->getMTmsi() == ue_info.mi_guti.m_TMSI)
 				{
-					log_msg(LOG_INFO, "and known\n");
+					log_msg(LOG_INFO, "and known");
 
 					attachType = knownGutiAttach_c;
 				}
 				else
 				{
 					log_msg(LOG_INFO, "mTMSI mismatches with UE context. "
-							"Treat as unknown GUTI attach\n");
+							"Treat as unknown GUTI attach");
 				}
 			}
 			else
 			{
-				log_msg(LOG_INFO, "UE context is null. Unknown GUTI attach triggered\n");
+				log_msg(LOG_INFO, "UE context is null. Unknown GUTI attach triggered");
 			}
 
 		}
@@ -189,7 +189,7 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 	const s1_incoming_msg_header_t* msgData_p = (s1_incoming_msg_header_t*)(buf->getDataPointer());
 	if(msgData_p == NULL)
 	{
-		log_msg(LOG_INFO, "MsgData is NULL .\n");
+		log_msg(LOG_INFO, "MsgData is NULL .");
 		return cb;
 	}
 
@@ -200,7 +200,7 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 			const ue_attach_info_t *ue_info = (ue_attach_info_t *)(msgData_p);
 			if(UE_ID_IMSI(ue_info->flags))
 			{
-				log_msg(LOG_INFO, "IMSI attach received.\n");
+				log_msg(LOG_INFO, "IMSI attach received.");
 
 				uint8_t imsi[BINARY_IMSI_LEN] = {0};
 				memcpy( imsi, ue_info->IMSI, BINARY_IMSI_LEN );
@@ -214,18 +214,17 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 				int cbIndex = SubsDataGroupManager::Instance()->findCBWithimsi(IMSIInfo);
 				if (cbIndex > 0)
 				{
-					log_msg(LOG_DEBUG, "existing cb for IMSI. %s \n",IMSIInfo.getDigitsArray());
+					log_msg(LOG_DEBUG, "existing cb for IMSI. %s ",IMSIInfo.getDigitsArray());
 					cb = SubsDataGroupManager::Instance()->findControlBlock(cbIndex);
 				}
 				if (cb == NULL)
 				{
-					log_msg(LOG_INFO, "create new cb for IMSI %s.\n",
-							IMSIInfo.getDigitsArray());
+					log_msg(LOG_INFO, "create new cb for IMSI %s.", IMSIInfo.getDigitsArray());
 
 					cb = SubsDataGroupManager::Instance()->allocateCB();
 					if(cb == NULL) 
 					{
-						log_msg(LOG_DEBUG, "create new cb for IMSI failed. %s \n",IMSIInfo.getDigitsArray());
+						log_msg(LOG_DEBUG, "create new cb for IMSI failed. %s ",IMSIInfo.getDigitsArray());
 						return nullptr;
 					}
 					cb->addTempDataBlock(DefaultMmeProcedureCtxt::Instance());
@@ -233,11 +232,11 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 			}
 			else if (UE_ID_GUTI(ue_info->flags))
 			{
-				log_msg(LOG_INFO, "GUTI attach received.\n");
+				log_msg(LOG_INFO, "GUTI attach received.");
 
 				if (isLocalGuti(ue_info->mi_guti))
 				{
-					log_msg(LOG_INFO, "GUTI is local.\n");
+					log_msg(LOG_INFO, "GUTI is local.");
 
 					int cbIndex = SubsDataGroupManager::Instance()->findCBWithmTmsi(ue_info->mi_guti.m_TMSI);
 					if (cbIndex > 0)
@@ -246,7 +245,7 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 					}
 					else
 					{
-						log_msg(LOG_ERROR, "Failed to find control block with mTmsi.\n");
+						log_msg(LOG_ERROR, "Failed to find control block with mTmsi.");
 
 						// allocate new cb and proceed?
 						cb = SubsDataGroupManager::Instance()->allocateCB();
@@ -270,13 +269,13 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 			}
 			else
 			{
-				log_msg(LOG_INFO, "Failed to find control block with mTmsi.\n");
+				log_msg(LOG_INFO, "Failed to find control block with mTmsi.");
 			}
 
 			if (cb == NULL)
 			{
 				log_msg(LOG_INFO, "Failed to find control block using mtmsi %d."
-						" Allocate a temporary control block\n", msgData_p->ue_idx);
+						" Allocate a temporary control block", msgData_p->ue_idx);
 			    
 			    // Respond  with Service Reject from default Service Request event handler
 			    cb = SubsDataGroupManager::Instance()->allocateCB();
@@ -295,7 +294,7 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 			}
 			else
 			{
-				log_msg(LOG_INFO, "Failed to find control block with mTmsi. %d\n", detach_Req->ue_m_tmsi);
+				log_msg(LOG_INFO, "Failed to find control block with mTmsi. %d", detach_Req->ue_m_tmsi);
 			}
 			break;
 		}
@@ -310,7 +309,7 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 			else
 			{
 				log_msg(LOG_INFO, "Failed to find control block using mTmsi %d."
-                                              " Allocate a temporary control block\n", tau_Req->ue_m_tmsi);
+                                              " Allocate a temporary control block", tau_Req->ue_m_tmsi);
 				// Respond  with TAU Reject from default TAU event handler
 				cb = SubsDataGroupManager::Instance()->allocateCB();
 				cb->addTempDataBlock(DefaultMmeProcedureCtxt::Instance());
@@ -320,7 +319,7 @@ SM::ControlBlock* MmeCommonUtils::findControlBlock(cmn::utils::MsgBuffer* buf)
 		}
 		default:
 		{
-			log_msg(LOG_INFO, "Unhandled message type %d \n", msgData_p->msg_type);
+			log_msg(LOG_INFO, "Unhandled message type %d ", msgData_p->msg_type);
 		}
 	}
 
@@ -334,7 +333,7 @@ ControlBlock* MmeCommonUtils::findControlBlockForS11Msg(cmn::utils::MsgBuffer* m
     const gtp_incoming_msg_data_t* msgData_p = (gtp_incoming_msg_data_t*)(msg_p->getDataPointer());
     if(msgData_p == NULL)
     {
-        log_msg(LOG_INFO, "GTP message data is NULL .\n");
+        log_msg(LOG_INFO, "GTP message data is NULL .");
         return cb_p;
     }
 
@@ -345,7 +344,7 @@ ControlBlock* MmeCommonUtils::findControlBlockForS11Msg(cmn::utils::MsgBuffer* m
 	    const struct ddn_Q_msg* ddn = (const struct ddn_Q_msg*) (msg_p->getDataPointer());
             if (ddn->s11_mme_cp_teid == 0)
             {
-                log_msg(LOG_INFO, "UE Index in DDN message data is 0.\n");
+                log_msg(LOG_INFO, "UE Index in DDN message data is 0.");
                 return cb_p;
             }
 
@@ -353,7 +352,7 @@ ControlBlock* MmeCommonUtils::findControlBlockForS11Msg(cmn::utils::MsgBuffer* m
             if (cb_p == NULL)
             {
                 log_msg(LOG_INFO, "Failed to find control block using index %d."
-                        " Allocate a temporary control block\n", ddn->s11_mme_cp_teid);
+                        " Allocate a temporary control block", ddn->s11_mme_cp_teid);
 
                 // Respond  with DDN failure from default DDN event handler
                 cb_p = SubsDataGroupManager::Instance()->allocateCB();
@@ -365,7 +364,7 @@ ControlBlock* MmeCommonUtils::findControlBlockForS11Msg(cmn::utils::MsgBuffer* m
 	    const struct cb_req_Q_msg * cbr = (const struct cb_req_Q_msg *) (msg_p->getDataPointer());
             if (cbr->s11_mme_cp_teid == 0)
             {
-                log_msg(LOG_INFO, "UE Index in CB Req message data is 0.\n");
+                log_msg(LOG_INFO, "UE Index in CB Req message data is 0.");
                 return cb_p;
             }
 
@@ -373,7 +372,7 @@ ControlBlock* MmeCommonUtils::findControlBlockForS11Msg(cmn::utils::MsgBuffer* m
             if (cb_p == NULL)
             {
                 log_msg(LOG_INFO, "Failed to find control block using index %d."
-                        " Allocate a temporary control block\n", cbr->s11_mme_cp_teid);
+                        " Allocate a temporary control block", cbr->s11_mme_cp_teid);
 
                 // Respond  with CB Resp from default CB Req event handler
                 cb_p = SubsDataGroupManager::Instance()->allocateCB();
@@ -385,7 +384,7 @@ ControlBlock* MmeCommonUtils::findControlBlockForS11Msg(cmn::utils::MsgBuffer* m
             const struct db_req_Q_msg * dbr = (const struct db_req_Q_msg *) (msg_p->getDataPointer());
             if (dbr->s11_mme_cp_teid == 0)
             {
-                log_msg(LOG_INFO, "UE Index in DB Req message data is 0.\n");
+                log_msg(LOG_INFO, "UE Index in DB Req message data is 0.");
                 return cb_p;
             }
 
@@ -393,7 +392,7 @@ ControlBlock* MmeCommonUtils::findControlBlockForS11Msg(cmn::utils::MsgBuffer* m
             if (cb_p == NULL)
             {
                 log_msg(LOG_INFO, "Failed to find control block using index %d."
-                        " Allocate a temporary control block\n", dbr->s11_mme_cp_teid);
+                        " Allocate a temporary control block", dbr->s11_mme_cp_teid);
 
                 // Respond  with DB Resp from default DB Req event handler
                 cb_p = SubsDataGroupManager::Instance()->allocateCB();
@@ -402,7 +401,7 @@ ControlBlock* MmeCommonUtils::findControlBlockForS11Msg(cmn::utils::MsgBuffer* m
         }break;
         default:
         {
-            log_msg(LOG_INFO, "Unhandled message type\n");
+            log_msg(LOG_INFO, "Unhandled message type");
         }
     }
     return cb_p;
@@ -427,19 +426,19 @@ bool MmeCommonUtils::isUeNRCapable(UEContext &ueCtxt)
     bool rc;
 
     if (!ueCtxt.getUeNetCapab().ue_net_capab_m.u.bits.dcnr) {
-        log_msg(LOG_DEBUG, "UE does not support dual connectivity\n");
+        log_msg(LOG_DEBUG, "UE does not support dual connectivity");
         rc = false;
     } else if (!mme_cfg->feature_list.dcnr_support) {
-        log_msg(LOG_DEBUG,"MME local config does not allow dual connectivity\n");
+        log_msg(LOG_DEBUG,"MME local config does not allow dual connectivity");
         rc = false;
     } else if (!(ueCtxt.getHssFeatList2().feature_list & nrAsSecRatBitMask_c)) {
-        log_msg(LOG_DEBUG,"HSS does not support dual connectivity feature\n");
+        log_msg(LOG_DEBUG,"HSS does not support dual connectivity feature");
         rc = false;
     } else if (ueCtxt.getAccessRestrictionData() & nrAsSecRatInEutranNotAllowedBitMask_c) {
-        log_msg(LOG_DEBUG,"hss informed about access restriction for this UE\n");
+        log_msg(LOG_DEBUG,"hss informed about access restriction for this UE");
         rc = false;
     } else {
-        log_msg(LOG_DEBUG,"All well, this UE can use DCNR\n");
+        log_msg(LOG_DEBUG,"All well, this UE can use DCNR");
         rc = true;
     }
 

--- a/src/mme-app/utils/mmeContextManagerUtils.cpp
+++ b/src/mme-app/utils/mmeContextManagerUtils.cpp
@@ -347,7 +347,7 @@ bool MmeContextManagerUtils::deleteProcedureCtxt(MmeProcedureCtxt* procedure_p)
 		}
 		default:
 		{
-			log_msg(LOG_INFO, "Unsupported procedure type %d\n", procedure_p->getCtxtType());
+			log_msg(LOG_INFO, "Unsupported procedure type %d", procedure_p->getCtxtType());
 			rc = false;
 		}
 	}
@@ -358,13 +358,13 @@ bool MmeContextManagerUtils::deallocateProcedureCtxt(SM::ControlBlock& cb_r, Mme
 {
     if (procedure_p == NULL)
     {
-        log_msg(LOG_DEBUG, "procedure_p is NULL \n");
+        log_msg(LOG_DEBUG, "procedure_p is NULL ");
         return true;
     }
 
     if (procedure_p->getCtxtType() == defaultMmeProcedure_c)
     {
-        log_msg(LOG_ERROR, "CB %d trying to delete default procedure context \n", cb_r.getCBIndex());
+        log_msg(LOG_ERROR, "CB %d trying to delete default procedure context ", cb_r.getCBIndex());
         return true;
     }
 
@@ -446,7 +446,7 @@ void MmeContextManagerUtils::deleteAllSessionContext(SM::ControlBlock& cb_r)
     auto &sessionCtxtContainer = ueCtxt_p->getSessionContextContainer();
     if (sessionCtxtContainer.size() < 1)
     {
-        log_msg(LOG_ERROR, "Session context list is empty for UE IDX %d\n",
+        log_msg(LOG_ERROR, "Session context list is empty for UE IDX %d",
                 cb_r.getCBIndex());
         return;
     }
@@ -568,7 +568,7 @@ void MmeContextManagerUtils::deallocateSessionContext(SM::ControlBlock &cb_r,
         auto &bearerCtxtContainer = sessionCtxt_p->getBearerContextContainer();
         if (bearerCtxtContainer.size() < 1)
         {
-            log_msg(LOG_ERROR, "Bearer context list is empty for UE IDX %d\n",
+            log_msg(LOG_ERROR, "Bearer context list is empty for UE IDX %d",
                     cb_r.getCBIndex());
             return;
         }

--- a/src/mme-app/utils/mmeGtpMsgUtils.cpp
+++ b/src/mme-app/utils/mmeGtpMsgUtils.cpp
@@ -29,7 +29,7 @@ void MmeGtpMsgUtils::populateModifyBearerRequestHo(SM::ControlBlock& cb,
     BearerContext *bearerCtxt = sessionCtxt.findBearerContextByBearerId(sessionCtxt.getLinkedBearerId());
     if (bearerCtxt == NULL)
     {
-        log_msg(LOG_DEBUG, "send_mb_req_to_sgw_for_ho: bearer ctxt is NULL \n");
+        log_msg(LOG_DEBUG, "send_mb_req_to_sgw_for_ho: bearer ctxt is NULL ");
         return;
     }
 
@@ -117,14 +117,14 @@ bool MmeGtpMsgUtils::populateCreateBearerResponse(SM::ControlBlock &cb,
         else
         {
             log_msg(LOG_INFO,
-                    "populateCreateBearerResponse : SessionContext is NULL \n");
+                    "populateCreateBearerResponse : SessionContext is NULL ");
             cb_resp.cause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
         }
     }
     else
     {
         log_msg(LOG_INFO,
-                "populateCreateBearerResponse : UEContext is NULL \n");
+                "populateCreateBearerResponse : UEContext is NULL ");
         cb_resp.cause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
     }
 
@@ -159,7 +159,7 @@ bool MmeGtpMsgUtils::populateCreateBearerResponse(SM::ControlBlock &cb,
 
                 status = true;
 
-                log_msg(LOG_INFO, "populateCreateBearerResponse : CB Response Cause: %d \n", cb_resp.cause);
+                log_msg(LOG_INFO, "populateCreateBearerResponse : CB Response Cause: %d ", cb_resp.cause);
             }
         }
     }
@@ -194,7 +194,7 @@ bool MmeGtpMsgUtils::populateDeleteBearerResponse(SM::ControlBlock &cb,
     if (db_req == NULL)
     {
         log_msg(LOG_INFO,
-                "populateDeleteBearerResponse : db_Req is NULL \n");
+                "populateDeleteBearerResponse : db_Req is NULL ");
         return status;
     }
 
@@ -249,14 +249,14 @@ bool MmeGtpMsgUtils::populateDeleteBearerResponse(SM::ControlBlock &cb,
         else
         {
             log_msg(LOG_INFO,
-                    "populateDeleteBearerResponse : SessionContext is NULL \n");
+                    "populateDeleteBearerResponse : SessionContext is NULL ");
             gtpCause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
         }
     }
     else
     {
         log_msg(LOG_INFO,
-                "populateDeleteBearerResponse : UEContext is NULL \n");
+                "populateDeleteBearerResponse : UEContext is NULL ");
         gtpCause = GTPV2C_CAUSE_CONTEXT_NOT_FOUND;
     }
 
@@ -281,7 +281,7 @@ bool MmeGtpMsgUtils::populateDeleteBearerResponse(SM::ControlBlock &cb,
 
     status = true;
 
-    log_msg(LOG_INFO, "populateDeleteBearerResponse : DB Response Cause: %d \n",
+    log_msg(LOG_INFO, "populateDeleteBearerResponse : DB Response Cause: %d ",
             db_resp.cause);
 
     return status;

--- a/src/mme-app/utils/mmeNasUtils.cpp
+++ b/src/mme-app/utils/mmeNasUtils.cpp
@@ -27,13 +27,13 @@ static unsigned short get_length(unsigned char **msg)
 
     unsigned char val = ((*msg)[0] & 0xc0) >> 6;
     if(val == 2) {
-        //log_msg(LOG_INFO, "length more than 128\n");
+        //log_msg(LOG_INFO, "length more than 128");
         unsigned short higher = (unsigned char)(*msg)[0] & 0x3f;
         (*msg)++;
         unsigned short lower = (unsigned char)(*msg)[0];
         ie_len = (higher << 8) | lower;
     } else {
-        //log_msg(LOG_INFO, "length less than 128\n");
+        //log_msg(LOG_INFO, "length less than 128");
         ie_len = (unsigned short)(*msg)[0];
     }
     (*msg)++;
@@ -68,9 +68,9 @@ void printBytes(unsigned char *buf, size_t len)
     //Can enable if needed to check encrypted bytes.
 #if 0
   for(unsigned int i=0; i<len; i++) {
-    log_msg(LOG_DEBUG,"%02x \n", buf[i]);
+    log_msg(LOG_DEBUG,"%02x ", buf[i]);
   }
-  log_msg(LOG_DEBUG,"\n");
+  log_msg(LOG_DEBUG,"");
 #endif
 }
 
@@ -82,15 +82,15 @@ calculate_aes_mac(uint8_t *int_key, uint32_t count, uint8_t direction,
   unsigned char mact[16] = {0};
   size_t mactlen = 0;
   uint32_t msg_len = 0;
-  log_msg(LOG_DEBUG,"count %d, bearer %d direction %d, data_len %d \n", count, bearer, direction, data_len);
-  log_msg(LOG_DEBUG,"nas data \n");
+  log_msg(LOG_DEBUG,"count %d, bearer %d direction %d, data_len %d ", count, bearer, direction, data_len);
+  log_msg(LOG_DEBUG,"nas data ");
   printBytes(data, data_len);
-  log_msg(LOG_DEBUG,"nas key \n");
+  log_msg(LOG_DEBUG,"nas key ");
   printBytes(int_key, AES_128_KEY_SIZE);
   unsigned char* message = (unsigned char*)calloc(data_len+8, sizeof(uint8_t));
   if(message == NULL)
   {
-      log_msg(LOG_ERROR,"Memory alloc for mac calculation failed.\n");
+      log_msg(LOG_ERROR,"Memory alloc for mac calculation failed.");
       return;
   }
 
@@ -106,7 +106,7 @@ calculate_aes_mac(uint8_t *int_key, uint32_t count, uint8_t direction,
 
   CMAC_Update(ctx, message, sizeof(message));
   CMAC_Final(ctx, mact, &mactlen);
-  log_msg(LOG_DEBUG,"mac length = %lu\n",mactlen);
+  log_msg(LOG_DEBUG,"mac length = %lu",mactlen);
 
   printBytes(mact, mactlen);
 
@@ -127,8 +127,8 @@ calculate_aes_mac(uint8_t *int_key, uint32_t count, uint8_t direction,
   const char cipher[] = "AES-128-CBC";
   EVP_MAC_CTX *ctx = NULL;
 
-  log_msg(LOG_DEBUG,"count %d, bearer %d direction %d, data_len %d \n", count, bearer, direction, data_len);
-  log_msg(LOG_DEBUG,"nas data \n");
+  log_msg(LOG_DEBUG,"count %d, bearer %d direction %d, data_len %d ", count, bearer, direction, data_len);
+  log_msg(LOG_DEBUG,"nas data ");
   printBytes(data, data_len);
   OSSL_PARAM params[3];
   size_t params_n = 0;
@@ -137,7 +137,7 @@ calculate_aes_mac(uint8_t *int_key, uint32_t count, uint8_t direction,
   uint32_t msg_len = 0;
   if(message == NULL)
   {
-      log_msg(LOG_ERROR,"Memory alloc for mac calculation failed.\n");
+      log_msg(LOG_ERROR,"Memory alloc for mac calculation failed.");
       return;
   }
   else
@@ -149,9 +149,9 @@ calculate_aes_mac(uint8_t *int_key, uint32_t count, uint8_t direction,
       memcpy(&message[8], data, data_len);
   }
 
-  log_msg(LOG_DEBUG,"cipher %s %d\n",cipher, strlen(cipher));
+  log_msg(LOG_DEBUG,"cipher %s %d",cipher, strlen(cipher));
   printBytes(int_key, AES_128_KEY_SIZE);
-  log_msg(LOG_DEBUG,"key  %d\n", strlen((const char*)int_key));
+  log_msg(LOG_DEBUG,"key  %d", strlen((const char*)int_key));
   params[params_n++] =
       OSSL_PARAM_construct_utf8_string("cipher", (char*)cipher, strlen(cipher));
   params[params_n++] =
@@ -161,13 +161,13 @@ calculate_aes_mac(uint8_t *int_key, uint32_t count, uint8_t direction,
   ctx = EVP_MAC_CTX_new(mac_evp);
   if(ctx==NULL)
   {
-      log_msg(LOG_ERROR,"ctx null\n");
+      log_msg(LOG_ERROR,"ctx null");
       return;
   }
 
   if(EVP_MAC_CTX_set_params(ctx, params) <= 0)
   {
-      log_msg(LOG_ERROR,"set params fail\n");
+      log_msg(LOG_ERROR,"set params fail");
       return;
   }
 
@@ -179,10 +179,10 @@ calculate_aes_mac(uint8_t *int_key, uint32_t count, uint8_t direction,
 
   printBytes(message, msg_len);
   EVP_MAC_update(ctx, message, msg_len);
-  log_msg(LOG_DEBUG,"message length = %lu bytes (%lu bits)\n", 
+  log_msg(LOG_DEBUG,"message length = %lu bytes (%lu bits)", 
                 strlen((const char*)message), strlen((const char*)message)*8);
   EVP_MAC_final(ctx, mact, &mactlen, msg_len);
-  log_msg(LOG_DEBUG,"mac length = %lu\n",mactlen);
+  log_msg(LOG_DEBUG,"mac length = %lu",mactlen);
 
   printBytes(mact, mactlen);
   /* expected result T = 070a16b4 6b4d4144 f79bdd9d d04a287c */
@@ -200,7 +200,7 @@ calculate_s3g_mac(uint8_t *int_key, uint32_t seq_no, uint8_t direction,
         uint8_t *mac)
 {
     std::unique_lock<std::mutex> lock(mutex_m);
-    log_msg(LOG_DEBUG,"count %d, bearer %d direction %d, data_len %d \n", seq_no, bearer, direction, data_len);
+    log_msg(LOG_DEBUG,"count %d, bearer %d direction %d, data_len %d ", seq_no, bearer, direction, data_len);
     f9(int_key, seq_no, bearer, direction, data, data_len * 8, mac);
     return;
 }
@@ -210,20 +210,20 @@ calculate_mac(uint8_t *int_key, uint32_t count, uint8_t direction,
 		uint8_t bearer, uint8_t *data, uint16_t data_len,
 		uint8_t *mac, nas_int_algo_enum int_alg)
 {
-    log_msg(LOG_DEBUG, "Calculate mac. Int Alg : %d.\n",int_alg);
+    log_msg(LOG_DEBUG, "Calculate mac. Int Alg : %d.",int_alg);
     switch(int_alg)
     {
         case NAS_INT_ALGORITHMS_EIA2:
-            log_msg(LOG_DEBUG,"Integrity algo use is AES.\n");
+            log_msg(LOG_DEBUG,"Integrity algo use is AES.");
             calculate_aes_mac(int_key, count, direction, 
                               bearer, data, data_len, mac);
             break;
         case NAS_INT_ALGORITHMS_EIA1:
-            log_msg(LOG_WARNING, "Integrity algo use is Snow3G. Need to apply for license to productize this.\n");
+            log_msg(LOG_WARNING, "Integrity algo use is Snow3G. Need to apply for license to productize this.");
             calculate_s3g_mac(int_key, count, direction, bearer, data, data_len, mac);
             break;
         default:
-            log_msg(LOG_ERROR,"Integrity Algo not supported. Defaulting to no Integrity.\n");
+            log_msg(LOG_ERROR,"Integrity Algo not supported. Defaulting to no Integrity.");
 
     }
 }
@@ -237,7 +237,7 @@ static void log_buffer_free(unsigned char** buffer)
 
 void MmeNasUtils::select_sec_alg(UEContext *ue_ctxt)
 {
-    log_msg(LOG_DEBUG, "Inside select_sec_alg \n");
+    log_msg(LOG_DEBUG, "Inside select_sec_alg ");
 
     uint8_t eea;
     uint8_t eia;
@@ -284,14 +284,14 @@ void MmeNasUtils::decode_attach_req(unsigned char *msg, int &nas_msg_len,
     {
         // Mobile Identity contains imsi
         nas->flags |= NAS_MSG_UE_IE_IMSI;
-        log_msg(LOG_INFO, "IMSI len = %u - %u\n", imsi_len, BINARY_IMSI_LEN);
+        log_msg(LOG_DEBUG, "IMSI len = %u - %u", imsi_len, BINARY_IMSI_LEN);
         nas->elements[index].msgType = NAS_IE_TYPE_EPS_MOBILE_ID_IMSI;
         memcpy(&(nas->elements[index].pduElement.IMSI), msg, imsi_len);
         break;
     }
     case NAS_EPS_MOBILE_ID_GUTI:
     {
-        log_msg(LOG_INFO, "Mobile identity GUTI Rcvd \n");
+        log_msg(LOG_INFO, "Mobile identity GUTI Rcvd ");
         // Mobile Identity contains GUTI
         // MCC+MNC offset = 3
         // MME Group Id   = 2
@@ -306,12 +306,12 @@ void MmeNasUtils::decode_attach_req(unsigned char *msg, int &nas_msg_len,
         nas->elements[index].pduElement.mi_guti.m_TMSI = ntohl(
                 *((unsigned int*) (&msg[7])));
         log_msg(LOG_INFO,
-                "NAS Attach Request Rcvd ID: GUTI. PLMN id %d %d %d \n",
+                "NAS Attach Request Rcvd ID: GUTI. PLMN id %d %d %d ",
                 nas->elements[index].pduElement.mi_guti.plmn_id.idx[0],
                 nas->elements[index].pduElement.mi_guti.plmn_id.idx[1],
                 nas->elements[index].pduElement.mi_guti.plmn_id.idx[2]);
         log_msg(LOG_INFO,
-                "NAS Attach Request Rcvd ID: GUTI. mme group id = %d, MME code %d  mtmsi = %d\n",
+                "NAS Attach Request Rcvd ID: GUTI. mme group id = %d, MME code %d  mtmsi = %d",
                 nas->elements[index].pduElement.mi_guti.mme_grp_id,
                 nas->elements[index].pduElement.mi_guti.mme_code,
                 nas->elements[index].pduElement.mi_guti.m_TMSI);
@@ -327,7 +327,7 @@ void MmeNasUtils::decode_attach_req(unsigned char *msg, int &nas_msg_len,
 
     msg += imsi_len;
     unsigned char *bufflog = NULL;
-    log_msg(LOG_INFO, "IMSI=%s [to be read nibble-swapped]\n",
+    log_msg(LOG_INFO, "IMSI=%s [to be read nibble-swapped]",
             msg_to_hex_str(
                     (unsigned char* )nas->elements[index].pduElement.IMSI,
                     imsi_len, &bufflog));
@@ -347,11 +347,10 @@ void MmeNasUtils::decode_attach_req(unsigned char *msg, int &nas_msg_len,
     unsigned short len = msg[0] << 8 | msg[1];
     msg += 2;
     //now msg points to ESM message contents
-    log_msg(LOG_INFO, "len=%x\n", len);
-    log_msg(LOG_INFO, "msg[0]=%x\n", msg[0]);
+    log_msg(LOG_DEBUG, "ESM Message len=%x", len);
     nas->elements[index].pduElement.pti = msg[1];
     nas->elements[index].msgType = NAS_IE_TYPE_PTI;
-    log_msg(LOG_INFO, "pti=%x\n", nas->elements[index].pduElement.pti);
+    log_msg(LOG_DEBUG, "pti=%x", nas->elements[index].pduElement.pti);
     unsigned short int msg_offset = 4;
     /*ESM message header len is 4: bearer_id_flags(1)+proc_tx_id(1)+msg_id(1)
      * +pdn_type(1)*/
@@ -361,7 +360,7 @@ void MmeNasUtils::decode_attach_req(unsigned char *msg, int &nas_msg_len,
     while (msg_offset < len)
     {
         unsigned char val = msg[msg_offset];
-        log_msg(LOG_INFO, "ESM container AVP val=%x\n", val);
+        log_msg(LOG_DEBUG, "ESM container AVP val=%x", val);
         if (13 == (val >> 4))
         {
             index++;
@@ -371,7 +370,7 @@ void MmeNasUtils::decode_attach_req(unsigned char *msg, int &nas_msg_len,
             if (val & 1)
             {
                 nas->elements[index].pduElement.esm_info_tx_required = true;
-                log_msg(LOG_INFO, "ESM information requested ");
+                log_msg(LOG_DEBUG, "ESM information requested ");
             }
             msg_offset++; /* just one byte AVP */
             continue;
@@ -389,7 +388,6 @@ void MmeNasUtils::decode_attach_req(unsigned char *msg, int &nas_msg_len,
                     &msg[msg_offset + 2], pco_length);
             nas->elements[index].pduElement.pco_opt.pco_length = pco_length;
             msg_offset = pco_length + 2; // msg offset was already at PCO AVP type. Now it should point to next AVP type
-            log_msg(LOG_DEBUG, "PCO length = %d \n", pco_length);
             continue;
         }
         break; // unhandled ESM AVP...Add support..for now just break out..else we would be in tight loop
@@ -405,7 +403,7 @@ void MmeNasUtils::decode_attach_req(unsigned char *msg, int &nas_msg_len,
         {
         case NAS_IE_TYPE_UE_ADDITIONAL_SECURITY_CAPABILITY:
         {
-            log_msg(LOG_DEBUG, "UE_ADDITIONAL_SECURITY_CAPABILITY. Handling\n");
+            log_msg(LOG_DEBUG, "UE_ADDITIONAL_SECURITY_CAPABILITY. Handling");
             nas->elements[index].msgType =
                     NAS_IE_TYPE_UE_ADDITIONAL_SECURITY_CAPABILITY;
             msg++; //skipping Element ID
@@ -419,7 +417,7 @@ void MmeNasUtils::decode_attach_req(unsigned char *msg, int &nas_msg_len,
         }
         case NAS_IE_TYPE_MS_NETWORK_CAPABILITY:
         {
-            log_msg(LOG_DEBUG, "MS Network capability : Handling.\n");
+            log_msg(LOG_DEBUG, "MS Network capability : Handling.");
             index++;
             nas->elements[index].msgType = NAS_IE_TYPE_MS_NETWORK_CAPABILITY;
             nas->elements[index].pduElement.ms_network.pres = true;
@@ -488,7 +486,7 @@ void MmeNasUtils::decode_attach_req(unsigned char *msg, int &nas_msg_len,
             break;
         }
         default:
-            log_msg(LOG_WARNING, "NAS ATTACH REQ - Unhandled IE %x\n", elem_id);
+            log_msg(LOG_WARNING, "NAS ATTACH REQ - Unhandled IE %x", elem_id);
             // set status to false to break out of while loop.
             status = false;
             break;
@@ -514,14 +512,13 @@ void MmeNasUtils::decode_tau_req(unsigned char *msg, int &nas_msg_len,
 
     /*EPS mobility identity*/
     datalen = msg[1];
-    log_msg(LOG_DEBUG, "datalen :%d\n", datalen);
+    log_msg(LOG_DEBUG, "datalen :%d", datalen);
     unsigned char eps_identity = msg[2] & 0x07;
-    log_msg(LOG_INFO, "NAS TAU Request Rcvd :  %d %d %d %d, eps id %d\n",
+    log_msg(LOG_DEBUG, "NAS TAU Request Rcvd :  %d %d %d %d, eps id %d",
             msg[0], msg[1], msg[2], msg[4], eps_identity);
 
     if (eps_identity == NAS_EPS_MOBILE_ID_GUTI)
     {
-        log_msg(LOG_INFO, "Mobile identity GUTI Rcvd \n");
         // Mobile Identity contains GUTI
         // MCC+MNC offset = 3
         // MME Group Id   = 2
@@ -534,17 +531,16 @@ void MmeNasUtils::decode_tau_req(unsigned char *msg, int &nas_msg_len,
         nas->elements[index].pduElement.mi_guti.mme_code = msg[8];
         nas->elements[index].pduElement.mi_guti.m_TMSI = ntohl(
                 *((unsigned int*) (&msg[9])));
-        log_msg(LOG_INFO, "NAS TAU Request Rcvd ID: GUTI. PLMN id %d %d %d \n",
-                nas->elements[index].pduElement.mi_guti.plmn_id.idx[0],
-                nas->elements[index].pduElement.mi_guti.plmn_id.idx[1],
-                nas->elements[index].pduElement.mi_guti.plmn_id.idx[2]);
-        log_msg(LOG_INFO,
-                "NAS TAU Request Rcvd ID: GUTI. mme group id = %d, MME code %d  mtmsi = %d\n",
-                nas->elements[index].pduElement.mi_guti.mme_grp_id,
-                nas->elements[index].pduElement.mi_guti.mme_code,
-                nas->elements[index].pduElement.mi_guti.m_TMSI);
+        log_msg(LOG_DEBUG,"NAS TAU Request Rcvd ID: GUTI. PLMN id %d %d %d "
+                          "NAS TAU Request Rcvd ID: GUTI. mme group id = %d, MME code %d  mtmsi = %d",
+                          nas->elements[index].pduElement.mi_guti.plmn_id.idx[0],
+                          nas->elements[index].pduElement.mi_guti.plmn_id.idx[1],
+                          nas->elements[index].pduElement.mi_guti.plmn_id.idx[2],
+                          nas->elements[index].pduElement.mi_guti.mme_grp_id,
+                          nas->elements[index].pduElement.mi_guti.mme_code,
+                          nas->elements[index].pduElement.mi_guti.m_TMSI);
         nas->flags |= NAS_MSG_UE_IE_GUTI;
-	index++;
+        index++;
         msg += datalen + 2; //Datalength of EPS mobile identity(7) + Length Byte of EPS mobile identity(1) +
         //NAS KSI (1/2) + EPS Update Type (1/2)
     }
@@ -560,7 +556,7 @@ void MmeNasUtils::decode_tau_req(unsigned char *msg, int &nas_msg_len,
         case NAS_IE_TYPE_UE_NETWORK_CAPABILITY:
         {
             log_msg(LOG_DEBUG,
-                    "NAS TAU REQ - UE Network capability : Handling.\n");
+                    "NAS TAU REQ - UE Network capability : Handling.");
             nas->elements[index].msgType = NAS_IE_TYPE_UE_NETWORK_CAPABILITY;
             msg++; //skipping Element ID
             datalen = msg[0];
@@ -649,7 +645,7 @@ void MmeNasUtils::decode_tau_req(unsigned char *msg, int &nas_msg_len,
         }
         default:
         {
-            log_msg(LOG_WARNING, "NAS TAU REQ - Unhandled IE %x\n", elem_id);
+            log_msg(LOG_WARNING, "NAS TAU REQ - Unhandled IE %x", elem_id);
 
             // set status to false to break out of while
             status = false;
@@ -698,7 +694,7 @@ void MmeNasUtils::decode_act_ded_br_ctxt_acpt(unsigned char *msg, int& nas_msg_l
 		}
 		default:
         	{
-            		log_msg(LOG_WARNING, "NAS ACT_DED_BR_CTXT_ACPT - Unhandled IE %x\n", elem_id);
+            		log_msg(LOG_WARNING, "NAS ACT_DED_BR_CTXT_ACPT - Unhandled IE %x", elem_id);
 
             		// set status to false to break out of while
             		status = false;
@@ -740,7 +736,7 @@ void MmeNasUtils::decode_act_ded_br_ctxt_rjct(unsigned char *msg, int& nas_msg_l
             }
             default:
             {
-                log_msg(LOG_WARNING, "NAS ACT_DED_BR_CTXT_RJCT - Unhandled IE %x\n", elem_id);
+                log_msg(LOG_WARNING, "NAS ACT_DED_BR_CTXT_RJCT - Unhandled IE %x", elem_id);
 
                 // set status to false to break out of while
                 status = false;
@@ -793,7 +789,7 @@ void MmeNasUtils::decode_deact_ded_br_ctxt_acpt(unsigned char *msg,
             default:
             {
                 log_msg(LOG_WARNING,
-                        "NAS DEACT_DED_BR_CTXT_ACPT - Unhandled IE %x\n",
+                        "NAS DEACT_DED_BR_CTXT_ACPT - Unhandled IE %x",
                         elem_id);
 
                 // set status to false to break out of while
@@ -809,7 +805,7 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
    	unsigned short msg_len = nas_msg_len;
 
    	unsigned char *bufflog = NULL;
-   	log_msg(LOG_INFO, "NAS PDU msg: %s\n", msg_to_hex_str(msg, msg_len, &bufflog));
+   	log_msg(LOG_INFO, "NAS PDU msg: %s", msg_to_hex_str(msg, msg_len, &bufflog));
    	log_buffer_free(&bufflog);
 
    	nas_pdu_header_sec nas_header_sec;
@@ -823,14 +819,14 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
    	sec_header_type = (msg[0] >> 4) & 0x0F;
    	protocol_discr = msg[0] & 0x0F;
    	unsigned char is_ESM = ((unsigned short)protocol_discr == 0x02);  // see TS 24.007
-   	log_msg(LOG_INFO, "Security header=%d\n", sec_header_type);
-   	log_msg(LOG_INFO, "Protocol discriminator=%d\n", protocol_discr);
-   	log_msg(LOG_INFO, "is_ESM=%d\n", is_ESM);
+   	log_msg(LOG_INFO, "Security header=%d", sec_header_type);
+   	log_msg(LOG_INFO, "Protocol discriminator=%d", protocol_discr);
+   	log_msg(LOG_INFO, "is_ESM=%d", is_ESM);
 
     unsigned char *buffer = NULL;
     if(0 != sec_header_type) 
 	{ /*security header*/
-        log_msg(LOG_INFO, "Security header\n");
+        log_msg(LOG_INFO, "Security header");
         if(SERVICE_REQ_SECURITY_HEADER == sec_header_type)
         {
                 log_msg(LOG_INFO, "Recvd security header for Service request.");
@@ -849,19 +845,19 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
             memcpy(&nas_header_sec, msg, sizeof(nas_pdu_header_sec));
             if((sec_header_type == 1)||(sec_header_type = 2))
             {
-                log_msg(LOG_DEBUG,"header type Integrity protected.\n");
-                log_msg(LOG_INFO, "seq no=%x\n", nas_header_sec.seq_no);
+                log_msg(LOG_DEBUG,"header type Integrity protected.");
+                log_msg(LOG_INFO, "seq no=%x", nas_header_sec.seq_no);
                 nas->header.seq_no = nas_header_sec.seq_no; 
                 unsigned char *msg_ptr = msg + 6;
 
                 sec_header_type = msg_ptr[0] >> 4;
                 protocol_discr = msg_ptr[0] & 0x0F;
                 unsigned char is_EMM = ((unsigned short)protocol_discr == 0x07);  // see TS 24.007
-                log_msg(LOG_INFO, "Security header=%d\n", sec_header_type);
-                log_msg(LOG_INFO, "Protocol discriminator=%d\n", protocol_discr);
-                log_msg(LOG_INFO, "is_EMM=%d\n", is_EMM);
+                log_msg(LOG_INFO, "Security header=%d", sec_header_type);
+                log_msg(LOG_INFO, "Protocol discriminator=%d", protocol_discr);
+                log_msg(LOG_INFO, "is_EMM=%d", is_EMM);
                 if(is_EMM){
-                    log_msg(LOG_INFO, "NAS PDU is EMM\n");
+                    log_msg(LOG_INFO, "NAS PDU is EMM");
                     memcpy(&nas_header_short, msg_ptr, sizeof(nas_header_short)); /*copy only till msg type*/
                     msg_ptr += 2;
 
@@ -876,7 +872,7 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
                    || (TauRequest == nas->header.message_type)
                    || (DetachRequest == nas->header.message_type))
                 {
-                    log_msg(LOG_DEBUG,"No Need for mac check.\n");
+                    log_msg(LOG_DEBUG,"No Need for mac check.");
                     skip_mac_check = true;
                 }
             }
@@ -891,9 +887,9 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
                 initial_ue_msg_t *init = (initial_ue_msg_t*)msg_data;
                 int32_t tmsi = ntohl(init->s_tmsi.m_TMSI);
                 init->header.ue_idx = tmsi; // copy tmsi as UE id. 
-                log_msg(LOG_DEBUG,"TMSI : %u\n", tmsi);
+                log_msg(LOG_DEBUG,"TMSI : %u", tmsi);
 			    uint32_t cbIndex = SubsDataGroupManager::Instance()->findCBWithmTmsi(tmsi);
-                log_msg(LOG_DEBUG,"cb_index : %u\n", cbIndex);
+                log_msg(LOG_DEBUG,"cb_index : %u", cbIndex);
                 controlBlk_p = 
                     SubsDataGroupManager::Instance()->findControlBlock(cbIndex);
                 if(controlBlk_p != NULL)
@@ -905,7 +901,7 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
                     {
                         Secinfo &secContext = ueCtxt_p->getUeSecInfo();
                         unsigned char *bufflog = NULL;
-                        log_msg(LOG_INFO, "mac=%s\n", 
+                        log_msg(LOG_INFO, "mac=%s", 
                                 msg_to_hex_str(
                                    (unsigned char *)nas->header.short_mac, 
                                     SHORT_MAC_SIZE, &bufflog));
@@ -926,17 +922,17 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
                                       direction, bearer, buffer, buf_len,
                                       calc_mac, int_alg);
 
-                        log_msg(LOG_DEBUG, "Check Service Req Short mac.\n");
+                        log_msg(LOG_DEBUG, "Check Service Req Short mac.");
                         unsigned char short_mac_local[SHORT_MAC_SIZE] = {0};
                         bufflog = NULL;
-                        log_msg(LOG_INFO, "calcmac=%s\n", 
+                        log_msg(LOG_INFO, "calcmac=%s", 
                                 msg_to_hex_str(
                                    (unsigned char *)calc_mac, 
                                     MAC_SIZE, &bufflog));
                         log_buffer_free(&bufflog);
                         macPtr = calc_mac + 2;
                         memcpy(short_mac_local, macPtr, SHORT_MAC_SIZE);
-                        log_msg(LOG_INFO, "short calc mac=%s\n", 
+                        log_msg(LOG_INFO, "short calc mac=%s", 
                                 msg_to_hex_str(
                                    (unsigned char *)short_mac_local, 
                                     SHORT_MAC_SIZE, &bufflog));
@@ -944,29 +940,29 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
                         if(memcmp(nas->header.short_mac, 
                                   short_mac_local, SHORT_MAC_SIZE))
                         {
-                            log_msg(LOG_ERROR,"Service Request :  MAC not matching. Fail msg.\n");
+                            log_msg(LOG_ERROR,"Service Request :  MAC not matching. Fail msg.");
                             return E_FAIL;
                         }
 
-                        log_msg(LOG_DEBUG, "MAC matched for service req.\n");
+                        log_msg(LOG_DEBUG, "MAC matched for service req.");
                         secContext.increment_uplink_count();
                         return SUCCESS;
                     }
                     else
                     {
-                        log_msg(LOG_DEBUG, "No Ue context.\n");
+                        log_msg(LOG_DEBUG, "No Ue context.");
                         return E_FAIL;
                     }
                 }
                 else
                 {
-                    log_msg(LOG_ERROR,"Control block not found\n");
+                    log_msg(LOG_ERROR,"Control block not found");
                     return SUCCESS;
                 }
             }
             else
             {
-                log_msg(LOG_DEBUG,"ue_idx : %u\n", msg_data->ue_idx);
+                log_msg(LOG_DEBUG,"ue_idx : %u", msg_data->ue_idx);
                 controlBlk_p = 
                     SubsDataGroupManager::Instance()->findControlBlock(
                                                             msg_data->ue_idx);
@@ -979,7 +975,7 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
                     {
                         Secinfo &secContext = ueCtxt_p->getUeSecInfo();
                         unsigned char *bufflog = NULL;
-                        log_msg(LOG_INFO, "mac=%s\n", msg_to_hex_str((unsigned char *)nas_header_sec.mac, MAC_SIZE, &bufflog));
+                        log_msg(LOG_INFO, "mac=%s", msg_to_hex_str((unsigned char *)nas_header_sec.mac, MAC_SIZE, &bufflog));
                         log_buffer_free(&bufflog);
                         /* calculate mac and compare with received mac */
                         unsigned char int_key[NAS_INT_KEY_SIZE];
@@ -997,40 +993,40 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
                                       direction, bearer, buffer, buf_len,
                                       calc_mac, int_alg);
                         bufflog = NULL;
-                        log_msg(LOG_INFO, "calcmac=%s\n", 
+                        log_msg(LOG_INFO, "calcmac=%s", 
                                 msg_to_hex_str(
                                                (unsigned char *)calc_mac, 
                                                MAC_SIZE, &bufflog));
                         log_buffer_free(&bufflog);
                         if(memcmp(nas_header_sec.mac, calc_mac, MAC_SIZE))
                         {
-                            log_msg(LOG_ERROR,"MAC not matching. Fail msg.\n");
+                            log_msg(LOG_ERROR,"MAC not matching. Fail msg.");
                             return E_FAIL;
                         }
                             
-                        log_msg(LOG_DEBUG, "MAC matched.\n");
+                        log_msg(LOG_DEBUG, "MAC matched.");
                         secContext.increment_uplink_count();
                     }
                 }
                 else
                 {
-                    log_msg(LOG_ERROR,"Control block not found\n");
+                    log_msg(LOG_ERROR,"Control block not found");
                 }
             }
         }
         
-        log_msg(LOG_INFO, "seq no=%x\n", nas_header_sec.seq_no);
+        log_msg(LOG_INFO, "seq no=%x", nas_header_sec.seq_no);
         nas->header.seq_no = nas_header_sec.seq_no; 
         msg += 6;
 
         sec_header_type = msg[0] >> 4;
         protocol_discr = msg[0] & 0x0F;
         unsigned char is_ESM = ((unsigned short)protocol_discr == 0x02);  // see TS 24.007
-        log_msg(LOG_INFO, "Security header=%d\n", sec_header_type);
-        log_msg(LOG_INFO, "Protocol discriminator=%d\n", protocol_discr);
-        log_msg(LOG_INFO, "is_ESM=%d\n", is_ESM);
+        log_msg(LOG_INFO, "Security header=%d", sec_header_type);
+        log_msg(LOG_INFO, "Protocol discriminator=%d", protocol_discr);
+        log_msg(LOG_INFO, "is_ESM=%d", is_ESM);
         if (is_ESM) {
-                log_msg(LOG_INFO, "NAS PDU is ESM\n");
+                log_msg(LOG_INFO, "NAS PDU is ESM");
                 memcpy(&nas_header_long, msg, sizeof(nas_header_long)); /*copy only till msg type*/
                 msg += 3;
 
@@ -1039,7 +1035,7 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
                 nas->header.procedure_trans_identity = nas_header_long.procedure_trans_identity;
                 nas->header.message_type = nas_header_long.message_type;
         } else {
-                log_msg(LOG_INFO, "NAS PDU is EMM\n");
+                log_msg(LOG_INFO, "NAS PDU is EMM");
                 memcpy(&nas_header_short, msg, sizeof(nas_header_short)); /*copy only till msg type*/
                 msg += 2;
 
@@ -1050,7 +1046,7 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
     } 
 	else 
 	{
-        log_msg(LOG_INFO, "No security header\n");
+        log_msg(LOG_INFO, "No security header");
         memcpy(&nas_header_short, msg, sizeof(nas_header_short)); /*copy only till msg type*/
         msg += 2;
 
@@ -1060,13 +1056,13 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
     }
 
 
-    log_msg(LOG_INFO, "Nas msg type: %X\n", nas->header.message_type);
+    log_msg(LOG_INFO, "Nas msg type: %X", nas->header.message_type);
 
     switch(nas->header.message_type) 
     {
         case ESMInformationResponse:
 		{
-            log_msg(LOG_INFO, "NAS_ESM_RESP recvd\n");
+            log_msg(LOG_INFO, "NAS_ESM_RESP recvd");
 
             unsigned char element_id;
             memcpy(&element_id, msg, 1);
@@ -1079,31 +1075,31 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
             memcpy(&(nas->elements[0].pduElement.apn.len), msg, 1);
             msg++;
             memcpy(nas->elements[0].pduElement.apn.val, msg, nas->elements[0].pduElement.apn.len);
-            log_msg(LOG_INFO, "APN name - %s\n", nas->elements[0].pduElement.apn.val);
+            log_msg(LOG_INFO, "APN name - %s", nas->elements[0].pduElement.apn.val);
             break;
         }
 
         case SecurityModeComplete:
 		{
-            log_msg(LOG_INFO, "NAS_SEC_MODE_COMPLETE recvd\n");
+            log_msg(LOG_INFO, "NAS_SEC_MODE_COMPLETE recvd");
             break;
 		}
 
         case AuthenticationResponse:
 		{
-            log_msg(LOG_INFO, "NAS_AUTH_RESP recvd\n");
+            log_msg(LOG_INFO, "NAS_AUTH_RESP recvd");
             nas->elements_len = 1;
             nas->elements = (nas_pdu_elements *)calloc(sizeof(nas_pdu_elements), 5);
             //if(NULL == nas.elements)...
             memcpy(&(nas->elements[0].pduElement.auth_resp), msg, sizeof(struct XRES));
             uint64_t res = *(uint64_t *)(&nas->elements[0].pduElement.auth_resp.val);
-            log_msg(LOG_INFO, "NAS_AUTH_RESP recvd len %d %lu\n",nas->elements[0].pduElement.auth_resp.len,res);
+            log_msg(LOG_INFO, "NAS_AUTH_RESP recvd len %d %lu",nas->elements[0].pduElement.auth_resp.len,res);
             break;
 		}
 
         case IdentityResponse:
 		{
-            log_msg(LOG_INFO, "NAS_IDENTITY_RESPONSE recvd\n");
+            log_msg(LOG_INFO, "NAS_IDENTITY_RESPONSE recvd");
             nas->elements_len = 1;
             nas->elements = (nas_pdu_elements *)calloc(sizeof(nas_pdu_elements), 1);
             unsigned short imsi_len = get_length(&msg);
@@ -1114,7 +1110,7 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
 
         case TauRequest:
         {
-            log_msg(LOG_INFO, "NAS_TAU_REQUEST recvd\n");
+            log_msg(LOG_INFO, "NAS_TAU_REQUEST recvd");
 	        MmeNasUtils::decode_tau_req(msg, nas_msg_len, nas);
 	        break;
 	    }
@@ -1140,28 +1136,28 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
         }
         case AttachRequest:
         {
-            log_msg(LOG_INFO, "NAS_ATTACH_REQUEST recvd\n");
+            log_msg(LOG_INFO, "NAS_ATTACH_REQUEST recvd");
 	        MmeNasUtils::decode_attach_req(msg, nas_msg_len, nas);
 	        break;
         }
         case AttachComplete:
 		{
-            log_msg(LOG_INFO, "NAS_ATTACH_COMPLETE recvd\n");
+            log_msg(LOG_INFO, "NAS_ATTACH_COMPLETE recvd");
             /*Other than error check there seems no information to pass to mme. Marking TODO for protocol study*/
             break;
 		}
         case DetachRequest:
         {
-            log_msg(LOG_INFO, "NAS_DETACH_REQUEST recvd\n");
+            log_msg(LOG_INFO, "NAS_DETACH_REQUEST recvd");
             nas->elements_len = 1;
             nas->elements = (nas_pdu_elements *) calloc(sizeof(nas_pdu_elements), 1);
 
             /*EPS mobility identity*/
             unsigned char eps_identity = msg[2] & 0x07;
-            log_msg(LOG_INFO, "NAS Detach Request Rcvd :  %d %d %d %d, eps id %d\n", msg[0],msg[1],msg[2],msg[4],eps_identity); 
+            log_msg(LOG_INFO, "NAS Detach Request Rcvd :  %d %d %d %d, eps id %d", msg[0],msg[1],msg[2],msg[4],eps_identity); 
             if(eps_identity == 0x06)
             {
-                log_msg(LOG_INFO, "Mobile identity GUTI Rcvd \n");
+                log_msg(LOG_INFO, "Mobile identity GUTI Rcvd ");
                 // Mobile Identity contains GUTI
                 // MCC+MNC offset = 3
                 // MME Group Id   = 2
@@ -1172,10 +1168,10 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
                 nas->elements[0].pduElement.mi_guti.mme_grp_id = ntohs(*(short int *)(&msg[6]));
                 nas->elements[0].pduElement.mi_guti.mme_code = msg[8];
                 nas->elements[0].pduElement.mi_guti.m_TMSI = ntohl(*((unsigned int *)(&msg[9])));
-                log_msg(LOG_INFO, "NAS Detach Request Rcvd ID: GUTI. PLMN id %d %d %d \n", nas->elements[0].pduElement.mi_guti.plmn_id.idx[0], 
+                log_msg(LOG_INFO, "NAS Detach Request Rcvd ID: GUTI. PLMN id %d %d %d ", nas->elements[0].pduElement.mi_guti.plmn_id.idx[0], 
                                 nas->elements[0].pduElement.mi_guti.plmn_id.idx[1], 
                                 nas->elements[0].pduElement.mi_guti.plmn_id.idx[2] );
-                log_msg(LOG_INFO, "NAS Detach Request Rcvd ID: GUTI. mme group id = %d, MME code %d  mtmsi = %d\n", 
+                log_msg(LOG_INFO, "NAS Detach Request Rcvd ID: GUTI. mme group id = %d, MME code %d  mtmsi = %d", 
                                 nas->elements[0].pduElement.mi_guti.mme_grp_id, 
                                 nas->elements[0].pduElement.mi_guti.mme_code,
                                 nas->elements[0].pduElement.mi_guti.m_TMSI);
@@ -1185,31 +1181,31 @@ int MmeNasUtils::parse_nas_pdu(s1_incoming_msg_header_t* msg_data, unsigned char
         }
         case DetachAccept:
 		{
-            log_msg(LOG_INFO, "NAS_DETACH_ACCEPT recvd\n");
+            log_msg(LOG_INFO, "NAS_DETACH_ACCEPT recvd");
             break;
         }
 	case ActivateDedicatedBearerContextAccept:
 	{
-	    log_msg(LOG_INFO, "NAS_ACT_DED_BEARER_CTXT_ACPT recvd\n");
+	    log_msg(LOG_INFO, "NAS_ACT_DED_BEARER_CTXT_ACPT recvd");
 	    MmeNasUtils::decode_act_ded_br_ctxt_acpt(msg, nas_msg_len, nas);
 	    break;
 	}
 	case ActivateDedicatedBearerContextReject:
 	{
-	    log_msg(LOG_INFO, "NAS_ACT_DED_BEARER_CTXT_RJCT received\n");
+	    log_msg(LOG_INFO, "NAS_ACT_DED_BEARER_CTXT_RJCT received");
 	    MmeNasUtils::decode_act_ded_br_ctxt_rjct(msg, nas_msg_len, nas);
 	    break;
 	}
         case DeactivateEPSBearerContextAccept:
         {
-            log_msg(LOG_INFO, "NAS_DEACT_DED_BEARER_CTXT_ACPT recvd\n");
+            log_msg(LOG_INFO, "NAS_DEACT_DED_BEARER_CTXT_ACPT recvd");
             MmeNasUtils::decode_deact_ded_br_ctxt_acpt(msg, nas_msg_len, nas);
             break;
         }
 
         default:
 		{
-            log_msg(LOG_ERROR, "Unknown NAS Message type- 0x%x\n", nas->header.message_type);
+            log_msg(LOG_ERROR, "Unknown NAS Message type- 0x%x", nas->header.message_type);
             break;
 
         }
@@ -1226,7 +1222,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		{
             ue_attach_info_t attach_req = {0};
             initial_ue_msg_t *init = (initial_ue_msg_t*)s1Msg;
-			log_msg(LOG_INFO, "Copy Required details of message ATTACH REQUEST\n");
+			log_msg(LOG_INFO, "Copy Required details of message ATTACH REQUEST");
     		int nas_index = 0;
             attach_req.header = *s1Msg; // copy header 
 			attach_req.header.msg_type = msg_type_t::attach_request;
@@ -1241,7 +1237,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
             // copy nas AVPs
 			while(nas_index < nas->elements_len)
             {
-                log_msg(LOG_INFO, "nasIndex %d, msgType %d\n", nas_index, nas->elements[nas_index].msgType);
+                log_msg(LOG_DEBUG, "nasIndex %d, msgType %d", nas_index, nas->elements[nas_index].msgType);
                 attach_req.seq_no = nas->header.seq_no;
                 switch(nas->elements[nas_index].msgType)
                 {
@@ -1284,7 +1280,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
                     case NAS_IE_TYPE_TX_FLAG:
                         {
                             attach_req.esm_info_tx_required = nas->elements[nas_index].pduElement.esm_info_tx_required;
-                            log_msg(LOG_INFO, "ESM info flag %d \n", attach_req.esm_info_tx_required);
+                            log_msg(LOG_INFO, "ESM info flag %d ", attach_req.esm_info_tx_required);
                             break;
                         }
                     case NAS_IE_TYPE_PTI:
@@ -1306,7 +1302,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
                         }
                     default:
                         {
-                            log_msg(LOG_INFO, "nas element not handled\n");
+                            log_msg(LOG_INFO, "nas element not handled");
                         }
                 }
 
@@ -1317,7 +1313,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		}
 		case AuthenticationResponse:
 		{
-			log_msg(LOG_INFO, "Copy Required details of message AUTH RESPONSE \n");
+			log_msg(LOG_INFO, "Copy Required details of message AUTH RESPONSE ");
             authresp_Q_msg_t auth_rsp = {0};
             auth_rsp.header = *s1Msg;
 			auth_rsp.header.msg_type = msg_type_t::auth_response;
@@ -1330,7 +1326,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		}
 		case AuthenticationFailure:
 		{
-			log_msg(LOG_INFO, "Copy Required details of message AUTH FAILURE \n");
+			log_msg(LOG_INFO, "Copy Required details of message AUTH FAILURE ");
             authresp_Q_msg_t auth_rsp = {0};
             auth_rsp.header = *s1Msg;
 			auth_rsp.header.msg_type = msg_type_t::auth_response;
@@ -1343,7 +1339,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		}
 		case SecurityModeComplete:
 		{
-			log_msg(LOG_INFO, "Copy Required details of message SEC MODE COMPLETE \n");
+			log_msg(LOG_INFO, "Copy Required details of message SEC MODE COMPLETE ");
             secmode_resp_Q_msg_t *sec_rsp = (secmode_resp_Q_msg_t *)s1Msg;
 			sec_rsp->header.msg_type = msg_type_t::sec_mode_complete;
             sec_rsp->status = SUCCESS;
@@ -1352,7 +1348,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		case ESMInformationResponse:
 		{
             esm_resp_Q_msg_t esm_resp = {0};
-			log_msg(LOG_INFO, "Copy Required details of message ESM RESPONSE \n");
+			log_msg(LOG_INFO, "Copy Required details of message ESM RESPONSE ");
             uplink_nas_t *ulMsg = (uplink_nas_t*)s1Msg;
 			ulMsg->header.msg_type = msg_type_t::esm_info_response;
             esm_resp.header = *s1Msg;
@@ -1364,7 +1360,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		}
 		case AttachComplete:
 		{
-			log_msg(LOG_INFO, "Copy Required details of message ATTACH COMPLETE \n");
+			log_msg(LOG_INFO, "Copy Required details of message ATTACH COMPLETE ");
             attach_complete_Q_msg_t att_cmp = {0}; 
             att_cmp.header = *s1Msg;
 			att_cmp.header.msg_type = msg_type_t::attach_complete;
@@ -1374,7 +1370,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		}
 		case ServiceRequest:
 		{
-			log_msg(LOG_INFO, "Copy Required details of message SERVICE REQUEST \n");
+			log_msg(LOG_INFO, "Copy Required details of message SERVICE REQUEST ");
             service_req_Q_msg_t serv_req = {0}; 
 	        initial_ue_msg_t *init = (initial_ue_msg_t*)(s1Msg);
             serv_req.header = *s1Msg;
@@ -1397,7 +1393,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		case DetachRequest:
 		{
             detach_req_Q_msg_t det_req = {0};
-			log_msg(LOG_INFO, "Copy Required details of message DETACH REQUEST \n");
+			log_msg(LOG_INFO, "Copy Required details of message DETACH REQUEST ");
             det_req.header = *s1Msg;
 			det_req.header.msg_type = msg_type_t::detach_request;
 		   	det_req.ue_m_tmsi = nas->elements[0].pduElement.mi_guti.m_TMSI;
@@ -1406,14 +1402,14 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		}
 		case DetachAccept:
 		{
-			log_msg(LOG_INFO, "Copy Required details of message DETACH ACCEPT \n");
+			log_msg(LOG_INFO, "Copy Required details of message DETACH ACCEPT ");
 			s1Msg->msg_type = msg_type_t::detach_accept_from_ue;
 			break;
 		}
 		case TauRequest:
 		{
             tauReq_Q_msg_t tau_req  = {0};
-			log_msg(LOG_INFO, "Copy Required details of message TAU REQUEST \n");
+			log_msg(LOG_INFO, "Copy Required details of message TAU REQUEST ");
             int nas_index = 0;
             tau_req.header = *s1Msg;
 
@@ -1431,7 +1427,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 
             while (nas_index < nas->elements_len)
             {
-                log_msg(LOG_INFO, "nasIndex %d, msgType %d\n", nas_index, nas->elements[nas_index].msgType);
+                log_msg(LOG_INFO, "nasIndex %d, msgType %d", nas_index, nas->elements[nas_index].msgType);
                 tau_req.seq_num = nas->header.seq_no;
                 switch (nas->elements[nas_index].msgType)
                 {
@@ -1443,7 +1439,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 				    }
                     case NAS_IE_TYPE_UE_NETWORK_CAPABILITY:
                     {
-                        log_msg(LOG_DEBUG, "NAS_IE_TYPE_UE_NETWORK_CAPABILITY\n");
+                        log_msg(LOG_DEBUG, "NAS_IE_TYPE_UE_NETWORK_CAPABILITY");
                         tau_req.ue_net_capab.len = nas->elements[nas_index].pduElement.ue_network.len;
                         memcpy(&(tau_req.ue_net_capab.u.octets),
                             	&(nas->elements[nas_index].pduElement.ue_network.u.octets),
@@ -1460,7 +1456,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
                     }
                     default:
                     {
-                       log_msg(LOG_INFO, "nas element %d not handled\n", nas->elements[nas_index].msgType );
+                       log_msg(LOG_INFO, "nas element %d not handled", nas->elements[nas_index].msgType );
                     }
                	}
                 nas_index++;
@@ -1471,7 +1467,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		case IdentityResponse:
 		{
             identityResp_Q_msg_t id_rsp = {0};
-			log_msg(LOG_INFO, "Copy Required details of message IDENTITY RESPONSE \n");
+			log_msg(LOG_INFO, "Copy Required details of message IDENTITY RESPONSE ");
             id_rsp.header = *s1Msg;
 			id_rsp.header.msg_type = msg_type_t::id_response;
             id_rsp.status = SUCCESS;
@@ -1486,7 +1482,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		case ActivateDedicatedBearerContextAccept:
 		{
             dedicatedBearerContextAccept_Q_msg_t act_ded_br_accept = {0};
-	        log_msg(LOG_INFO, "Copy Required details of NAS_ACT_DED_BEARER_CTXT_ACPT\n");
+	        log_msg(LOG_INFO, "Copy Required details of NAS_ACT_DED_BEARER_CTXT_ACPT");
 
             act_ded_br_accept.header = *s1Msg;
 		    act_ded_br_accept.header.msg_type = msg_type_t::activate_dedicated_eps_bearer_ctxt_accept;
@@ -1496,7 +1492,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		    int nas_index = 0;
 		    while (nas_index < nas->elements_len)
             {
-                log_msg(LOG_INFO, "nasIndex %d, msgType %d\n", nas_index, nas->elements[nas_index].msgType);
+                log_msg(LOG_INFO, "nasIndex %d, msgType %d", nas_index, nas->elements[nas_index].msgType);
 			    switch (nas->elements[nas_index].msgType)
                 {
 			        case NAS_IE_TYPE_PCO:
@@ -1510,7 +1506,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 			        }
 			        default:
                     {
-                        log_msg(LOG_INFO, "nas element %d not handled\n", nas->elements[nas_index].msgType );
+                        log_msg(LOG_INFO, "nas element %d not handled", nas->elements[nas_index].msgType );
                     }
 			    }
 			    nas_index++;
@@ -1520,7 +1516,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		}
 		case ActivateDedicatedBearerContextReject:
 		{
-	    	log_msg(LOG_INFO, "Copy Required details of NAS_ACT_DED_BEARER_CTXT_RJCT\n");
+	    	log_msg(LOG_INFO, "Copy Required details of NAS_ACT_DED_BEARER_CTXT_RJCT");
             dedicatedBearerContextReject_Q_msg_t act_ded_br_reject = {0};
             act_ded_br_reject.header = *s1Msg;
 	    	act_ded_br_reject.header.msg_type = msg_type_t::activate_dedicated_eps_bearer_ctxt_reject;
@@ -1530,7 +1526,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 		    int nas_index = 0;
 		    while (nas_index < nas->elements_len)
             {
-                log_msg(LOG_INFO, "nasIndex %d, msgType %d\n", nas_index, nas->elements[nas_index].msgType);
+                log_msg(LOG_INFO, "nasIndex %d, msgType %d", nas_index, nas->elements[nas_index].msgType);
                 switch (nas->elements[nas_index].msgType)
                 {
 			        case NAS_IE_TYPE_ESM_CAUSE:
@@ -1540,7 +1536,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 			        }
 			        default:
                     {
-                        log_msg(LOG_INFO, "nas element %d not handled\n", nas->elements[nas_index].msgType );
+                        log_msg(LOG_INFO, "nas element %d not handled", nas->elements[nas_index].msgType );
                     }
                 }
                 nas_index++;
@@ -1550,7 +1546,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
         }
         case DeactivateEPSBearerContextAccept:
         {
-            log_msg(LOG_INFO, "Copy Required details of NAS_DEACT_DED_BEARER_CTXT_ACPT\n");
+            log_msg(LOG_INFO, "Copy Required details of NAS_DEACT_DED_BEARER_CTXT_ACPT");
             deactivate_epsbearerctx_accept_Q_msg_t deact_bearer_accept = {0};
             int nas_index = 0;
             deact_bearer_accept.header = *s1Msg;
@@ -1560,7 +1556,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
 
             while(nas_index < nas->elements_len)
             {
-                log_msg(LOG_INFO, "nasIndex %d, msgType %d\n", nas_index, nas->elements[nas_index].msgType);
+                log_msg(LOG_INFO, "nasIndex %d, msgType %d", nas_index, nas->elements[nas_index].msgType);
                 switch (nas->elements[nas_index].msgType)
                 {
         	        case NAS_IE_TYPE_PCO:
@@ -1575,7 +1571,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
         	        }
         	        default:
         	        {
-            	        log_msg(LOG_INFO, "nas element %d not handled\n",
+            	        log_msg(LOG_INFO, "nas element %d not handled",
                     	    nas->elements[nas_index].msgType);
         	        }
                 }
@@ -1586,7 +1582,7 @@ void MmeNasUtils::copy_nas_to_s1msg(struct nasPDU *nas, s1_incoming_msg_header_t
         }
 		default:
 		{
-			log_msg(LOG_INFO, "Copy Required details of message ATTACH REQUEST\n");
+			log_msg(LOG_INFO, "Copy Required details of message ATTACH REQUEST");
 			s1Msg->msg_type = attach_request;
 			break;
 		}
@@ -2033,7 +2029,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 	{
 		case AuthenticationRequest:
 		{
-			log_msg(LOG_DEBUG, "Encoding Authentication Request NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding Authentication Request NAS message in mme-app");
 			uint8_t value = (nas->header.security_header_type) | nas->header.proto_discriminator;
 			nasBuffer->pos = 0;
 			buffer_copy(nasBuffer, &value, sizeof(value));
@@ -2049,7 +2045,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case ESMInformationRequest: 
 		{
-			log_msg(LOG_DEBUG, "Encoding ESM information request NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding ESM information request NAS message in mme-app");
 			nasBuffer->pos = 0;
 			unsigned char value = (nas->header.security_header_type << 4 | nas->header.proto_discriminator);
 			buffer_copy(nasBuffer, &value, sizeof(value));
@@ -2076,7 +2072,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case SecurityModeCommand: 
 		{
-			log_msg(LOG_DEBUG, "Encoding Security Mode Command NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding Security Mode Command NAS message in mme-app");
 			nasBuffer->pos = 0;
 			unsigned char value = (nas->header.security_header_type << 4 | nas->header.proto_discriminator);
 			buffer_copy(nasBuffer, &value, sizeof(value));
@@ -2128,7 +2124,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case AttachAccept: 
 		{
-			log_msg(LOG_DEBUG, "Encoding Attach Accept NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding Attach Accept NAS message in mme-app");
 			nasBuffer->pos = 0;
 			unsigned char value = (nas->header.security_header_type << 4 | nas->header.proto_discriminator);
 			buffer_copy(nasBuffer, &value, sizeof(value));
@@ -2315,7 +2311,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case EMMInformation:
 		{
-			log_msg(LOG_DEBUG, "Encoding EMM informaton NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding EMM informaton NAS message in mme-app");
     		nasBuffer->pos = 0; 
     		unsigned char nas_sec_hdr[1] = { 0x27}; 
     		buffer_copy(nasBuffer, nas_sec_hdr, 1);
@@ -2355,7 +2351,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case IdentityRequest:
 		{
-			log_msg(LOG_DEBUG, "Encoding Identity Request NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding Identity Request NAS message in mme-app");
 			uint8_t value = (nas->header.security_header_type) | nas->header.proto_discriminator;
 			nasBuffer->pos = 0;
 			buffer_copy(nasBuffer, &value, sizeof(value));
@@ -2365,7 +2361,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case DetachAccept:
 		{
-			log_msg(LOG_DEBUG, "Encoding detach Accept NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding detach Accept NAS message in mme-app");
 			nasBuffer->pos = 0;
 			unsigned char value = (nas->header.security_header_type << 4 | nas->header.proto_discriminator);
 			buffer_copy(nasBuffer, &value, sizeof(value));
@@ -2392,7 +2388,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case DetachRequest:
 		{
-			log_msg(LOG_DEBUG, "Encoding detach request NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding detach request NAS message in mme-app");
 			nasBuffer->pos = 0;
 			unsigned char value = (nas->header.security_header_type << 4 | nas->header.proto_discriminator);
 			buffer_copy(nasBuffer, &value, sizeof(value));
@@ -2425,7 +2421,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case AttachReject:
 		{
-			log_msg(LOG_DEBUG, "Encoding Attach Reject NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding Attach Reject NAS message in mme-app");
 			uint8_t value = (nas->header.security_header_type) | nas->header.proto_discriminator;
 			nasBuffer->pos = 0;
 			buffer_copy(nasBuffer, &value, sizeof(value));
@@ -2435,7 +2431,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case ServiceReject:
 		{
-			log_msg(LOG_DEBUG, "Encoding Service Reject NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding Service Reject NAS message in mme-app");
 			uint8_t value = (nas->header.security_header_type) | nas->header.proto_discriminator;
 			nasBuffer->pos = 0;
 			buffer_copy(nasBuffer, &value, sizeof(value));
@@ -2445,7 +2441,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case TauAccept:
 		{
-			log_msg(LOG_DEBUG, "Encoding TAU Accept NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding TAU Accept NAS message in mme-app");
 			nasBuffer->pos = 0;
 			unsigned char value = (nas->header.security_header_type << 4 | nas->header.proto_discriminator);
 			buffer_copy(nasBuffer, &value, sizeof(value));
@@ -2521,7 +2517,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
 		case ActivateDedicatedBearerContextRequest:
 		{
-			log_msg(LOG_DEBUG, "Encoding Activate Dedicated Bearer Context Req NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding Activate Dedicated Bearer Context Req NAS message in mme-app");
 			uint8_t mac_data_pos = MmeNasUtils::encode_act_ded_br_req(nasBuffer, nas);
 			
 			/* Calculate mac */
@@ -2538,7 +2534,7 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
 		}
         	case DeactivateEPSBearerContextRequest:
         	{
-            		log_msg(LOG_DEBUG, "Encoding deactivate Dedicated Bearer Context Req NAS message in mme-app\n");
+            		log_msg(LOG_DEBUG, "Encoding deactivate Dedicated Bearer Context Req NAS message in mme-app");
             		uint8_t mac_data_pos = MmeNasUtils::encode_deact_ded_br_req(nasBuffer, nas);
 
             		/* Calculate mac */
@@ -2554,6 +2550,6 @@ void MmeNasUtils::encode_nas_msg(struct Buffer *nasBuffer, struct nasPDU *nas, S
             		break;
         	}
 		default:
-			log_msg(LOG_DEBUG, "Encoding Authentication Request NAS message in mme-app\n");
+			log_msg(LOG_DEBUG, "Encoding Authentication Request NAS message in mme-app");
 	}
 }

--- a/src/mme-app/utils/mmeS1MsgUtils.cpp
+++ b/src/mme-app/utils/mmeS1MsgUtils.cpp
@@ -34,7 +34,7 @@ void MmeS1MsgUtils::populateHoRequest(SM::ControlBlock& cb,
     if(sessionCtxtContainer.size() < 1)
     {
         log_msg(LOG_DEBUG,
-		" send_ho_request_to_target_enb:Session context list is empty\n");
+		" send_ho_request_to_target_enb:Session context list is empty");
 	return;
     }
 
@@ -42,7 +42,7 @@ void MmeS1MsgUtils::populateHoRequest(SM::ControlBlock& cb,
     BearerContext *bearerCtxt = sessionCtxt->findBearerContextByBearerId(sessionCtxt->getLinkedBearerId());
     if (bearerCtxt == NULL)
     {
-        log_msg(LOG_ERROR, "Failed to retrieve Bearer context for UE IDx %d\n",
+        log_msg(LOG_ERROR, "Failed to retrieve Bearer context for UE IDx %d",
                 cb.getCBIndex());
         return;
     }
@@ -139,7 +139,7 @@ bool MmeS1MsgUtils::populateErabSetupAndActDedBrReq(SM::ControlBlock &cb,
 
     SessionContext *sess_p = ueCtxt.findSessionContextByLinkedBearerId(procCtxt.getBearerId());
     VERIFY(sess_p, procCtxt.setMmeErrorCause(SESSION_CONTEXT_NOT_FOUND);
-        return false, "Session Context is NULL\n");
+        return false, "Session Context is NULL");
 
     auto& cbBearerStatusCont = procCtxt.getBearerStatusContainer();
 

--- a/src/mme-app/utils/mmeTimerUtils.cpp
+++ b/src/mme-app/utils/mmeTimerUtils.cpp
@@ -59,7 +59,7 @@ uint32_t MmeTimerUtils::stopTimer(TimerContext* timerCtxt)
         rc = timeoutMgr.cancelTimer(timerCtxt);
         if (rc > 0)
         {
-            log_msg(LOG_DEBUG, "Timer deleted\n");
+            log_msg(LOG_DEBUG, "Timer deleted");
             delete timerCtxt;
         }
     }
@@ -68,12 +68,12 @@ uint32_t MmeTimerUtils::stopTimer(TimerContext* timerCtxt)
 
 void MmeTimerUtils::onTimeout(TimerContext* timerCtxt)
 {
-    log_msg(LOG_DEBUG, "\n %s : %d \n",__FUNCTION__,__LINE__);
+    log_msg(LOG_DEBUG, " timeout ");
 
     MmeUeTimerContext* mmeTimerCtxt = static_cast<MmeUeTimerContext *>(timerCtxt);
     if (mmeTimerCtxt == NULL)
     {
-        log_msg(LOG_DEBUG, "\n %s : %d invalid mmeTimerCtxt \n",__FUNCTION__,__LINE__);
+        log_msg(LOG_DEBUG, "invalid mmeTimerCtxt ");
         return;
     }
     if(mmeTimerCtxt->getTimerType() == mmeConfigDnsResolve_c)
@@ -84,14 +84,14 @@ void MmeTimerUtils::onTimeout(TimerContext* timerCtxt)
     }
     else if (mmeTimerCtxt->getTimerType() == stateGuardTimer_c)
     {
-        log_msg(LOG_DEBUG, "State Guard Timer expiry \n");
+        log_msg(LOG_DEBUG, "State Guard Timer expiry ");
 
         ControlBlock *controlBlk_p =
                 SubsDataGroupManager::Instance()->findControlBlock(
                         mmeTimerCtxt->getUeIndex());
         if (controlBlk_p == NULL)
         {
-            log_msg(LOG_INFO, "Failed to find UE context using idx %d\n",
+            log_msg(LOG_INFO, "Failed to find UE context using idx %d",
                     mmeTimerCtxt->getUeIndex());
 
             return;

--- a/src/s11/cpp_utils/gtp_cpp_wrapper.cpp
+++ b/src/s11/cpp_utils/gtp_cpp_wrapper.cpp
@@ -7,7 +7,8 @@ static gtpTables *table = nullptr;
 
 extern "C"
 {
-     #include "gtp_cpp_wrapper.h"
+    #include "gtp_cpp_wrapper.h"
+    #include "log.h"
 
     void init_cpp_gtp_tables(void)
     {
@@ -16,13 +17,13 @@ extern "C"
 
     int add_gtp_transaction(uint32_t msg_seq, uint32_t ue_index)
     {
-        printf("%s  Seq %d, Index - %d \n",__FUNCTION__,msg_seq, ue_index);
+        log_msg(LOG_DEBUG, "Seq %d, Index - %d ",msg_seq, ue_index);
         return table->addSeqKey(msg_seq, ue_index); 
     }
 
     int find_gtp_transaction(uint32_t msg_seq)
     {
-        printf("%s  Seq %d \n",__FUNCTION__,msg_seq);
+        log_msg(LOG_DEBUG,"Seq %d ",msg_seq);
         return table->findUeIdxWithSeq(msg_seq); 
     }
 

--- a/src/s11/handlers/create_bearer_resp_handler.c
+++ b/src/s11/handlers/create_bearer_resp_handler.c
@@ -46,7 +46,7 @@ cb_resp_processing(struct CB_RESP_Q_msg *cb_resp_msg)
 	struct MsgBuffer*  cbRespMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
 	if(cbRespMsgBuf_p == NULL)
 	{
-        log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+        log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.");
         return -1;
     }
 	
@@ -123,7 +123,7 @@ cb_resp_processing(struct CB_RESP_Q_msg *cb_resp_msg)
 			MsgBuffer_getBufLen(cbRespMsgBuf_p), 0,
 			(struct sockaddr*)&sgw_ip, g_s11_serv_size);
 
-	log_msg(LOG_INFO, "Create Bearer Resp Sent, len - %d bytes.\n", MsgBuffer_getBufLen(cbRespMsgBuf_p));
+	log_msg(LOG_INFO, "Create Bearer Resp Sent, len - %d bytes.", MsgBuffer_getBufLen(cbRespMsgBuf_p));
 	MsgBuffer_free(cbRespMsgBuf_p);
 	return SUCCESS;
 }
@@ -135,7 +135,7 @@ cb_resp_processing(struct CB_RESP_Q_msg *cb_resp_msg)
 void*
 create_bearer_resp_handler(void *data)
 {
-	log_msg(LOG_INFO, "Create bearer Response handler initialized\n");
+	log_msg(LOG_INFO, "Create bearer Response handler initialized");
 	cb_resp_processing((struct CB_RESP_Q_msg *)data);
 	return NULL;
 }

--- a/src/s11/handlers/create_session_handler.c
+++ b/src/s11/handlers/create_session_handler.c
@@ -94,13 +94,13 @@ static int
 create_session_processing(struct CS_Q_msg * g_csReqInfo)
 {
 	struct MsgBuffer*  csReqMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
-	if(csReqMsgBuf_p == NULL)
-	{
-                log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
-                return -1;
-        }
-    	struct sockaddr_in sgw_addr = {0};
-	GtpV2MessageHeader gtpHeader;
+    if(csReqMsgBuf_p == NULL)
+    {
+        log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.");
+        return -1;
+    }
+    struct sockaddr_in sgw_addr = {0};
+    GtpV2MessageHeader gtpHeader;
 	gtpHeader.msgType = GTP_CREATE_SESSION_REQ;
     uint32_t seq = 0;
 	get_sequence(&seq);
@@ -116,7 +116,7 @@ create_session_processing(struct CS_Q_msg * g_csReqInfo)
         sgw_addr = g_s11_cp_addr; 
     }
 	
-	log_msg(LOG_INFO,"In create session handler->ue_idx:%d\n",g_csReqInfo->ue_idx);
+	log_msg(LOG_INFO,"In create session handler->ue_idx:%d",g_csReqInfo->ue_idx);
 
     add_gtp_transaction(gtpHeader.sequenceNumber, 
                           g_csReqInfo->ue_idx); 
@@ -133,7 +133,7 @@ create_session_processing(struct CS_Q_msg * g_csReqInfo)
 					BINARY_IMSI_LEN);
 
 	msgData.imsi.imsiValue.length = imsi_len;
-	log_msg(LOG_INFO, "IMSI Len: %d\n", imsi_len);
+	log_msg(LOG_INFO, "IMSI Len: %d", imsi_len);
 
 	msgData.msisdnIePresent = true;
 	msgData.msisdn.msisdnValue.length = 10;
@@ -232,7 +232,6 @@ create_session_processing(struct CS_Q_msg * g_csReqInfo)
 	msgData.aggregateMaximumBitRate.maxMbrUplink = g_csReqInfo->max_requested_bw_ul;
 	msgData.aggregateMaximumBitRate.maxMbrDownlink = g_csReqInfo->max_requested_bw_dl;
 
-    log_msg(LOG_INFO, "PCO length = %d\n", g_csReqInfo->pco_length);
     if(g_csReqInfo->pco_length > 0)
     {
         msgData.protocolConfigurationOptionsIePresent = true;
@@ -242,7 +241,7 @@ create_session_processing(struct CS_Q_msg * g_csReqInfo)
 
 	GtpV2Stack_buildGtpV2Message(gtpStack_gp, csReqMsgBuf_p, &gtpHeader, &msgData);
 
-	log_msg(LOG_INFO, "send %d bytes.\n",MsgBuffer_getBufLen(csReqMsgBuf_p));
+	log_msg(LOG_INFO, "send %d bytes.",MsgBuffer_getBufLen(csReqMsgBuf_p));
 
 	int res = sendto (
 			g_s11_fd,
@@ -251,10 +250,10 @@ create_session_processing(struct CS_Q_msg * g_csReqInfo)
 			(struct sockaddr*)(&sgw_addr),
 			g_s11_serv_size);
 	if (res < 0) {
-		log_msg(LOG_ERROR,"Error in sendto in detach stage 3 post to next\n");
+		log_msg(LOG_ERROR,"Error in sendto in detach stage 3 post to next");
 	}
 
-	log_msg(LOG_INFO,"%d bytes sent. Err : %d, %s\n",res,errno,
+	log_msg(LOG_INFO,"%d bytes sent. Err : %d, %s",res,errno,
 			strerror(errno));
 
 	MsgBuffer_free(csReqMsgBuf_p);
@@ -268,7 +267,7 @@ create_session_processing(struct CS_Q_msg * g_csReqInfo)
 void*
 create_session_handler(void *data)
 {
-	log_msg(LOG_INFO, "Create Session Request handler\n");
+	log_msg(LOG_INFO, "Create Session Request handler");
 
 	create_session_processing((struct CS_Q_msg *) data);
 

--- a/src/s11/handlers/ddn_ack_handler.c
+++ b/src/s11/handlers/ddn_ack_handler.c
@@ -44,7 +44,7 @@ ddn_ack_processing(struct DDN_ACK_Q_msg *ddn_ack_msg)
 	struct MsgBuffer* ddnAckMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
 	if(ddnAckMsgBuf_p == NULL)
 	{
-	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.");
             return -1;
 	}
 	GtpV2MessageHeader gtpHeader;
@@ -70,7 +70,7 @@ ddn_ack_processing(struct DDN_ACK_Q_msg *ddn_ack_msg)
 			MsgBuffer_getBufLen(ddnAckMsgBuf_p), 0,
 			(struct sockaddr*)&sgw_ip, g_s11_serv_size);
 	
-	log_msg(LOG_INFO, "DDN Ack Sent, len - %d bytes.\n", MsgBuffer_getBufLen(ddnAckMsgBuf_p));
+	log_msg(LOG_INFO, "DDN Ack Sent, len - %d bytes.", MsgBuffer_getBufLen(ddnAckMsgBuf_p));
 	MsgBuffer_free(ddnAckMsgBuf_p);
 	return SUCCESS;
 }
@@ -82,7 +82,7 @@ ddn_ack_processing(struct DDN_ACK_Q_msg *ddn_ack_msg)
 void*
 ddn_ack_handler(void *data)
 {
-	log_msg(LOG_INFO, "DDN Ack handler initialized\n");
+	log_msg(LOG_INFO, "DDN Ack handler initialized");
     ddn_ack_processing((struct DDN_ACK_Q_msg *)data);
 	return NULL;
 }

--- a/src/s11/handlers/ddn_failure_ind_handler.c
+++ b/src/s11/handlers/ddn_failure_ind_handler.c
@@ -43,7 +43,7 @@ ddn_failure_ind_processing(struct DDN_FAIL_Q_msg *ddn_fail_msg)
     struct MsgBuffer* ddnFailMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
     if(ddnFailMsgBuf_p == NULL)
     {
-        log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+        log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.");
             return -1;
     }
     GtpV2MessageHeader gtpHeader;
@@ -69,7 +69,7 @@ ddn_failure_ind_processing(struct DDN_FAIL_Q_msg *ddn_fail_msg)
             MsgBuffer_getBufLen(ddnFailMsgBuf_p), 0,
             (struct sockaddr*)&sgw_ip, g_s11_serv_size);
 
-    log_msg(LOG_INFO, "DDN Failure Indication Sent, len - %d bytes.\n", MsgBuffer_getBufLen(ddnFailMsgBuf_p));
+    log_msg(LOG_INFO, "DDN Failure Indication Sent, len - %d bytes.", MsgBuffer_getBufLen(ddnFailMsgBuf_p));
     MsgBuffer_free(ddnFailMsgBuf_p);
     return SUCCESS;
 }
@@ -81,7 +81,7 @@ ddn_failure_ind_processing(struct DDN_FAIL_Q_msg *ddn_fail_msg)
 void*
 ddn_failure_ind_handler(void *data)
 {
-    log_msg(LOG_INFO, "DDN Ack handler initialized\n");
+    log_msg(LOG_INFO, "DDN Ack handler initialized");
     ddn_failure_ind_processing((struct DDN_FAIL_Q_msg *)data);
     return NULL;
 }

--- a/src/s11/handlers/delete_bearer_resp_handler.c
+++ b/src/s11/handlers/delete_bearer_resp_handler.c
@@ -45,7 +45,7 @@ db_resp_processing(struct DB_RESP_Q_msg *db_resp_msg)
 	struct MsgBuffer*  dbRespMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
 	if(dbRespMsgBuf_p == NULL)
 	{
-        log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+        log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.");
         return -1;
     }
 	
@@ -103,7 +103,7 @@ db_resp_processing(struct DB_RESP_Q_msg *db_resp_msg)
 			MsgBuffer_getBufLen(dbRespMsgBuf_p), 0,
 			(struct sockaddr*)&sgw_ip, g_s11_serv_size);
 
-	log_msg(LOG_INFO, "Delete Bearer Resp Sent, len - %d bytes.\n", MsgBuffer_getBufLen(dbRespMsgBuf_p));
+	log_msg(LOG_INFO, "Delete Bearer Resp Sent, len - %d bytes.", MsgBuffer_getBufLen(dbRespMsgBuf_p));
 	MsgBuffer_free(dbRespMsgBuf_p);
 	return SUCCESS;
 }
@@ -115,7 +115,7 @@ db_resp_processing(struct DB_RESP_Q_msg *db_resp_msg)
 void*
 delete_bearer_resp_handler(void *data)
 {
-	log_msg(LOG_INFO, "Delete bearer Response handler initialized\n");
+	log_msg(LOG_INFO, "Delete bearer Response handler initialized");
 	db_resp_processing((struct DB_RESP_Q_msg *)data);
 	return NULL;
 }

--- a/src/s11/handlers/delete_session_handler.c
+++ b/src/s11/handlers/delete_session_handler.c
@@ -51,7 +51,7 @@ delete_session_processing(struct DS_Q_msg *ds_msg)
 	struct MsgBuffer*  dsReqMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
 	if(dsReqMsgBuf_p == NULL)
 	{
-	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.");
             return -1;
 	}
 	GtpV2MessageHeader gtpHeader;
@@ -81,7 +81,7 @@ delete_session_processing(struct DS_Q_msg *ds_msg)
 			MsgBuffer_getDataPointer(dsReqMsgBuf_p),
 			MsgBuffer_getBufLen(dsReqMsgBuf_p), 0,
 			(struct sockaddr*)&sgw_ip, g_s11_serv_size);
-	log_msg(LOG_INFO, "Send delete session request\n");
+	log_msg(LOG_INFO, "Send delete session request");
 
 	MsgBuffer_free(dsReqMsgBuf_p);
 
@@ -95,7 +95,7 @@ delete_session_processing(struct DS_Q_msg *ds_msg)
 void*
 delete_session_handler(void *data)
 {
-	log_msg(LOG_INFO, "Delete session handler initialized\n");
+	log_msg(LOG_INFO, "Delete session handler initialized");
 
         delete_session_processing((struct DS_Q_msg *)data);
 	return NULL;

--- a/src/s11/handlers/modify_bearer_handler.c
+++ b/src/s11/handlers/modify_bearer_handler.c
@@ -58,7 +58,7 @@ modify_bearer_processing(struct MB_Q_msg *mb_msg)
 	struct MsgBuffer*  mbReqMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
 	if(mbReqMsgBuf_p == NULL)
 	{
-	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.");
             return -1;
 	}
 	GtpV2MessageHeader gtpHeader;
@@ -144,7 +144,7 @@ modify_bearer_processing(struct MB_Q_msg *mb_msg)
 			(struct sockaddr*)&sgw_ip,
 			g_s11_serv_size);
 	//TODO " error chk, eagain etc?	
-	log_msg(LOG_INFO, "Modify bearer sent, len - %d bytes.\n", MsgBuffer_getBufLen(mbReqMsgBuf_p));
+	log_msg(LOG_INFO, "Modify bearer sent, len - %d bytes.", MsgBuffer_getBufLen(mbReqMsgBuf_p));
 
 	MsgBuffer_free(mbReqMsgBuf_p);
 
@@ -157,7 +157,7 @@ modify_bearer_processing(struct MB_Q_msg *mb_msg)
 void*
 modify_bearer_handler(void *data)
 {
-	log_msg(LOG_INFO, "Modify bearer handler initialized\n");
+	log_msg(LOG_INFO, "Modify bearer handler initialized");
 	
 	modify_bearer_processing((struct MB_Q_msg *)data);
 

--- a/src/s11/handlers/release_bearer_handler.c
+++ b/src/s11/handlers/release_bearer_handler.c
@@ -53,7 +53,7 @@ release_bearer_processing(struct RB_Q_msg *rb_msg)
     struct MsgBuffer*  rbReqMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
     if(rbReqMsgBuf_p == NULL)
     {
-	log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+	log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.");
 	return -1;
     }
     GtpV2MessageHeader gtpHeader;	
@@ -82,7 +82,7 @@ release_bearer_processing(struct RB_Q_msg *rb_msg)
            (struct sockaddr*)&sgw_ip,
            g_s11_serv_size);
     //TODO " error chk, eagain etc?
-    log_msg(LOG_INFO, "Release Bearer sent, len - %d bytes.\n", MsgBuffer_getBufLen(rbReqMsgBuf_p));
+    log_msg(LOG_INFO, "Release Bearer sent, len - %d bytes.", MsgBuffer_getBufLen(rbReqMsgBuf_p));
 
     MsgBuffer_free(rbReqMsgBuf_p);
 
@@ -98,7 +98,7 @@ void*
 release_bearer_handler(void *data)
 {
 	
-	log_msg(LOG_INFO, "Release bearer handler initialized\n");
+	log_msg(LOG_INFO, "Release bearer handler initialized");
 	
 	release_bearer_processing((struct RB_Q_msg *)data);
 

--- a/src/s11/handlers/s11_CB_req_handler.c
+++ b/src/s11/handlers/s11_CB_req_handler.c
@@ -58,7 +58,7 @@ s11_CB_req_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip,
 	if(rc == false)
 	{
 			log_msg(LOG_ERROR, "s11_CB_req_handler: "
-					"Failed to decode Create Bearer Request Msg %d\n",
+					"Failed to decode Create Bearer Request Msg %d",
 					hdr->teid);
 			return E_PARSING_FAILED;
 	}
@@ -103,7 +103,7 @@ s11_CB_req_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip,
 	cbr_info.header.destInstAddr = htonl(mmeAppInstanceNum_c);
 	cbr_info.header.srcInstAddr = htonl(s11AppInstanceNum_c);
 	/*Send CB request msg*/
-	log_msg(LOG_INFO, "Send CB req to mme-app.\n");
+	log_msg(LOG_INFO, "Send CB req to mme-app.");
 	send_tipc_message(g_resp_fd, mmeAppInstanceNum_c, (char *)&cbr_info, sizeof(struct cb_req_Q_msg));
 	return SUCCESS;
 }

--- a/src/s11/handlers/s11_CS_resp_handler.c
+++ b/src/s11/handlers/s11_CS_resp_handler.c
@@ -49,7 +49,7 @@ s11_CS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 	if(rc == false)
 	{
 			log_msg(LOG_ERROR, "s11_CS_resp_handler: "
-								"Failed to decode Create Session Response Msg %d\n",
+								"Failed to decode Create Session Response Msg %d",
 								hdr->teid);
 			return E_PARSING_FAILED;
 	}
@@ -106,7 +106,7 @@ s11_CS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 	csr_info.header.srcInstAddr = htonl(s11AppInstanceNum_c);
 
 	/*Send CS response msg*/
-	log_msg(LOG_INFO, "Send CS resp to mme-app stage6.\n");
+	log_msg(LOG_INFO, "Send CS resp to mme-app stage6.");
 	send_tipc_message(g_resp_fd, mmeAppInstanceNum_c, (char *)&csr_info, sizeof(struct csr_Q_msg));
 
 	return SUCCESS;

--- a/src/s11/handlers/s11_DB_req_handler.c
+++ b/src/s11/handlers/s11_DB_req_handler.c
@@ -44,7 +44,7 @@ s11_DB_req_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip,
     if (rc == false)
     {
         log_msg(LOG_ERROR, "s11_DB_req_handler: "
-                "Failed to decode Delete Bearer Request Msg %d\n", hdr->teid);
+                "Failed to decode Delete Bearer Request Msg %d", hdr->teid);
         return E_PARSING_FAILED;
     }
 
@@ -81,7 +81,7 @@ s11_DB_req_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip,
     dbr_info.header.srcInstAddr = htonl(s11AppInstanceNum_c);
 
     /*Send DB request msg*/
-    log_msg(LOG_INFO, "Send DB req to mme-app.\n");
+    log_msg(LOG_INFO, "Send DB req to mme-app.");
     send_tipc_message(g_resp_fd, mmeAppInstanceNum_c, (char*) &dbr_info,
             sizeof(struct db_req_Q_msg));
     return SUCCESS;

--- a/src/s11/handlers/s11_DDN_handler.c
+++ b/src/s11/handlers/s11_DDN_handler.c
@@ -43,12 +43,12 @@ s11_DDN_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip)
 	{
 			
 			log_msg(LOG_ERROR, "s11_Ddn_handler: "
-					   "Failed to decode ddn Msg %d\n",
+					   "Failed to decode ddn Msg %d",
 								hdr->teid);
 			return E_PARSING_FAILED;
 	}
 	/*****Message structure****/
-	log_msg(LOG_INFO, "Parse S11 Ddn message\n");
+	log_msg(LOG_INFO, "Parse S11 Ddn message");
 
 	//TODO : check cause for the result verification
 	if (msgData.allocationRetentionPriorityIePresent) {
@@ -65,7 +65,7 @@ s11_DDN_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip)
 	ddn_info.header.srcInstAddr = htonl(s11AppInstanceNum_c);
 
 	/*Send DDN msg*/
-	log_msg(LOG_INFO, "Send ddn to mme-app\n");
+	log_msg(LOG_INFO, "Send ddn to mme-app");
 	send_tipc_message(g_resp_fd, mmeAppInstanceNum_c, (char *)&ddn_info, sizeof(struct ddn_Q_msg));
 
 	return SUCCESS;

--- a/src/s11/handlers/s11_DS_resp_handler.c
+++ b/src/s11/handlers/s11_DS_resp_handler.c
@@ -37,7 +37,7 @@ s11_DS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 	dsr_info.header.msg_type = delete_session_response;
 
 	/*****Message structure****/
-	log_msg(LOG_INFO, "Parse S11 DS resp message\n");
+	log_msg(LOG_INFO, "Parse S11 DS resp message");
 
 	//TODO : check cause for the result verification
 
@@ -50,7 +50,7 @@ s11_DS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
     }
     else
     {
-        log_msg(LOG_WARNING, "Unknown Teid in DSR.\n");
+        log_msg(LOG_WARNING, "Unknown Teid in DSR.");
         dsr_info.s11_mme_cp_teid = find_gtp_transaction(hdr->sequenceNumber);
     }
 
@@ -60,7 +60,7 @@ s11_DS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 	dsr_info.header.srcInstAddr = htonl(s11AppInstanceNum_c);
 
 	/*Send CS response msg*/
-	log_msg(LOG_INFO, "Send DS resp to mme-app stage8.\n");
+	log_msg(LOG_INFO, "Send DS resp to mme-app stage8.");
 	send_tipc_message(g_resp_fd, mmeAppInstanceNum_c, (char *)&dsr_info,
 		 	sizeof(struct DS_resp_Q_msg));
 

--- a/src/s11/handlers/s11_ECHO_req_resp_handler.c
+++ b/src/s11/handlers/s11_ECHO_req_resp_handler.c
@@ -42,14 +42,14 @@ s11_ECHO_req_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t 
 	{
 			
 			log_msg(LOG_ERROR, "s11_ECHO_req_resp_handler: "
-					   "Failed to decode echo req Msg\n");
+					   "Failed to decode echo req Msg");
 			return E_PARSING_FAILED;
 	}
 
 	struct MsgBuffer* echoRespMsgBuf_p = createMsgBuffer(S11_MSGBUF_SIZE);
 	if(echoRespMsgBuf_p == NULL)
 	{
-	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.\n");
+	    log_msg(LOG_ERROR, "Error in initializing msg buffers required by gtp codec.");
             return -1;
 	}
 	
@@ -73,7 +73,7 @@ s11_ECHO_req_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t 
 			MsgBuffer_getBufLen(echoRespMsgBuf_p), 0,
 			(struct sockaddr*)&sgw_ip, g_s11_serv_size);
 	
-	log_msg(LOG_INFO, "ECHO Resp Sent, len - %d bytes.\n", MsgBuffer_getBufLen(echoRespMsgBuf_p));
+	log_msg(LOG_INFO, "ECHO Resp Sent, len - %d bytes.", MsgBuffer_getBufLen(echoRespMsgBuf_p));
 	MsgBuffer_free(echoRespMsgBuf_p);
 	return SUCCESS;
 

--- a/src/s11/handlers/s11_MB_resp_handler.c
+++ b/src/s11/handlers/s11_MB_resp_handler.c
@@ -36,7 +36,7 @@ s11_MB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 
 	/*****Message structure***
 	*/
-	log_msg(LOG_INFO, "Parse S11 MB resp message\n");
+	log_msg(LOG_INFO, "Parse S11 MB resp message");
 
 	//TODO : check cause foor the result verification
 	
@@ -47,7 +47,7 @@ s11_MB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
     }
     else
     {
-        log_msg(LOG_WARNING, "Unknown Teid in MBR.\n");
+        log_msg(LOG_WARNING, "Unknown Teid in MBR.");
         mbr_info.s11_mme_cp_teid = find_gtp_transaction(hdr->sequenceNumber);
     }
 
@@ -62,7 +62,7 @@ s11_MB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 	if (rc == false)
 	{
 		log_msg(LOG_ERROR, "s11_MB_resp_handler: "
-				"Failed to decode MB_resp Msg %d\n", hdr->teid);
+				"Failed to decode MB_resp Msg %d", hdr->teid);
 		return E_PARSING_FAILED;
 	}
 	mbr_info.cause = msgData.cause.causeValue;
@@ -91,7 +91,7 @@ s11_MB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 	mbr_info.header.destInstAddr = htonl(mmeAppInstanceNum_c);
 	mbr_info.header.srcInstAddr = htonl(s11AppInstanceNum_c);
 
-	log_msg(LOG_INFO, "Send MB resp to mme-app stage8.\n");
+	log_msg(LOG_INFO, "Send MB resp to mme-app stage8.");
 	send_tipc_message(g_resp_fd, mmeAppInstanceNum_c, (char *)&mbr_info, sizeof(struct MB_resp_Q_msg));
 
 	return SUCCESS;

--- a/src/s11/handlers/s11_RB_resp_handler.c
+++ b/src/s11/handlers/s11_RB_resp_handler.c
@@ -33,7 +33,7 @@ s11_RB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 	
 	/*****Message structure***
 	*/
-	log_msg(LOG_INFO, "Parse S11 RB resp message\n");
+	log_msg(LOG_INFO, "Parse S11 RB resp message");
 	
 	//TODO : check cause for the result verification
 	
@@ -43,7 +43,7 @@ s11_RB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
     }
     else
     {
-        log_msg(LOG_WARNING, "Unknown Teid in RABR.\n");
+        log_msg(LOG_WARNING, "Unknown Teid in RABR.");
         rbr_info.s11_mme_cp_teid = find_gtp_transaction(hdr->sequenceNumber);
     }
 
@@ -57,7 +57,7 @@ s11_RB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
         if(rc == false)
         {
                         log_msg(LOG_ERROR, "s11_RB_resp_handler: "
-                                                                "Failed to decode Release Access Bearer Response Msg %d\n",
+                                                                "Failed to decode Release Access Bearer Response Msg %d",
                                                                 hdr->teid);
                         return E_PARSING_FAILED;
         }
@@ -67,7 +67,7 @@ s11_RB_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 	rbr_info.header.srcInstAddr = htonl(s11AppInstanceNum_c);
 
 	/*Send RAB Release response msg*/
-	log_msg(LOG_INFO, "Send RB resp to mme-app stage2.\n");
+	log_msg(LOG_INFO, "Send RB resp to mme-app stage2.");
 	send_tipc_message(g_resp_fd, mmeAppInstanceNum_c, (char *)&rbr_info, sizeof(struct RB_resp_Q_msg));
 
 	return SUCCESS;

--- a/src/s11/handlers/s11_msg_delegator.c
+++ b/src/s11/handlers/s11_msg_delegator.c
@@ -90,7 +90,7 @@ parse_bearer_ctx(bearer_ctxt_t *bearer, char* data, short len)
 			break;
 
 		default:
-		log_msg(LOG_ERROR, "Unhandled S11 bearer IE: %d\n", header->ie_type);
+		log_msg(LOG_ERROR, "Unhandled S11 bearer IE: %d", header->ie_type);
 		}
 
 		data += ntohs(header->ie_len) + sizeof(struct s11_IE_header); /*goto next IE*/
@@ -104,7 +104,7 @@ parse_gtpv2c_IEs(char *msg, int len, struct s11_proto_IE *proto_ies)
 	proto_ies->no_of_ies = get_IE_cnt(msg, len);
 
 	if(0 == proto_ies->no_of_ies) {
-		log_msg(LOG_INFO, "No IEs recvd in message\n");
+		log_msg(LOG_INFO, "No IEs recvd in message");
 		return SUCCESS;
 	}
 	/*allocated IEs for message*/
@@ -150,7 +150,7 @@ parse_gtpv2c_IEs(char *msg, int len, struct s11_proto_IE *proto_ies)
 		break;
 
 		default:
-		log_msg(LOG_ERROR, "Unhandled S11 IE: %d\n", ie->header.ie_type);
+		log_msg(LOG_ERROR, "Unhandled S11 IE: %d", ie->header.ie_type);
 		}
 
 		msg += (ntohs(((struct s11_IE_header*)msg)->ie_len) + sizeof(struct s11_IE_header)) ; /*goto next IE*/
@@ -161,7 +161,7 @@ parse_gtpv2c_IEs(char *msg, int len, struct s11_proto_IE *proto_ies)
 void
 handle_s11_message(void *message)
 {
-	log_msg(LOG_INFO, "S11 recv msg handler.\n");
+	log_msg(LOG_INFO, "S11 recv msg handler.");
 
 	MsgBuffer* msgBuf_p = (MsgBuffer*)(message);
 
@@ -173,7 +173,7 @@ handle_s11_message(void *message)
 	bool rc = GtpV2Stack_decodeMessageHeader(gtpStack_gp, &msgHeader, msgBuf_p);
 
 	if(rc == false)
-		log_msg(LOG_ERROR,"Failed to decode the GTP Message\n");
+		log_msg(LOG_ERROR,"Failed to decode the GTP Message");
 
 	switch(msgHeader.msgType){
 	case GTP_CREATE_SESSION_RSP:

--- a/src/s11/json_config.c
+++ b/src/s11/json_config.c
@@ -66,8 +66,8 @@ parse_s11_conf()
 	  	{
 	  		// Keep trying ...May be SGW is not yet deployed 
 			// We shall be doing this once timer library is integrated 
-	  		fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(err));
-	  		log_msg(LOG_INFO, "getaddr info failed %s\n",gai_strerror(err));
+	  		fprintf(stderr, "getaddrinfo: %s", gai_strerror(err));
+	  		log_msg(LOG_INFO, "getaddr info failed %s",gai_strerror(err));
 	  	}
 	  	else 
 	  	{
@@ -76,7 +76,7 @@ parse_s11_conf()
 	  			if(rp->ai_family == AF_INET)
 	  			{
 	  				struct sockaddr_in *addrV4 = (struct sockaddr_in *)rp->ai_addr;
-	  				log_msg(LOG_INFO, "gw address received from DNS response %s\n", inet_ntoa(addrV4->sin_addr));
+	  				log_msg(LOG_INFO, "gw address received from DNS response %s", inet_ntoa(addrV4->sin_addr));
 	  				*config_addr[i].addr = addrV4->sin_addr.s_addr;
 	  			}
 	  		}

--- a/src/s11/main.c
+++ b/src/s11/main.c
@@ -114,12 +114,12 @@ init_s11_workers()
 {
 	if ((ipc_reader_tipc_s11 = create_tipc_socket()) <= 0)
 	{
-		log_msg(LOG_ERROR, "Failed to create IPC Reader tipc socket \n");
+		log_msg(LOG_ERROR, "Failed to create IPC Reader tipc socket ");
 		return -E_FAIL;
 	}
 	if ( bind_tipc_socket(ipc_reader_tipc_s11, s11AppInstanceNum_c) != 1)
 	{
-		log_msg(LOG_ERROR, "Failed to bind IPC Reader tipc socket \n");
+		log_msg(LOG_ERROR, "Failed to bind IPC Reader tipc socket ");
 		return -E_FAIL;
 	}
 
@@ -127,11 +127,11 @@ init_s11_workers()
 	g_tpool_tipc_reader_s11 = thread_pool_new(3);
 
 	if (g_tpool_tipc_reader_s11 == NULL) {
-		log_msg(LOG_ERROR, "Error in creating thread pool. \n");
+		log_msg(LOG_ERROR, "Error in creating thread pool. ");
 		return -E_FAIL_INIT;
 	}
 
-	log_msg(LOG_INFO, "S11 Listener thead pool initalized.\n");
+	log_msg(LOG_INFO, "S11 Listener thead pool initalized.");
 
 	// thread to read incoming ipc messages from tipc socket
 	pthread_attr_t attr;
@@ -153,7 +153,7 @@ init_gtpv2()
 	g_client_addr.sin_family = AF_INET;
 	//g_client_addr.sin_addr.s_addr = htonl(g_s11_cfg.local_egtp_ip);
 	struct in_addr mme_local_addr = {g_s11_cfg.local_egtp_ip};
-	fprintf(stderr, "....................local egtp %s\n", inet_ntoa(mme_local_addr));
+	fprintf(stderr, "....................local egtp %s", inet_ntoa(mme_local_addr));
 	g_client_addr.sin_addr.s_addr = htonl(g_s11_cfg.local_egtp_ip);
 	g_client_addr.sin_port = htons(g_s11_cfg.egtp_def_port);
 
@@ -163,11 +163,11 @@ init_gtpv2()
 	/*Configure settings in address struct*/
 	g_s11_cp_addr.sin_family = AF_INET;
 	//g_s11_cp_addr.sin_port = htons(g_s11_cfg.egtp_def_port);
-	fprintf(stderr, ".................... egtp def port %d\n", g_s11_cfg.egtp_def_port);
+	fprintf(stderr, ".................... egtp def port %d", g_s11_cfg.egtp_def_port);
 	g_s11_cp_addr.sin_port = htons(g_s11_cfg.egtp_def_port);
 	//g_s11_cp_addr.sin_addr.s_addr = htonl(g_s11_cfg.sgw_ip);
 	struct in_addr sgw_addr = {g_s11_cfg.sgw_ip};
-	fprintf(stderr, "....................sgw ip %s\n", inet_ntoa(sgw_addr));
+	fprintf(stderr, "....................sgw ip %s", inet_ntoa(sgw_addr));
 	g_s11_cp_addr.sin_addr.s_addr = g_s11_cfg.sgw_ip;
 	memset(g_s11_cp_addr.sin_zero, '\0', sizeof(g_s11_cp_addr.sin_zero));
 
@@ -179,11 +179,11 @@ init_gtpv2()
 int
 init_s11_ipc()
 {
-	log_msg(LOG_INFO, "Connecting to mme-app S11 CS response queue\n");
+	log_msg(LOG_INFO, "Connecting to mme-app S11 CS response queue");
 	if ((g_resp_fd  = create_tipc_socket()) <= 0)
 		return -E_FAIL;
 
-	log_msg(LOG_INFO, "S11 - mme-app IPC: Connected.\n");
+	log_msg(LOG_INFO, "S11 - mme-app IPC: Connected.");
 
 	return 0;
 }
@@ -212,7 +212,7 @@ s11_reader()
 			MsgBuffer_writeUint16(tmp_buf_p, src_port, true);
 			MsgBuffer_writeBytes(tmp_buf_p, buffer, len, true);
 			MsgBuffer_rewind(tmp_buf_p);
-			log_msg(LOG_INFO, "S11 Received msg len : %d \n",len);
+			log_msg(LOG_INFO, "S11 Received msg len : %d ",len);
 
 			insert_job(g_tpool, handle_s11_message, tmp_buf_p);
 		}
@@ -260,13 +260,13 @@ main(int argc, char **argv)
 	gtpStack_gp = createGtpV2Stack();
 	if (gtpStack_gp == NULL)
 	{
-		log_msg(LOG_ERROR, "Error in initializing ipc.\n");
+		log_msg(LOG_ERROR, "Error in initializing ipc.");
 		return -1;
 	}
 
 	/*Init writer sockets*/
 	if (init_s11_ipc() != 0) {
-		log_msg(LOG_ERROR, "Error in initializing ipc.\n");
+		log_msg(LOG_ERROR, "Error in initializing ipc.");
 		return -1;
 	}
 
@@ -276,10 +276,10 @@ main(int argc, char **argv)
 	g_tpool = thread_pool_new(S11_THREADPOOL_SIZE);
 
 	if (g_tpool == NULL) {
-		log_msg(LOG_ERROR, "Error in creating thread pool. \n");
+		log_msg(LOG_ERROR, "Error in creating thread pool. ");
 		return -1;
 	}
-	log_msg(LOG_INFO, "S11 listener threadpool initialized.\n");
+	log_msg(LOG_INFO, "S11 listener threadpool initialized.");
 
 	if (init_gtpv2() != 0)
 		return -1;

--- a/src/s11/options.c
+++ b/src/s11/options.c
@@ -59,9 +59,9 @@ void parse_args(int argc, char **argv)
 	} while (c != -1);
 
 	if ((args_set & REQ_ARGS) != REQ_ARGS) {
-		log_msg(LOG_ERROR, "Usage: %s\n", argv[0]);
+		log_msg(LOG_ERROR, "Usage: %s", argv[0]);
 		for (c = 0; long_options[c].name; ++c) {
-			log_msg(LOG_ERROR, "\t[ -%s | -%c ] %s\n",
+			log_msg(LOG_ERROR, "\t[ -%s | -%c ] %s",
 					long_options[c].name,
 					long_options[c].val,
 					long_options[c].name);

--- a/src/s1ap/handlers/attach_authreq.c
+++ b/src/s1ap/handlers/attach_authreq.c
@@ -42,7 +42,7 @@ get_authreq_protoie_value(struct proto_IE *value, struct authreq_info *g_authreq
 	value->data[0].val.mme_ue_s1ap_id = g_authreqInfo->ue_idx;
 	value->data[1].val.enb_ue_s1ap_id = g_authreqInfo->enb_s1ap_ue_id;
 
-	log_msg(LOG_INFO, "mme_ue_s1ap_id %d and enb_ue_s1ap_id %d and enodeb fd = %d\n",
+	log_msg(LOG_INFO, "mme_ue_s1ap_id %d and enb_ue_s1ap_id %d and enodeb fd = %d",
 			g_authreqInfo->ue_idx, g_authreqInfo->enb_s1ap_ue_id, g_authreqInfo->enb_fd);
 
 	return SUCCESS;
@@ -136,7 +136,7 @@ authreq_processing(struct authreq_info *g_authreqInfo)
 	buffer_copy(&g_value_buffer, &protocolIe_criticality,
 					sizeof(protocolIe_criticality));
 
-	log_msg(LOG_INFO, "Received Authrequest has nas message %d \n",g_authreqInfo->nasMsgSize);
+	log_msg(LOG_INFO, "Received Authrequest has nas message %d ",g_authreqInfo->nasMsgSize);
 	datalen = g_authreqInfo->nasMsgSize + 1; 
 
 	buffer_copy(&g_value_buffer, &datalen,
@@ -162,7 +162,7 @@ authreq_processing(struct authreq_info *g_authreqInfo)
 void*
 authreq_handler(void *data)
 {
-	log_msg(LOG_INFO, "AuthReq handler.\n");
+	log_msg(LOG_INFO, "AuthReq handler.");
 
 	authreq_processing((struct authreq_info *)data);
 

--- a/src/s1ap/handlers/attach_esmreq.c
+++ b/src/s1ap/handlers/attach_esmreq.c
@@ -53,7 +53,7 @@ esmreq_processing(struct esm_req_Q_msg * g_esmReqInfo)
     Buffer g_esm_buffer = {0};
 	unsigned char tmpStr[4];
 	struct s1ap_PDU s1apPDU = {0};
-	log_msg(LOG_INFO, "ESM Info Request handler MME-s1ap-id %d, enb-s1ap-id %d, fd %d \n",
+	log_msg(LOG_INFO, "ESM Info Request handler MME-s1ap-id %d, enb-s1ap-id %d, fd %d ",
 			g_esmReqInfo->ue_idx, g_esmReqInfo->enb_s1ap_ue_id, g_esmReqInfo->enb_fd);
 
 	s1apPDU.procedurecode = id_downlinkNASTransport;
@@ -142,7 +142,7 @@ esmreq_processing(struct esm_req_Q_msg * g_esmReqInfo)
 
 	int ret = send_sctp_msg(g_esmReqInfo->enb_fd, g_esm_buffer.buf, g_esm_buffer.pos, 1);
 	if(ret < 0) {
-	log_msg(LOG_ERROR, "Failed to send - ESM Info Request. MME-s1ap-id %d, enb-s1ap-id %d, fd %d \n",
+	log_msg(LOG_ERROR, "Failed to send - ESM Info Request. MME-s1ap-id %d, enb-s1ap-id %d, fd %d ",
 			g_esmReqInfo->ue_idx, g_esmReqInfo->enb_s1ap_ue_id, g_esmReqInfo->enb_fd);
 	}
 

--- a/src/s1ap/handlers/attach_icsreq.c
+++ b/src/s1ap/handlers/attach_icsreq.c
@@ -414,24 +414,24 @@ icsreq_processing(struct init_ctx_req_Q_msg *g_icsReqInfo)
 	buffer_copy(&g_ics_buffer, &datalen, sizeof(datalen));
 #endif
 
-	log_msg(LOG_INFO, "Received Nas message from mme-app size %d\n", g_icsReqInfo->nasMsgSize);
+	log_msg(LOG_INFO, "Received Nas message from mme-app size %d", g_icsReqInfo->nasMsgSize);
 //	datalen = g_icsReqInfo->nasMsgSize + 1; 
 
 //	buffer_copy(&g_rab2_buffer, &datalen, sizeof(datalen));
 
-	log_msg(LOG_INFO, "RAB2 payload length before adding NAS %d\n", g_rab2_buffer.pos);
+	log_msg(LOG_INFO, "RAB2 payload length before adding NAS %lu", g_rab2_buffer.pos);
 	buffer_copy(&g_rab2_buffer, &g_icsReqInfo->nasMsgSize, sizeof(uint8_t));
 
 	buffer_copy(&g_rab2_buffer, &g_icsReqInfo->nasMsgBuf[0], g_icsReqInfo->nasMsgSize);
 
-	log_msg(LOG_INFO, "RAB2 payload length %d\n", g_rab2_buffer.pos);
-	log_msg(LOG_INFO, "RAB1 payload length before appending RAB2  %d\n", g_rab1_buffer.pos);
+	log_msg(LOG_INFO, "RAB2 payload length %lu", g_rab2_buffer.pos);
+	log_msg(LOG_INFO, "RAB1 payload length before appending RAB2  %lu", g_rab1_buffer.pos);
     /* Now lets append rab2 to rab1 */ 
     if(g_rab2_buffer.pos <= 127)
     {
         datalen = g_rab2_buffer.pos;
 	    buffer_copy(&g_rab1_buffer, &datalen, sizeof(datalen));
-	    log_msg(LOG_INFO, "RAB1 payload length after adding rab2 lengh  %d\n", g_rab1_buffer.pos);
+	    log_msg(LOG_INFO, "RAB1 payload length after adding rab2 lengh  %lu", g_rab1_buffer.pos);
     /* Now lets append rab2 to rab1 */ 
     }
     else
@@ -441,7 +441,7 @@ icsreq_processing(struct init_ctx_req_Q_msg *g_icsReqInfo)
         lenStr[0] = rab2_pay_len >> 8;
         lenStr[1] = rab2_pay_len & 0xff;
 	    buffer_copy(&g_rab1_buffer, lenStr, sizeof(lenStr));
-	    log_msg(LOG_INFO, "RAB1 payload length after adding rab2 lengh  %d\n", g_rab1_buffer.pos);
+	    log_msg(LOG_INFO, "RAB1 payload length after adding rab2 lengh  %lu", g_rab1_buffer.pos);
     }
 	buffer_copy(&g_rab1_buffer, &g_rab2_buffer.buf[0], g_rab2_buffer.pos);
 
@@ -451,13 +451,13 @@ icsreq_processing(struct init_ctx_req_Q_msg *g_icsReqInfo)
 
     /*g_s1ap_buffer is having rab appended to it.. */
 
-	log_msg(LOG_INFO, "RAB1 payload length %d\n", g_rab1_buffer.pos);
-	log_msg(LOG_INFO, "s1ap buffer payload length before appending RAB1 %d\n", g_s1ap_buffer.pos);
+	log_msg(LOG_INFO, "RAB1 payload length %lu", g_rab1_buffer.pos);
+	log_msg(LOG_INFO, "s1ap buffer payload length before appending RAB1 %lu", g_s1ap_buffer.pos);
     if(g_rab1_buffer.pos <= 127)
     {
         datalen = g_rab1_buffer.pos;
 	    buffer_copy(&(g_s1ap_buffer), &datalen, sizeof(datalen));
-	    log_msg(LOG_INFO, "s1ap buffer payload length after adding rab1 header %d\n", g_s1ap_buffer.pos);
+	    log_msg(LOG_INFO, "s1ap buffer payload length after adding rab1 header %lu", g_s1ap_buffer.pos);
     }
     else
     {
@@ -466,10 +466,10 @@ icsreq_processing(struct init_ctx_req_Q_msg *g_icsReqInfo)
         lenStr[0] = rab1_pay_len >> 8;
         lenStr[1] = rab1_pay_len & 0xff;
 	    buffer_copy(&g_s1ap_buffer, lenStr, sizeof(lenStr));
-	    log_msg(LOG_INFO, "s1ap buffer payload length after adding rab1 header %d\n", g_s1ap_buffer.pos);
+	    log_msg(LOG_INFO, "s1ap buffer payload length after adding rab1 header %lu", g_s1ap_buffer.pos);
     }
 	buffer_copy(&g_s1ap_buffer, &g_rab1_buffer.buf[0], g_rab1_buffer.pos);
-	log_msg(LOG_INFO, "s1ap buffer payload length after appending RAB1 %d\n", g_s1ap_buffer.pos);
+	log_msg(LOG_INFO, "s1ap buffer payload length after appending RAB1 %lu", g_s1ap_buffer.pos);
     /* RAB is appended to s1ap payload now */ 
 
 	/* id-UESecurityCapabilities */
@@ -525,7 +525,7 @@ icsreq_processing(struct init_ctx_req_Q_msg *g_icsReqInfo)
 	/* Copy length to s1ap length field */
 	//datalen = g_s1ap_buffer.pos - s1ap_len_pos - 1;
 	//uint16_t s1aplen = g_s1ap_buffer.pos - s1ap_len_pos - 1;
-	log_msg(LOG_INFO, "S1AP payload length %d\n", g_s1ap_buffer.pos);
+	log_msg(LOG_INFO, "S1AP payload length %lu", g_s1ap_buffer.pos);
 	uint16_t s1aplen = g_s1ap_buffer.pos;
     if(s1aplen <= 127 )
     {
@@ -547,14 +547,14 @@ icsreq_processing(struct init_ctx_req_Q_msg *g_icsReqInfo)
 	free(s1apPDU.value.data);
 
 	send_sctp_msg(g_icsReqInfo->enb_fd, g_ics_buffer.buf, g_ics_buffer.pos, 1);
-	log_msg(LOG_INFO,"Initial Context Setup Request sent successfully\n");
+	log_msg(LOG_INFO,"Initial Context Setup Request sent successfully");
 	return SUCCESS;
 }
 
 void*
 icsreq_handler(void *data)
 {
-	log_msg(LOG_INFO, "icsreq handler ready.\n");
+	log_msg(LOG_INFO, "icsreq handler ready.");
 
 
 	icsreq_processing((struct init_ctx_req_Q_msg *)data);

--- a/src/s1ap/handlers/attach_id_req.c
+++ b/src/s1ap/handlers/attach_id_req.c
@@ -42,7 +42,7 @@ get_attach_id_request_protoie_value(struct proto_IE *value,struct attachIdReq_in
 	value->data[1].val.enb_ue_s1ap_id = g_attachIdReqInfo->s1ap_enb_ue_id;
     
 
-	log_msg(LOG_INFO, "mme_ue_s1ap_id %d and enb_ue_s1ap_id %d\n",
+	log_msg(LOG_INFO, "mme_ue_s1ap_id %d and enb_ue_s1ap_id %d",
 			g_attachIdReqInfo->ue_idx, g_attachIdReqInfo->s1ap_enb_ue_id);
 
 	return SUCCESS;
@@ -136,7 +136,7 @@ s1ap_attach_id_req_processing(struct attachIdReq_info *g_attachIdReqInfo)
 	buffer_copy(&g_value_buffer, &protocolIe_criticality,
 					sizeof(protocolIe_criticality));
 
-	log_msg(LOG_INFO, "Received Id Req has nas message %d \n",g_attachIdReqInfo->nasMsgSize);
+	log_msg(LOG_INFO, "Received Id Req has nas message %d ",g_attachIdReqInfo->nasMsgSize);
 	datalen = g_attachIdReqInfo->nasMsgSize + 1; 
 
 	buffer_copy(&g_value_buffer, &datalen,
@@ -168,7 +168,7 @@ void*
 idreq_handler(void *data)
 {
 	
-	log_msg(LOG_INFO, "S1Ap attach Id Request handler ready.\n");
+	log_msg(LOG_INFO, "S1Ap attach Id Request handler ready.");
 
 	s1ap_attach_id_req_processing((struct attachIdReq_info *)data);
 

--- a/src/s1ap/handlers/attach_initctxresp.c
+++ b/src/s1ap/handlers/attach_initctxresp.c
@@ -34,12 +34,12 @@ s1_init_ctx_resp_handler(SuccessfulOutcome_t *msg)
 	struct initctx_resp_Q_msg ics_resp= {0};
 
 	/*****Message structure****/
-	log_msg(LOG_INFO, "Parse int ctx s1ap response message:--\n");
+	log_msg(LOG_INFO, "Parse int ctx s1ap response message:--");
 	/*parse_IEs(msg+2, &s1_ics_ies, S1AP_INITIAL_CTX_RESP_CODE);*/
 	int decode_status = convertInitCtxRspToProtoIe(msg, &s1_ics_ies);
 	if(decode_status < 0) {
 		free(s1_ics_ies.data);
-		log_msg(LOG_ERROR, "Failed to decode s1ap message\n");
+		log_msg(LOG_ERROR, "Failed to decode s1ap message");
 		return E_FAIL;
 	}
     
@@ -67,7 +67,7 @@ s1_init_ctx_resp_handler(SuccessfulOutcome_t *msg)
                     }
                 }break;
             default:
-                log_msg(LOG_WARNING,"Unhandled IE %d \n",s1_ics_ies.data[i].IE_type);
+                log_msg(LOG_WARNING,"Unhandled IE %d ",s1_ics_ies.data[i].IE_type);
         }
     }
 	
@@ -78,10 +78,10 @@ s1_init_ctx_resp_handler(SuccessfulOutcome_t *msg)
 	int i = send_tipc_message(ipc_S1ap_Hndl, mmeAppInstanceNum_c, (char *)&ics_resp, sizeof(struct initctx_resp_Q_msg));
 
 	if (i < 0) {
-		log_msg(LOG_ERROR, "Error to write in s1_init_ctx_resp_handler\n");
+		log_msg(LOG_ERROR, "Error to write in s1_init_ctx_resp_handler");
 	}
 	/*Send S1Setup response*/
-	log_msg(LOG_INFO, "Init ctx resp send to mme-app stage7. Bytes send %d\n", sizeof(struct initctx_resp_Q_msg));
+	log_msg(LOG_INFO, "Init ctx resp send to mme-app stage7. Bytes send %lu", sizeof(struct initctx_resp_Q_msg));
 
 	free(s1_ics_ies.data);
 	return SUCCESS;

--- a/src/s1ap/handlers/attach_secreq.c
+++ b/src/s1ap/handlers/attach_secreq.c
@@ -107,7 +107,7 @@ secreq_processing(struct sec_mode_Q_msg * g_secReqInfo)
 			sizeof(protocolIe_criticality));
 
 
-	log_msg(LOG_INFO, "Received Security Command  has nas message %d \n",g_secReqInfo->nasMsgSize);
+	log_msg(LOG_INFO, "Received Security Command  has nas message %d ",g_secReqInfo->nasMsgSize);
 	datalen = g_secReqInfo->nasMsgSize + 1; 
 
 	buffer_copy(&g_sec_value_buffer, &datalen,
@@ -150,7 +150,7 @@ secreq_processing(struct sec_mode_Q_msg * g_secReqInfo)
 void*
 secreq_handler(void *data)
 {
-	log_msg(LOG_INFO, "SecReq handler ready.\n");
+	log_msg(LOG_INFO, "SecReq handler ready.");
 
 	secreq_processing((struct sec_mode_Q_msg *)data);
 

--- a/src/s1ap/handlers/common_reject.c
+++ b/src/s1ap/handlers/common_reject.c
@@ -27,7 +27,7 @@
 static int
 process_attach_rej(struct commonRej_info *g_mmeS1apInfo)
 {
-    log_msg(LOG_DEBUG,"Process Attach Reject.\n");
+    log_msg(LOG_DEBUG,"Process Attach Reject.");
 	uint32_t length = 0;
     uint8_t *buffer = NULL;
     struct s1ap_common_req_Q_msg message_p={0};
@@ -40,12 +40,12 @@ process_attach_rej(struct commonRej_info *g_mmeS1apInfo)
     int ret = s1ap_mme_encode_initiating(&message_p, &buffer, &length);
     if(ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding Attach Reject failed.\n");
+        log_msg(LOG_ERROR, "Encoding Attach Reject failed.");
         return E_FAIL;
     }
 
     send_sctp_msg(g_mmeS1apInfo->enb_fd, buffer, length, 1);
-	log_msg(LOG_INFO, "buffer size is %d\n", length);
+	log_msg(LOG_INFO, "buffer size is %d", length);
     if(buffer)
     {
         free(buffer);
@@ -73,12 +73,12 @@ process_service_rej(struct commonRej_info *g_mmeS1apInfo)
     int ret = s1ap_mme_encode_initiating(&message_p, &buffer, &length);
     if(ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding Service Reject failed.\n");
+        log_msg(LOG_ERROR, "Encoding Service Reject failed.");
         return E_FAIL;
     }
 
     send_sctp_msg(g_mmeS1apInfo->enb_fd, buffer, length, 1);
-	log_msg(LOG_INFO, "buffer size is %d\n", length);
+	log_msg(LOG_INFO, "buffer size is %d", length);
     if(buffer)
     {
         free(buffer);
@@ -106,12 +106,12 @@ process_tau_rej(struct commonRej_info *g_mmeS1apInfo)
     int ret = s1ap_mme_encode_initiating(&message_p, &buffer, &length);
     if(ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding TAU Reject failed.\n");
+        log_msg(LOG_ERROR, "Encoding TAU Reject failed.");
         return E_FAIL;
     }
 
     send_sctp_msg(g_mmeS1apInfo->enb_fd, buffer, length, 1);
-    log_msg(LOG_INFO, "buffer size is %d\n", length);
+    log_msg(LOG_INFO, "buffer size is %d", length);
     if(buffer)
     {
         free(buffer);
@@ -124,7 +124,7 @@ void*
 s1ap_reject_handler(void *data)
 {
 	
-	log_msg(LOG_INFO, "NAS Reject Handler.\n");
+	log_msg(LOG_INFO, "NAS Reject Handler.");
 
 	struct commonRej_info *nasReject = (struct commonRej_info *)data;
 

--- a/src/s1ap/handlers/ctxrelease_cmp.c
+++ b/src/s1ap/handlers/ctxrelease_cmp.c
@@ -31,12 +31,12 @@ s1_ctx_release_complete_handler(SuccessfulOutcome_t *msg)
 	struct proto_IE s1_ctx_release_ies;
 	s1_ctx_release_ies.data = NULL;
 
-	log_msg(LOG_INFO, "Parse s1ap context release complete message:--\n");
+	log_msg(LOG_INFO, "Parse s1ap context release complete message:--");
 
 	int decode_status = convertUeCtxRelComplToProtoIe(msg, &s1_ctx_release_ies);
 	if(decode_status < 0) {
 		free(s1_ctx_release_ies.data);
-		log_msg(LOG_ERROR, "Failed to decode s1ap message\n");
+		log_msg(LOG_ERROR, "Failed to decode s1ap message");
 		return E_FAIL;
 	}
 
@@ -50,7 +50,7 @@ s1_ctx_release_complete_handler(SuccessfulOutcome_t *msg)
 	                release_complete.ue_idx = s1_ctx_release_ies.data[i].val.mme_ue_s1ap_id;
                 }break;
             default:
-                log_msg(LOG_WARNING,"Unhandled IE %d \n",s1_ctx_release_ies.data[i].IE_type);
+                log_msg(LOG_WARNING,"Unhandled IE %d ",s1_ctx_release_ies.data[i].IE_type);
         }
     }
 
@@ -63,11 +63,11 @@ s1_ctx_release_complete_handler(SuccessfulOutcome_t *msg)
 				sizeof(s1_incoming_msg_header_t));
 	if (i < 0) {
 
-		log_msg(LOG_ERROR,"Error To write in s1_ctx_release_code_handler\n");
+		log_msg(LOG_ERROR,"Error To write in s1_ctx_release_code_handler");
 	}
 
 	log_msg(LOG_INFO, "Ctx Release complete sent to mme-app."
-				"Bytes sent %d\n", i);
+				"Bytes sent %d", i);
 
 	free(s1_ctx_release_ies.data);
 	return SUCCESS;

--- a/src/s1ap/handlers/ctxrelease_req.c
+++ b/src/s1ap/handlers/ctxrelease_req.c
@@ -34,12 +34,12 @@ s1_ctx_release_request_handler(InitiatingMessage_t *msg)
 	struct proto_IE s1_ctx_rel_req_ies;
 	s1_ctx_rel_req_ies.data = NULL;
 
-	log_msg(LOG_INFO, "Parse s1ap context release request message:--\n");
+	log_msg(LOG_INFO, "Parse s1ap context release request message:--");
 
 	int decode_status = convertUeCtxRelReqToProtoIe(msg, &s1_ctx_rel_req_ies);
 	if(decode_status < 0) {
 		free(s1_ctx_rel_req_ies.data);
-		log_msg(LOG_ERROR, "Failed to decode s1ap message\n");
+		log_msg(LOG_ERROR, "Failed to decode s1ap message");
 		return E_FAIL;
 	}
 
@@ -58,7 +58,7 @@ s1_ctx_release_request_handler(InitiatingMessage_t *msg)
                         = s1_ctx_rel_req_ies.data[i].val.enb_ue_s1ap_id;
                 }break;
             default:
-                log_msg(LOG_WARNING,"Unhandled IE %d\n",s1_ctx_rel_req_ies.data[i].IE_type);
+                log_msg(LOG_WARNING,"Unhandled IE %d",s1_ctx_rel_req_ies.data[i].IE_type);
         }
     }
 
@@ -72,11 +72,11 @@ s1_ctx_release_request_handler(InitiatingMessage_t *msg)
 				sizeof(release_request));
 				
 	if (i < 0) {
-		log_msg(LOG_ERROR,"Error To write in s1_ctx_release_request_handler\n");
+		log_msg(LOG_ERROR,"Error To write in s1_ctx_release_request_handler");
 	}
 
 	log_msg(LOG_INFO, "Ctx Release request sent to mme-app."
-				"Bytes send %d\n", i);
+				"Bytes send %d", i);
 
 	free(s1_ctx_rel_req_ies.data);
 	return SUCCESS;

--- a/src/s1ap/handlers/ctxrelease_resp.c
+++ b/src/s1ap/handlers/ctxrelease_resp.c
@@ -33,11 +33,11 @@ s1_ctx_release_resp_handler(SuccessfulOutcome_t *msg)
 	struct proto_IE s1_ctx_release_ies;
 	s1_ctx_release_ies.data = NULL;
 
-	log_msg(LOG_INFO, "Parse s1ap context release complete message:--\n");
+	log_msg(LOG_INFO, "Parse s1ap context release complete message:--");
 
 	int decode_status = convertUeCtxRelComplToProtoIe(msg, &s1_ctx_release_ies);
 	if(decode_status < 0) {
-		log_msg(LOG_ERROR, "Failed to decode s1ap message\n");
+		log_msg(LOG_ERROR, "Failed to decode s1ap message");
 		free(s1_ctx_release_ies.data);
 		return E_FAIL;
 	}
@@ -51,7 +51,7 @@ s1_ctx_release_resp_handler(SuccessfulOutcome_t *msg)
 	                release_complete.ue_idx = s1_ctx_release_ies.data[i].val.mme_ue_s1ap_id;
                 }break;
             default:
-                log_msg(LOG_WARNING,"Unhandled IE %d \n",s1_ctx_release_ies.data[i].IE_type);
+                log_msg(LOG_WARNING,"Unhandled IE %d ",s1_ctx_release_ies.data[i].IE_type);
         }
     }
 
@@ -64,11 +64,11 @@ s1_ctx_release_resp_handler(SuccessfulOutcome_t *msg)
 				sizeof(release_complete));
 	if (i < 0) {
 
-		log_msg(LOG_ERROR,"Error To write in s1_ctx_release_code_handler\n");
+		log_msg(LOG_ERROR,"Error To write in s1_ctx_release_code_handler");
 	}
 
 	log_msg(LOG_INFO, "Ctx Release complete sent to mme-app."
-				"Bytes sent %d\n", i);
+				"Bytes sent %d", i);
 
     free(s1_ctx_release_ies.data);
 	return SUCCESS;

--- a/src/s1ap/handlers/detach_accept.c
+++ b/src/s1ap/handlers/detach_accept.c
@@ -115,7 +115,7 @@ detach_accept_processing(const struct detach_accept_Q_msg *g_acptReqInfo)
 	buffer_copy(&g_acpt_buffer, &protocolIe_criticality,
 					sizeof(protocolIe_criticality));
 
-	log_msg(LOG_INFO, "Received detach accept message  - encoded nas message size %d \n",g_acptReqInfo->nasMsgSize);
+	log_msg(LOG_INFO, "Received detach accept message  - encoded nas message size %d ",g_acptReqInfo->nasMsgSize);
 	datalen = g_acptReqInfo->nasMsgSize + 1; 
 	buffer_copy(&g_acpt_buffer, &datalen, sizeof(datalen));
 	buffer_copy(&g_acpt_buffer, (void *)&g_acptReqInfo->nasMsgSize, sizeof(uint8_t));
@@ -151,7 +151,7 @@ ue_ctx_release_processing(const struct detach_accept_Q_msg *g_acptReqInfo)
 	uint8_t s1ap_len_pos;
 	uint8_t u8value = 0;
 
-	log_msg(LOG_INFO, "ue_ctx_release_processing \n");
+	log_msg(LOG_INFO, "ue_ctx_release_processing ");
 	s1apPDU.procedurecode = id_UEContexRelease;
 	s1apPDU.criticality = CRITICALITY_REJECT;
 
@@ -234,14 +234,14 @@ ue_ctx_release_processing(const struct detach_accept_Q_msg *g_acptReqInfo)
 	/* TODO : Revisit. cause : nas(2) and value : detach (2), why 0x24 ? */
 	u8value = 0x24;
 	buffer_copy(&g_ctxrel_buffer, &u8value, sizeof(u8value));
-	log_msg(LOG_INFO,"S1 Release sent to UE pos  = %d \n",g_ctxrel_buffer.pos);
+	log_msg(LOG_INFO,"S1 Release sent to UE pos  = %lu",g_ctxrel_buffer.pos);
 
 	/* Copy length to s1ap length field */
 	datalen = g_ctxrel_buffer.pos - s1ap_len_pos - 1;
 	memcpy(g_ctxrel_buffer.buf + s1ap_len_pos, &datalen, sizeof(datalen));
 	send_sctp_msg(g_acptReqInfo->enb_fd, g_ctxrel_buffer.buf, g_ctxrel_buffer.pos,1);
 
-	log_msg(LOG_INFO,"S1 Release sent to UE size = %d \n",g_ctxrel_buffer.pos);
+	log_msg(LOG_INFO,"S1 Release sent to UE size = %lu",g_ctxrel_buffer.pos);
 	free(s1apPDU.value.data);
 
 	return SUCCESS;
@@ -253,7 +253,7 @@ ue_ctx_release_processing(const struct detach_accept_Q_msg *g_acptReqInfo)
 void*
 detach_accept_handler(void *data)
 {
-   log_msg(LOG_INFO, "detach accept handler ready.\n");
+   log_msg(LOG_INFO, "detach accept handler ready.");
    struct detach_accept_Q_msg *msg = (struct detach_accept_Q_msg *)data;
 
    detach_accept_processing(msg);

--- a/src/s1ap/handlers/enb_status_transfer.c
+++ b/src/s1ap/handlers/enb_status_transfer.c
@@ -21,12 +21,12 @@ int s1_enb_status_transfer_handler(InitiatingMessage_t *msg)
 {
     enb_status_transfer_Q_msg_t ho_enb_status_transfer = {0};
     struct proto_IE ho_enb_status_transfer_ies = {0};
-    log_msg(LOG_INFO, "Parse s1ap handover enb_status_transfer message\n");
+    log_msg(LOG_INFO, "Parse s1ap handover enb_status_transfer message");
 
     int decode_status = convertEnbStatusTransferToProtoIe(msg, &ho_enb_status_transfer_ies);
     if (decode_status < 0)
     {
-        log_msg(LOG_ERROR, "Failed to decode enb-status-transfer message\n");
+        log_msg(LOG_ERROR, "Failed to decode enb-status-transfer message");
 
         if (ho_enb_status_transfer_ies.data != NULL)
             free(ho_enb_status_transfer_ies.data);
@@ -41,7 +41,7 @@ int s1_enb_status_transfer_handler(InitiatingMessage_t *msg)
         case S1AP_IE_MME_UE_ID:
         {
             log_msg(LOG_INFO,
-                    "handover enb_status_transfer S1AP_IE_MME_UE_ID.\n");
+                    "handover enb_status_transfer S1AP_IE_MME_UE_ID.");
             ho_enb_status_transfer.header.ue_idx =
                     ho_enb_status_transfer_ies.data[i].val.mme_ue_s1ap_id;
             ho_enb_status_transfer.s1ap_mme_ue_id =
@@ -51,7 +51,7 @@ int s1_enb_status_transfer_handler(InitiatingMessage_t *msg)
         case S1AP_IE_ENB_UE_ID:
         {
             log_msg(LOG_INFO,
-                    "handover enb_status_transfer S1AP_IE_ENB_UE_ID.\n");
+                    "handover enb_status_transfer S1AP_IE_ENB_UE_ID.");
             ho_enb_status_transfer.header.s1ap_enb_ue_id =
                     ho_enb_status_transfer_ies.data[i].val.enb_ue_s1ap_id;
         }
@@ -59,7 +59,7 @@ int s1_enb_status_transfer_handler(InitiatingMessage_t *msg)
 
         case S1AP_IE_ENB_STATUS_TRANSFER_TRANSPARENTCONTAINER:
         {
-            log_msg(LOG_INFO, "handover enb_status_transfer S1AP_IE_TAI.\n");
+            log_msg(LOG_INFO, "handover enb_status_transfer S1AP_IE_TAI.");
             memcpy(
                     &ho_enb_status_transfer.enB_status_transfer_transparent_containerlist,
                     &ho_enb_status_transfer_ies.data[i].val.enB_status_transfer_transparent_containerlist,
@@ -82,11 +82,11 @@ int s1_enb_status_transfer_handler(InitiatingMessage_t *msg)
     if (i < 0)
     {
         log_msg(LOG_ERROR,
-                "Error To write in s1_enb_status_transfer_handler\n");
+                "Error To write in s1_enb_status_transfer_handler");
     }
 
     log_msg(LOG_INFO, "enb_status_transfer sent to mme-app."
-            "Bytes sent %d\n", i);
+            "Bytes sent %d", i);
 
     if (ho_enb_status_transfer_ies.data != NULL)
         free(ho_enb_status_transfer_ies.data);

--- a/src/s1ap/handlers/erab_mod_confirmation.c
+++ b/src/s1ap/handlers/erab_mod_confirmation.c
@@ -18,7 +18,7 @@
 static int
 erab_mod_confirm_processing(struct erab_mod_confirm *g_erab_mod_conf)
 {
-	log_msg(LOG_DEBUG,"E-RAB Modification Confirmation.\n");
+	log_msg(LOG_DEBUG,"E-RAB Modification Confirmation.");
 
 	uint32_t length = 0;
 	uint8_t *buffer = NULL;
@@ -26,14 +26,14 @@ erab_mod_confirm_processing(struct erab_mod_confirm *g_erab_mod_conf)
 	int ret = s1ap_mme_encode_erab_mod_confirmation(g_erab_mod_conf, &buffer, &length);
 	if(ret == -1)
 	{
-		log_msg(LOG_ERROR, "Encoding E-RAB Modification Confirmation failed.\n");
+		log_msg(LOG_ERROR, "Encoding E-RAB Modification Confirmation failed.");
 		return E_FAIL;
 	}
 
 	send_sctp_msg(
 	        g_erab_mod_conf->enb_context_id, buffer, length, 1);
 
-	log_msg(LOG_DEBUG, "E-RAB Modification Confirmation sent. No. of bytes %d\n", length);
+	log_msg(LOG_DEBUG, "E-RAB Modification Confirmation sent. No. of bytes %d", length);
 	if(buffer != NULL) {
 		free(buffer);
 	}

--- a/src/s1ap/handlers/erab_mod_ind.c
+++ b/src/s1ap/handlers/erab_mod_ind.c
@@ -20,16 +20,16 @@ extern ipc_handle ipc_S1ap_Hndl;
 
 void dump_erab_mod_info(erab_mod_ind_Q_msg_t *msg)
 {
-   log_msg(LOG_INFO, "MME-UE-S1AP-ID %d\n", msg->header.ue_idx);
-   log_msg(LOG_INFO, "eNB-UE-S1AP-ID %d\n", msg->header.s1ap_enb_ue_id);
-   log_msg(LOG_INFO, "erab_mod_list_count %d\n", msg->erab_to_be_mod_list.count);
+   log_msg(LOG_INFO, "MME-UE-S1AP-ID %d", msg->header.ue_idx);
+   log_msg(LOG_INFO, "eNB-UE-S1AP-ID %d", msg->header.s1ap_enb_ue_id);
+   log_msg(LOG_INFO, "erab_mod_list_count %d", msg->erab_to_be_mod_list.count);
    for(int i = 0; i < msg->erab_to_be_mod_list.count; i++)
    {
-       log_msg(LOG_INFO,"erab_to_be_modified_item[%d].erab_id: %d\n", i, msg->erab_to_be_mod_list.
+       log_msg(LOG_INFO,"erab_to_be_modified_item[%d].erab_id: %d", i, msg->erab_to_be_mod_list.
 		       erab_to_be_mod_item[i].e_RAB_ID);
-       log_msg(LOG_INFO,"erab_to_be_modified_item[%d].transportLayerAddress: %x\n", i, msg->erab_to_be_mod_list.
+       log_msg(LOG_INFO,"erab_to_be_modified_item[%d].transportLayerAddress: %x", i, msg->erab_to_be_mod_list.
                        erab_to_be_mod_item[i].transportLayerAddress);
-       log_msg(LOG_INFO,"erab_to_be_modified_item[%d].dl_gtp_teid: %d\n", i, msg->erab_to_be_mod_list.
+       log_msg(LOG_INFO,"erab_to_be_modified_item[%d].dl_gtp_teid: %d", i, msg->erab_to_be_mod_list.
                        erab_to_be_mod_item[i].dl_gtp_teid);
    }
 
@@ -42,7 +42,7 @@ int erab_mod_indication_handler(InitiatingMessage_t *msg)
     int decode_status = convertErabModIndToProtoIe(msg, &erab_mod_ind_ies);
     if (decode_status < 0)
     {
-        log_msg(LOG_ERROR, "Failed to decode ERAB Modification Indication\n");
+        log_msg(LOG_ERROR, "Failed to decode ERAB Modification Indication");
 
         if (erab_mod_ind_ies.data != NULL)
             free(erab_mod_ind_ies.data);
@@ -57,7 +57,7 @@ int erab_mod_indication_handler(InitiatingMessage_t *msg)
         case S1AP_IE_MME_UE_ID:
         {
             log_msg(LOG_INFO,
-                    "ERAB Modification Indication S1AP_IE_MME_UE_ID %d\n", 
+                    "ERAB Modification Indication S1AP_IE_MME_UE_ID %lu", 
 		    erab_mod_ind_ies.data[i].val.mme_ue_s1ap_id);
 
             erab_mod_ind.header.ue_idx = erab_mod_ind_ies.data[i].val.mme_ue_s1ap_id;
@@ -66,7 +66,7 @@ int erab_mod_indication_handler(InitiatingMessage_t *msg)
         case S1AP_IE_ENB_UE_ID:
         {
             log_msg(LOG_INFO,
-                    "ERAB Modification Indication S1AP_IE_ENB_UE_ID %d\n",
+                    "ERAB Modification Indication S1AP_IE_ENB_UE_ID %lu",
 		    erab_mod_ind_ies.data[i].val.enb_ue_s1ap_id);
 
             erab_mod_ind.header.s1ap_enb_ue_id = erab_mod_ind_ies.data[i].val.enb_ue_s1ap_id;
@@ -76,7 +76,7 @@ int erab_mod_indication_handler(InitiatingMessage_t *msg)
         {
             log_msg(LOG_INFO,
                     "ERAB Modification Indication S1AP_IE_E_RAB_TO_BE_MOD_LIST_BEARER_MOD_IND\
-		    received with the count : %d\n", 
+		    received with the count : %d", 
 		    erab_mod_ind_ies.data[i].val.erab_to_be_mod_list.count);
 
             erab_mod_ind.erab_to_be_mod_list.count =
@@ -88,7 +88,7 @@ int erab_mod_indication_handler(InitiatingMessage_t *msg)
         }
             break;
         default:
-            log_msg(LOG_WARNING, "Unhandled IE %d\n", erab_mod_ind_ies.data[i].IE_type);
+            log_msg(LOG_WARNING, "Unhandled IE %d", erab_mod_ind_ies.data[i].IE_type);
         }
     }
 
@@ -102,10 +102,10 @@ int erab_mod_indication_handler(InitiatingMessage_t *msg)
             sizeof(erab_mod_ind));
     if (i < 0)
     {
-        log_msg(LOG_ERROR, "Error To write in erab_mod_ind_handler %s\n", strerror(errno));
+        log_msg(LOG_ERROR, "Error To write in erab_mod_ind_handler %s", strerror(errno));
     }
 
-    log_msg(LOG_INFO, "ERAB Modification Indication sent to mme-app. Bytes sent %d\n", i);
+    log_msg(LOG_INFO, "ERAB Modification Indication sent to mme-app. Bytes sent %d", i);
 
     if (erab_mod_ind_ies.data != NULL)
         free(erab_mod_ind_ies.data);

--- a/src/s1ap/handlers/erab_release_command.c
+++ b/src/s1ap/handlers/erab_release_command.c
@@ -17,7 +17,7 @@
 static int erab_release_command_processing(
         struct erab_release_command_Q_msg *g_erab_rel_cmd)
 {
-    log_msg(LOG_DEBUG, "E-RAB release command Processing.\n");
+    log_msg(LOG_DEBUG, "E-RAB release command Processing.");
 
     uint32_t length = 0;
     uint8_t *buffer = NULL;
@@ -26,14 +26,14 @@ static int erab_release_command_processing(
                                                    &length);
     if(ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding E-RAB release command  failed.\n");
+        log_msg(LOG_ERROR, "Encoding E-RAB release command  failed.");
         return E_FAIL;
     }
 
     send_sctp_msg(g_erab_rel_cmd->enb_context_id, buffer, length, 1);
 
     log_msg(LOG_DEBUG,
-            "E-RAB release command sent. No. of bytes %d on enb_context_id %d\n",
+            "E-RAB release command sent. No. of bytes %d on enb_context_id %d",
             length, g_erab_rel_cmd->enb_context_id);
     if(buffer != NULL) {
         free(buffer);

--- a/src/s1ap/handlers/erab_release_response.c
+++ b/src/s1ap/handlers/erab_release_response.c
@@ -20,23 +20,23 @@ extern ipc_handle ipc_S1ap_Hndl;
 
 void dump_erab_rel_resp(struct erab_rel_resp_Q_msg *msg)
 {
-    log_msg(LOG_INFO, "MME-UE-S1AP-ID %d\n", msg->header.ue_idx);
-    log_msg(LOG_INFO, "eNB-UE-S1AP-ID %d\n", msg->header.s1ap_enb_ue_id);
-    log_msg(LOG_INFO, "erab_release_list_count %d\n",
+    log_msg(LOG_INFO, "MME-UE-S1AP-ID %d", msg->header.ue_idx);
+    log_msg(LOG_INFO, "eNB-UE-S1AP-ID %d", msg->header.s1ap_enb_ue_id);
+    log_msg(LOG_INFO, "erab_release_list_count %d",
             msg->erab_rel_list.count);
     for (int i = 0; i < msg->erab_rel_list.count; i++)
     {
-        log_msg(LOG_INFO, "erab_release item %d::erab_id = %d\n", i,
+        log_msg(LOG_INFO, "erab_release item %d::erab_id = %d", i,
                 msg->erab_rel_list.erab_id[i]);
     }
-    log_msg(LOG_INFO, "erab_failed_to_release_list count %d\n",
+    log_msg(LOG_INFO, "erab_failed_to_release_list count %d",
             msg->erab_failed_to_release_list.count);
     for (int i = 0; i < msg->erab_failed_to_release_list.count; i++)
     {
-        log_msg(LOG_INFO, "erab_failed_to_release item [%d]::erab_id = %d\n", i,
+        log_msg(LOG_INFO, "erab_failed_to_release item [%d]::erab_id = %d", i,
                 msg->erab_failed_to_release_list.erab_item[i].e_RAB_ID);
-        log_msg(LOG_INFO, "erab_failed_to_release item [%d]::Cause = %d\n", i,
-                msg->erab_failed_to_release_list.erab_item[i].cause);
+        log_msg(LOG_INFO, "erab_failed_to_release item [%d]::Cause = %lu", i,
+                msg->erab_failed_to_release_list.erab_item[i].cause.choice.misc);
     }
 
 }
@@ -49,7 +49,7 @@ int erab_release_response_handler(SuccessfulOutcome_t *msg)
     int decode_status = convertErabRelRespToProtoIe(msg, &erab_rel_resp_ies);
     if(decode_status < 0)
     {
-        log_msg(LOG_ERROR, "Failed to decode ERAB Release Response\n");
+        log_msg(LOG_ERROR, "Failed to decode ERAB Release Response");
 
         if(erab_rel_resp_ies.data != NULL)
             free(erab_rel_resp_ies.data);
@@ -64,7 +64,7 @@ int erab_release_response_handler(SuccessfulOutcome_t *msg)
             case S1AP_IE_MME_UE_ID:
             {
                 log_msg(LOG_INFO,
-                        "ERAB Release Response S1AP_IE_MME_UE_ID %d\n",
+                        "ERAB Release Response S1AP_IE_MME_UE_ID %lu",
                         erab_rel_resp_ies.data[i].val.mme_ue_s1ap_id);
 
                 erab_rel_resp.header.ue_idx =
@@ -74,7 +74,7 @@ int erab_release_response_handler(SuccessfulOutcome_t *msg)
             case S1AP_IE_ENB_UE_ID:
             {
                 log_msg(LOG_INFO,
-                        "ERAB Release Response S1AP_IE_ENB_UE_ID %d\n",
+                        "ERAB Release Response S1AP_IE_ENB_UE_ID %lu",
                         erab_rel_resp_ies.data[i].val.enb_ue_s1ap_id);
 
                 erab_rel_resp.header.s1ap_enb_ue_id =
@@ -85,7 +85,7 @@ int erab_release_response_handler(SuccessfulOutcome_t *msg)
             {
                 log_msg(LOG_INFO,
                         "ERAB Release Response S1AP_IE_E_RAB_TO_BE_RELEASED_LIST \
-                     received with the count : %d\n",
+                     received with the count : %d",
                         erab_rel_resp_ies.data[i].val.erab_releaselist.count);
 
                 erab_rel_resp.erab_rel_list.count =
@@ -99,7 +99,7 @@ int erab_release_response_handler(SuccessfulOutcome_t *msg)
             {
                 log_msg(LOG_INFO,
                         "ERAB Release Response S1AP_IE_E_RAB_FAILED_TO_RELEASED_LIST \
-                     received with the count : %d\n",
+                     received with the count : %d",
                         erab_rel_resp_ies.data[i].val.erab_failed_to_release_list.count);
 
                 erab_rel_resp.erab_failed_to_release_list.count =
@@ -110,7 +110,7 @@ int erab_release_response_handler(SuccessfulOutcome_t *msg)
             }
                 break;
             default:
-                log_msg(LOG_WARNING, "Unhandled IE %d\n",
+                log_msg(LOG_WARNING, "Unhandled IE %d",
                         erab_rel_resp_ies.data[i].IE_type);
         }
     }
@@ -125,11 +125,11 @@ int erab_release_response_handler(SuccessfulOutcome_t *msg)
                               sizeof(struct erab_rel_resp_Q_msg));
     if(i < 0)
     {
-        log_msg(LOG_ERROR, "Error To write in erab_rel_resp_handler %s\n",
+        log_msg(LOG_ERROR, "Error To write in erab_rel_resp_handler %s",
                 strerror(errno));
     }
 
-    log_msg(LOG_INFO, "ERAB Release Response sent to mme-app. Bytes sent %d\n",
+    log_msg(LOG_INFO, "ERAB Release Response sent to mme-app. Bytes sent %d",
             i);
 
     if(erab_rel_resp_ies.data != NULL)

--- a/src/s1ap/handlers/erab_setup_request.c
+++ b/src/s1ap/handlers/erab_setup_request.c
@@ -18,7 +18,7 @@
 static int
 erab_setup_req_processing(struct erabsu_ctx_req_Q_msg *g_erab_su_req)
 {
-    log_msg(LOG_DEBUG,"E-RAB Setup Request Processing.\n");
+    log_msg(LOG_DEBUG,"E-RAB Setup Request Processing.");
 
     uint32_t length = 0;
     uint8_t *buffer = NULL;
@@ -26,13 +26,13 @@ erab_setup_req_processing(struct erabsu_ctx_req_Q_msg *g_erab_su_req)
     int ret = s1ap_mme_encode_erab_setup_request(g_erab_su_req, &buffer, &length);
     if(ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding E-RAB Setup Request failed.\n");
+        log_msg(LOG_ERROR, "Encoding E-RAB Setup Request failed.");
         return E_FAIL;
     }
 
     send_sctp_msg(g_erab_su_req->enb_context_id, buffer, length, 1);
 
-    log_msg(LOG_DEBUG, "E-RAB Setup Request sent. No. of bytes %d on enb_context_id %d\n", length, g_erab_su_req->enb_context_id);
+    log_msg(LOG_DEBUG, "E-RAB Setup Request sent. No. of bytes %d on enb_context_id %d", length, g_erab_su_req->enb_context_id);
     if(buffer != NULL) {
         free(buffer);
     }

--- a/src/s1ap/handlers/erab_setup_response.c
+++ b/src/s1ap/handlers/erab_setup_response.c
@@ -20,22 +20,22 @@ extern ipc_handle ipc_S1ap_Hndl;
 
 void dump_erab_su_resp(struct erabSuResp_Q_msg *msg)
 {
-   log_msg(LOG_INFO, "MME-UE-S1AP-ID %d\n", msg->s1ap_mme_ue_id);
-   log_msg(LOG_INFO, "eNB-UE-S1AP-ID %d\n", msg->header.s1ap_enb_ue_id);
-   log_msg(LOG_INFO, "eRABSetupList_count %d\n", msg->erab_su_list.count);
+   log_msg(LOG_INFO, "MME-UE-S1AP-ID %d", msg->s1ap_mme_ue_id);
+   log_msg(LOG_INFO, "eNB-UE-S1AP-ID %d", msg->header.s1ap_enb_ue_id);
+   log_msg(LOG_INFO, "eRABSetupList_count %d", msg->erab_su_list.count);
    for(int i = 0; i < msg->erab_su_list.count; i++)
    {
-       log_msg(LOG_INFO,"eRAB_setup_item[%d].erab_id: %d\n", i, msg->erab_su_list.
+       log_msg(LOG_INFO,"eRAB_setup_item[%d].erab_id: %d", i, msg->erab_su_list.
 		       erab_su_item[i].e_RAB_ID);
        struct in_addr tl_address = 
        			{msg->erab_su_list.erab_su_item[i].transportLayerAddress};
-       log_msg(LOG_INFO,"eRAB_setup_item[%d].transportLayerAddress: %s\n", i, inet_ntoa(tl_address));
-       log_msg(LOG_INFO,"eRAB_setup_item[%d].gtp_teid: %d\n", i, msg->erab_su_list.
+       log_msg(LOG_INFO,"eRAB_setup_item[%d].transportLayerAddress: %s", i, inet_ntoa(tl_address));
+       log_msg(LOG_INFO,"eRAB_setup_item[%d].gtp_teid: %d", i, msg->erab_su_list.
                        erab_su_item[i].gtp_teid);
    }
    for(int i = 0; i < msg->erab_fail_list.count; i++)
    {
-       log_msg(LOG_INFO,"eRAB_failed_to_setup_item[%d].erab_id: %d\n", i, msg->erab_fail_list.
+       log_msg(LOG_INFO,"eRAB_failed_to_setup_item[%d].erab_id: %d", i, msg->erab_fail_list.
 		       erab_fail_item[i].e_RAB_ID);
    }
 
@@ -49,7 +49,7 @@ int erab_setup_response_handler(SuccessfulOutcome_t *msg)
     int decode_status = convertErabSetupRespToProtoIe(msg, &erab_su_resp_ies);
     if (decode_status < 0)
     {
-        log_msg(LOG_ERROR, "Failed to decode ERAB Setup Response\n");
+        log_msg(LOG_ERROR, "Failed to decode ERAB Setup Response");
 
         if (erab_su_resp_ies.data != NULL)
             free(erab_su_resp_ies.data);
@@ -64,7 +64,7 @@ int erab_setup_response_handler(SuccessfulOutcome_t *msg)
             case S1AP_IE_MME_UE_ID:
             {
                 log_msg(LOG_INFO,
-                    "ERAB Setup Response S1AP_IE_MME_UE_ID %d\n", 
+                    "ERAB Setup Response S1AP_IE_MME_UE_ID %lu", 
                 erab_su_resp_ies.data[i].val.mme_ue_s1ap_id);
 
                 erab_su_resp.header.ue_idx = erab_su_resp_ies.data[i].val.mme_ue_s1ap_id;
@@ -73,7 +73,7 @@ int erab_setup_response_handler(SuccessfulOutcome_t *msg)
             case S1AP_IE_ENB_UE_ID:
             {
                 log_msg(LOG_INFO,
-                    "ERAB Setup Response S1AP_IE_ENB_UE_ID %d\n",
+                    "ERAB Setup Response S1AP_IE_ENB_UE_ID %lu",
                 erab_su_resp_ies.data[i].val.enb_ue_s1ap_id);
 
                 erab_su_resp.header.s1ap_enb_ue_id = erab_su_resp_ies.data[i].val.enb_ue_s1ap_id;
@@ -83,7 +83,7 @@ int erab_setup_response_handler(SuccessfulOutcome_t *msg)
             {   
                 log_msg(LOG_INFO,
                     "ERAB Setup Response S1AP_IE_E_RAB_SETUP_LIST_BEARER_SU_RES \
-		             received with the count : %d\n", 
+		             received with the count : %d", 
                      erab_su_resp_ies.data[i].val.erab_su_list.count);
 
                 erab_su_resp.erab_su_list.count =
@@ -98,7 +98,7 @@ int erab_setup_response_handler(SuccessfulOutcome_t *msg)
             {
                 log_msg(LOG_INFO,
                     "ERAB Setup Response S1AP_IE_E_RAB_FAILED_TO_SETUP_LIST_BEARER_SU_RES \
-		             received with the count : %d\n", 
+		             received with the count : %d", 
                      erab_su_resp_ies.data[i].val.erab_fail_list.count);
 
                 erab_su_resp.erab_fail_list.count =
@@ -110,7 +110,7 @@ int erab_setup_response_handler(SuccessfulOutcome_t *msg)
             }
             break;
             default:
-                log_msg(LOG_WARNING, "Unhandled IE %d\n", erab_su_resp_ies.data[i].IE_type);
+                log_msg(LOG_WARNING, "Unhandled IE %d", erab_su_resp_ies.data[i].IE_type);
         }
     }
 
@@ -124,10 +124,10 @@ int erab_setup_response_handler(SuccessfulOutcome_t *msg)
             sizeof(struct erabSuResp_Q_msg));
     if (i < 0)
     {
-        log_msg(LOG_ERROR, "Error To write in erab_su_resp_handler %s\n", strerror(errno));
+        log_msg(LOG_ERROR, "Error To write in erab_su_resp_handler %s", strerror(errno));
     }
 
-    log_msg(LOG_INFO, "ERAB Setup Response sent to mme-app. Bytes sent %d\n", i);
+    log_msg(LOG_INFO, "ERAB Setup Response sent to mme-app. Bytes sent %d", i);
 
     free(erab_su_resp_ies.data);
 

--- a/src/s1ap/handlers/handle_emmreq.c
+++ b/src/s1ap/handlers/handle_emmreq.c
@@ -132,7 +132,7 @@ emm_info_request_processing(struct ue_emm_info *g_ueEmmInfoMsg)
 		    sizeof(protocolIe_criticality));
 
 
-	log_msg(LOG_INFO, "Received EMM information request has nas message %d \n",g_ueEmmInfoMsg->nasMsgSize);
+	log_msg(LOG_INFO, "Received EMM information request has nas message %d ",g_ueEmmInfoMsg->nasMsgSize);
 	datalen = g_ueEmmInfoMsg->nasMsgSize + 1; 
 	buffer_copy(&g_s1ap_buffer, &datalen, sizeof(datalen));
 	buffer_copy(&g_s1ap_buffer, &g_ueEmmInfoMsg->nasMsgSize, sizeof(uint8_t));
@@ -145,10 +145,10 @@ emm_info_request_processing(struct ue_emm_info *g_ueEmmInfoMsg)
     buffer_copy(&g_buffer, &g_s1ap_buffer.buf[0], g_s1ap_buffer.pos);
     /* Now s1ap header + s1ap buffer is attached */
     
-    log_msg(LOG_INFO, "EMM info request sent on fd = %u , enb-id %u mmeid %u EMM \n",g_ueEmmInfoMsg->enb_fd, 
+    log_msg(LOG_INFO, "EMM info request sent on fd = %u , enb-id %u mmeid %u EMM ",g_ueEmmInfoMsg->enb_fd, 
 		    g_ueEmmInfoMsg->enb_s1ap_ue_id, g_ueEmmInfoMsg->mme_s1ap_ue_id);
 
-    log_msg(LOG_INFO, "EMM info request : Buffer size %d g_ueEmmInfoMsg = %p \n", g_buffer.pos,g_ueEmmInfoMsg);
+    log_msg(LOG_INFO, "EMM info request : Buffer size %lu g_ueEmmInfoMsg = %p ", g_buffer.pos,g_ueEmmInfoMsg);
 
     send_sctp_msg(g_ueEmmInfoMsg->enb_fd, g_buffer.buf, g_buffer.pos, 1);
     
@@ -158,7 +158,7 @@ emm_info_request_processing(struct ue_emm_info *g_ueEmmInfoMsg)
 void*
 emm_info_req_handler(void *data)
 {
-    log_msg(LOG_INFO, "emm_info_req_handler ready.\n");
+    log_msg(LOG_INFO, "emm_info_req_handler ready.");
     
     emm_info_request_processing((struct ue_emm_info *) data);
     

--- a/src/s1ap/handlers/handover_ack.c
+++ b/src/s1ap/handlers/handover_ack.c
@@ -19,15 +19,15 @@ extern ipc_handle ipc_S1ap_Hndl;
 
 void dumpHOReqAck(struct handover_req_acknowledge_Q_msg* msg)
 {
-    log_msg(LOG_INFO, "MME-UE-S1AP-ID %d\n", msg->s1ap_mme_ue_id);
-    log_msg(LOG_INFO, "eNB-UE-S1AP-ID %d\n", msg->header.s1ap_enb_ue_id);
-    log_msg(LOG_INFO, "eRAB Admitted list count %d\n", msg->erab_admitted_list.count);
-    log_msg(LOG_INFO, "eRAB ID %d\n", msg->erab_admitted_list.erab_admitted[0].e_RAB_ID);
-    log_msg(LOG_INFO, "eRAB GTP TEID %d\n", msg->erab_admitted_list.erab_admitted[0].gtp_teid);
-    log_msg(LOG_INFO, "eRAB S1uENB IP %x\n", msg->erab_admitted_list.erab_admitted[0].transportLayerAddress);
-    log_msg(LOG_INFO, "eRAB DL GTP TEID %d\n", msg->erab_admitted_list.erab_admitted[0].dL_gtp_teid);
-    log_msg(LOG_INFO, "eRAB DL IP %x\n", msg->erab_admitted_list.erab_admitted[0].dL_transportLayerAddress);
-    log_msg(LOG_INFO, "TRANS Container Size %d\n", msg->targetToSrcTranspContainer.count);
+    log_msg(LOG_INFO, "MME-UE-S1AP-ID %d", msg->s1ap_mme_ue_id);
+    log_msg(LOG_INFO, "eNB-UE-S1AP-ID %d", msg->header.s1ap_enb_ue_id);
+    log_msg(LOG_INFO, "eRAB Admitted list count %d", msg->erab_admitted_list.count);
+    log_msg(LOG_INFO, "eRAB ID %d", msg->erab_admitted_list.erab_admitted[0].e_RAB_ID);
+    log_msg(LOG_INFO, "eRAB GTP TEID %d", msg->erab_admitted_list.erab_admitted[0].gtp_teid);
+    log_msg(LOG_INFO, "eRAB S1uENB IP %x", msg->erab_admitted_list.erab_admitted[0].transportLayerAddress);
+    log_msg(LOG_INFO, "eRAB DL GTP TEID %d", msg->erab_admitted_list.erab_admitted[0].dL_gtp_teid);
+    log_msg(LOG_INFO, "eRAB DL IP %x", msg->erab_admitted_list.erab_admitted[0].dL_transportLayerAddress);
+    log_msg(LOG_INFO, "TRANS Container Size %d", msg->targetToSrcTranspContainer.count);
 }
 
 int s1_handover_ack_handler(SuccessfulOutcome_t *msg)
@@ -38,7 +38,7 @@ int s1_handover_ack_handler(SuccessfulOutcome_t *msg)
     int decode_status = convertHoAcklToProtoIe(msg, &s1_ho_ack_ies); //create
     if (decode_status < 0)
     {
-        log_msg(LOG_ERROR, "Failed to decode HO Request Ack\n");
+        log_msg(LOG_ERROR, "Failed to decode HO Request Ack");
 
         if (s1_ho_ack_ies.data != NULL)
             free(s1_ho_ack_ies.data);
@@ -54,7 +54,7 @@ int s1_handover_ack_handler(SuccessfulOutcome_t *msg)
         case S1AP_IE_MME_UE_ID:
         {
             log_msg(LOG_INFO,
-                    "Handover Request Ack S1AP_IE_MME_UE_ID.\n");
+                    "Handover Request Ack S1AP_IE_MME_UE_ID.");
 
             handover_ack.header.ue_idx = s1_ho_ack_ies.data[i].val.mme_ue_s1ap_id;
             handover_ack.s1ap_mme_ue_id =
@@ -64,7 +64,7 @@ int s1_handover_ack_handler(SuccessfulOutcome_t *msg)
         case S1AP_IE_ENB_UE_ID:
         {
             log_msg(LOG_INFO,
-                    "Handover Request Ack S1AP_IE_ENB_UE_ID.\n");
+                    "Handover Request Ack S1AP_IE_ENB_UE_ID.");
 
             handover_ack.header.s1ap_enb_ue_id =
                     s1_ho_ack_ies.data[i].val.enb_ue_s1ap_id;
@@ -73,7 +73,7 @@ int s1_handover_ack_handler(SuccessfulOutcome_t *msg)
         case S1AP_IE_E_RAB_ADMITTED:
         {
             log_msg(LOG_INFO,
-                    "Handover Request Ack S1AP_IE_E_RAB_ADMITTED.\n");
+                    "Handover Request Ack S1AP_IE_E_RAB_ADMITTED.");
 
             handover_ack.erab_admitted_list.count =
                     s1_ho_ack_ies.data[i].val.erab_admittedlist.count;
@@ -86,7 +86,7 @@ int s1_handover_ack_handler(SuccessfulOutcome_t *msg)
         case S1AP_IE_TARGET_TOSOURCE_TRANSPARENTCONTAINER:
         {
             log_msg(LOG_INFO,
-                    "Handover Request Ack S1AP_IE_TARGET_TOSOURCE_TRANSPARENTCONTAINER.\n");
+                    "Handover Request Ack S1AP_IE_TARGET_TOSOURCE_TRANSPARENTCONTAINER.");
 
             handover_ack.targetToSrcTranspContainer.count =
                     s1_ho_ack_ies.data[i].val.targetToSrcTranspContainer.size;
@@ -112,10 +112,10 @@ int s1_handover_ack_handler(SuccessfulOutcome_t *msg)
             sizeof(struct handover_req_acknowledge_Q_msg));
     if (i < 0)
     {
-        log_msg(LOG_ERROR, "Error To write in s1_handover_ack_handler\n");
+        log_msg(LOG_ERROR, "Error To write in s1_handover_ack_handler");
     }
 
-    log_msg(LOG_INFO, "Handover Request Ack sent to mme-app. Bytes sent %d\n", i);
+    log_msg(LOG_INFO, "Handover Request Ack sent to mme-app. Bytes sent %d", i);
 
     if (s1_ho_ack_ies.data != NULL)
         free(s1_ho_ack_ies.data);

--- a/src/s1ap/handlers/handover_cancel.c
+++ b/src/s1ap/handlers/handover_cancel.c
@@ -21,12 +21,12 @@ int s1_handover_cancel_handler(InitiatingMessage_t *msg)
 {
     handover_cancel_Q_msg_t ho_cancel = {0};
     struct proto_IE ho_cancel_ies = {0};
-    log_msg(LOG_INFO, "Parse s1ap handover cancel message\n");
+    log_msg(LOG_INFO, "Parse s1ap handover cancel message");
 
     int decode_status = convertUeHoCancelToProtoIe(msg, &ho_cancel_ies);
     if (decode_status < 0)
     {
-        log_msg(LOG_ERROR, "Failed to decode HO Cancel\n");
+        log_msg(LOG_ERROR, "Failed to decode HO Cancel");
 
         if (ho_cancel_ies.data != NULL)
             free(ho_cancel_ies.data);
@@ -39,14 +39,14 @@ int s1_handover_cancel_handler(InitiatingMessage_t *msg)
         {
         case S1AP_IE_MME_UE_ID:
         {
-            log_msg(LOG_INFO, "handover cancel S1AP_IE_MME_UE_ID.\n");
+            log_msg(LOG_INFO, "handover cancel S1AP_IE_MME_UE_ID.");
 
             ho_cancel.header.ue_idx = ho_cancel_ies.data[i].val.mme_ue_s1ap_id;
         }
             break;
         case S1AP_IE_ENB_UE_ID:
         {
-            log_msg(LOG_INFO,"handover cancel S1AP_IE_ENB_UE_ID.\n");
+            log_msg(LOG_INFO,"handover cancel S1AP_IE_ENB_UE_ID.");
 
             ho_cancel.header.s1ap_enb_ue_id = ho_cancel_ies.data[i].val.enb_ue_s1ap_id;
 
@@ -54,7 +54,7 @@ int s1_handover_cancel_handler(InitiatingMessage_t *msg)
             break;
        case S1AP_IE_CAUSE:
         {
-            log_msg(LOG_INFO, "handover cancel S1AP_IE_CAUSE.\n");
+            log_msg(LOG_INFO, "handover cancel S1AP_IE_CAUSE.");
 
             memcpy(&ho_cancel.cause,
                     &ho_cancel_ies.data[i].val.cause,
@@ -76,7 +76,7 @@ int s1_handover_cancel_handler(InitiatingMessage_t *msg)
 
     if (i < 0)
     {
-        log_msg(LOG_ERROR, "Error To write in s1_handover_cancel_handler\n");
+        log_msg(LOG_ERROR, "Error To write in s1_handover_cancel_handler");
     }
     if (ho_cancel_ies.data != NULL)
         free(ho_cancel_ies.data);

--- a/src/s1ap/handlers/handover_cancel_ack.c
+++ b/src/s1ap/handlers/handover_cancel_ack.c
@@ -26,14 +26,14 @@ static int handover_cancel_ack_processing(
             &length);
     if (ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding Handover Cancel Acknowledge failed.\n");
+        log_msg(LOG_ERROR, "Encoding Handover Cancel Acknowledge failed.");
         return E_FAIL;
     }
 
     send_sctp_msg(g_ho_cancel_ack->src_enb_context_id, buffer, length, 1);
 
     log_msg(LOG_DEBUG,
-            "HO Handover Cancel Acknowledge Sent. Num of bytes - %d\n", length);
+            "HO Handover Cancel Acknowledge Sent. Num of bytes - %d", length);
 	if(buffer != NULL) {
 		free(buffer);
 	}

--- a/src/s1ap/handlers/handover_command.c
+++ b/src/s1ap/handlers/handover_command.c
@@ -18,7 +18,7 @@
 static int
 handover_command_processing(struct handover_command_Q_msg *g_ho_cmd)
 {
-	log_msg(LOG_DEBUG,"Process Handover Command.\n");
+	log_msg(LOG_DEBUG,"Process Handover Command.");
 
 	uint32_t length = 0;
 	uint8_t *buffer = NULL;
@@ -26,14 +26,14 @@ handover_command_processing(struct handover_command_Q_msg *g_ho_cmd)
 	int ret = s1ap_mme_encode_handover_command(g_ho_cmd, &buffer, &length);
 	if(ret == -1)
 	{
-		log_msg(LOG_ERROR, "Encoding Handover Command failed.\n");
+		log_msg(LOG_ERROR, "Encoding Handover Command failed.");
 		return E_FAIL;
 	}
 
 	send_sctp_msg(
 	        g_ho_cmd->src_enb_context_id, buffer, length, 1);
 
-	log_msg(LOG_DEBUG, "HO Command sent. No. of bytes %d\n", length);
+	log_msg(LOG_DEBUG, "HO Command sent. No. of bytes %d", length);
 	if(buffer != NULL) {
 		free(buffer);
 	}

--- a/src/s1ap/handlers/handover_failure.c
+++ b/src/s1ap/handlers/handover_failure.c
@@ -21,12 +21,12 @@ int s1_handover_faliure_handler(UnsuccessfulOutcome_t *msg)
 {
     handover_failure_Q_msg_t ho_failure = {0};
     struct proto_IE ho_failure_ies = {0};
-    log_msg(LOG_INFO, "Parse s1ap handover failure message\n");
+    log_msg(LOG_INFO, "Parse s1ap handover failure message");
 
     int decode_status = convertHoFailureToProtoIe(msg, &ho_failure_ies);
     if (decode_status < 0)
     {
-        log_msg(LOG_ERROR, "Failed to decode HO Failure\n");
+        log_msg(LOG_ERROR, "Failed to decode HO Failure");
 
         if (ho_failure_ies.data != NULL)
             free(ho_failure_ies.data);
@@ -39,14 +39,14 @@ int s1_handover_faliure_handler(UnsuccessfulOutcome_t *msg)
         {
         case S1AP_IE_MME_UE_ID:
         {
-            log_msg(LOG_INFO, "handover failure S1AP_IE_MME_UE_ID.\n");
+            log_msg(LOG_INFO, "handover failure S1AP_IE_MME_UE_ID.");
 
             ho_failure.header.ue_idx = ho_failure_ies.data[i].val.mme_ue_s1ap_id;
         }
             break;
         case S1AP_IE_CAUSE:
         {
-            log_msg(LOG_INFO, "handover failure S1AP_IE_CAUSE.\n");
+            log_msg(LOG_INFO, "handover failure S1AP_IE_CAUSE.");
 
             memcpy(&ho_failure.cause,
                     &ho_failure_ies.data[i].val.cause,
@@ -68,7 +68,7 @@ int s1_handover_faliure_handler(UnsuccessfulOutcome_t *msg)
 
     if (i < 0)
     {
-        log_msg(LOG_ERROR, "Error To write in s1_handover_faliure_handler\n");
+        log_msg(LOG_ERROR, "Error To write in s1_handover_faliure_handler");
     }
     if (ho_failure_ies.data != NULL)
         free(ho_failure_ies.data);

--- a/src/s1ap/handlers/handover_notify.c
+++ b/src/s1ap/handlers/handover_notify.c
@@ -21,12 +21,12 @@ int s1_handover_notify_handler(InitiatingMessage_t *msg)
 {
     handover_notify_Q_msg_t notify = {0};
     struct proto_IE ho_notify_ies = {0};
-    log_msg(LOG_INFO, "Parse s1ap handover notify message\n");
+    log_msg(LOG_INFO, "Parse s1ap handover notify message");
 
     int decode_status = convertHoNotifyToProtoIe(msg, &ho_notify_ies);
     if (decode_status < 0)
     {
-        log_msg(LOG_ERROR, "Failed to decode HO Notify\n");
+        log_msg(LOG_ERROR, "Failed to decode HO Notify");
 
         if (ho_notify_ies.data != NULL)
             free(ho_notify_ies.data);
@@ -40,7 +40,7 @@ int s1_handover_notify_handler(InitiatingMessage_t *msg)
         {
         case S1AP_IE_MME_UE_ID:
         {
-            log_msg(LOG_INFO, "handover notify S1AP_IE_MME_UE_ID.\n");
+            log_msg(LOG_INFO, "handover notify S1AP_IE_MME_UE_ID.");
             notify.header.ue_idx = ho_notify_ies.data[i].val.mme_ue_s1ap_id;
             notify.s1ap_mme_ue_id =
                     ho_notify_ies.data[i].val.mme_ue_s1ap_id;
@@ -48,21 +48,21 @@ int s1_handover_notify_handler(InitiatingMessage_t *msg)
             break;
         case S1AP_IE_ENB_UE_ID:
         {
-            log_msg(LOG_INFO, "handover notify S1AP_IE_ENB_UE_ID.\n");
+            log_msg(LOG_INFO, "handover notify S1AP_IE_ENB_UE_ID.");
             notify.header.s1ap_enb_ue_id =
                     ho_notify_ies.data[i].val.enb_ue_s1ap_id;
         }
             break;
         case S1AP_IE_UTRAN_CGI:
         {
-            log_msg(LOG_INFO, "handover notify S1AP_IE_UTRAN_CGI.\n");
+            log_msg(LOG_INFO, "handover notify S1AP_IE_UTRAN_CGI.");
             memcpy(&notify.utran_cgi,
                     &ho_notify_ies.data[i].val.utran_cgi, sizeof(struct CGI));
         }
             break;
         case S1AP_IE_TAI:
         {
-            log_msg(LOG_INFO, "handover notify S1AP_IE_TAI.\n");
+            log_msg(LOG_INFO, "handover notify S1AP_IE_TAI.");
             memcpy(&notify.tai,
                     &ho_notify_ies.data[i].val.tai, sizeof(struct TAI));
         }
@@ -81,11 +81,11 @@ int s1_handover_notify_handler(InitiatingMessage_t *msg)
             sizeof(notify));
     if (i < 0)
     {
-        log_msg(LOG_ERROR, "Error To write in s1_handover_notify_handler\n");
+        log_msg(LOG_ERROR, "Error To write in s1_handover_notify_handler");
     }
 
     log_msg(LOG_INFO, "Handover notify complete sent to mme-app."
-            "Bytes sent %d\n", i);
+            "Bytes sent %d", i);
 
     if (ho_notify_ies.data != NULL)
         free(ho_notify_ies.data);

--- a/src/s1ap/handlers/handover_preparation_failure.c
+++ b/src/s1ap/handlers/handover_preparation_failure.c
@@ -26,14 +26,14 @@ static int handover_preparation_failure_processing(
             &length);
     if (ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding Handover Preparation Failure failed.\n");
+        log_msg(LOG_ERROR, "Encoding Handover Preparation Failure failed.");
         return E_FAIL;
     }
 
     send_sctp_msg(g_ho_prep_fail->src_enb_context_id, buffer, length, 1);
 
     log_msg(LOG_DEBUG,
-            "HO Handover Preparation Failure Sent. Num of bytes - %d\n",
+            "HO Handover Preparation Failure Sent. Num of bytes - %d",
             length);
 
 	if(buffer != NULL) {

--- a/src/s1ap/handlers/handover_request.c
+++ b/src/s1ap/handlers/handover_request.c
@@ -17,7 +17,7 @@
 static int
 handover_request_processing(struct handover_request_Q_msg *g_ho_req)
 {
-	log_msg(LOG_DEBUG,"Process Handover Request. %d\n",g_ho_req->target_enb_context_id);
+	log_msg(LOG_DEBUG,"Process Handover Request. %d",g_ho_req->target_enb_context_id);
 
 	uint32_t length = 0;
     uint8_t *buffer = NULL;
@@ -25,14 +25,14 @@ handover_request_processing(struct handover_request_Q_msg *g_ho_req)
 	int ret = s1ap_mme_encode_handover_request(g_ho_req, &buffer, &length);
     if (ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding handover request failed.\n");
+        log_msg(LOG_ERROR, "Encoding handover request failed.");
         return E_FAIL;
     }
 
 	send_sctp_msg(g_ho_req->target_enb_context_id, buffer, length, 1);
 
 	log_msg(LOG_DEBUG,
-	        "HO Request Sent. Num of bytes - %d, enb_fd - %d\n",
+	        "HO Request Sent. Num of bytes - %d, enb_fd - %d",
 	        length, g_ho_req->target_enb_context_id);
 	
 	if(buffer != NULL) {

--- a/src/s1ap/handlers/handover_required.c
+++ b/src/s1ap/handlers/handover_required.c
@@ -20,11 +20,11 @@ extern ipc_handle ipc_S1ap_Hndl;
 
 void dumpHoRequired(handover_required_Q_msg_t *msg)
 {
-    log_msg(LOG_INFO, "MME-UE-S1AP-ID %d\n", msg->s1ap_mme_ue_id);
-    log_msg(LOG_INFO, "eNB-UE-S1AP-ID %d\n", msg->header.s1ap_enb_ue_id);
-    log_msg(LOG_INFO, "HO Type %d\n", msg->handoverType);
-    log_msg(LOG_INFO, "S1AP Cause %d\n", msg->cause.choice.radioNetwork);
-    log_msg(LOG_INFO, "Transp Cont Size %d\n",
+    log_msg(LOG_INFO, "MME-UE-S1AP-ID %d", msg->s1ap_mme_ue_id);
+    log_msg(LOG_INFO, "eNB-UE-S1AP-ID %d", msg->header.s1ap_enb_ue_id);
+    log_msg(LOG_INFO, "HO Type %d", msg->handoverType);
+    log_msg(LOG_INFO, "S1AP Cause %lu", msg->cause.choice.radioNetwork);
+    log_msg(LOG_INFO, "Transp Cont Size %d",
             msg->srcToTargetTranspContainer.count);
 
     /*char container[4096] = {0};
@@ -34,7 +34,7 @@ void dumpHoRequired(handover_required_Q_msg_t *msg)
      sprintf(&container[j], "%02x ", (int)msg->srcToTargetTranspContainer.buffer[i]);
      j = j+3;
      }
-     log_msg(LOG_INFO, "Container is \n %s \n", container);*/
+     log_msg(LOG_INFO, "Container is  %s ", container);*/
 }
 
 int s1_handover_required_handler(InitiatingMessage_t *msg, int enb_fd)
@@ -42,12 +42,12 @@ int s1_handover_required_handler(InitiatingMessage_t *msg, int enb_fd)
     handover_required_Q_msg_t ho_required = {0};
     struct proto_IE ho_required_ies = {0};
     int enb_id = 0;
-    log_msg(LOG_INFO, "Parse s1ap handover required message\n");
+    log_msg(LOG_INFO, "Parse s1ap handover required message");
 
     int decode_status = convertUehoReqToProtoIe(msg, &ho_required_ies);
     if (decode_status < 0)
     {
-        log_msg(LOG_ERROR, "Failed to decode HO Required\n");
+        log_msg(LOG_ERROR, "Failed to decode HO Required");
 
         if (ho_required_ies.data != NULL)
             free(ho_required_ies.data);
@@ -65,7 +65,7 @@ int s1_handover_required_handler(InitiatingMessage_t *msg, int enb_fd)
             ho_required.header.ue_idx = ho_required_ies.data[i].val.mme_ue_s1ap_id;
             ho_required.s1ap_mme_ue_id =
                     ho_required_ies.data[i].val.mme_ue_s1ap_id;
-            log_msg(LOG_INFO, "handover required S1AP_IE_MME_UE_ID %u .\n",ho_required.header.ue_idx);
+            log_msg(LOG_INFO, "handover required S1AP_IE_MME_UE_ID %u .",ho_required.header.ue_idx);
         }
             break;
         case S1AP_IE_ENB_UE_ID:
@@ -74,12 +74,12 @@ int s1_handover_required_handler(InitiatingMessage_t *msg, int enb_fd)
             ho_required.header.s1ap_enb_ue_id =
                     ho_required_ies.data[i].val.enb_ue_s1ap_id;
 
-            log_msg(LOG_INFO, "handover required S1AP_IE_ENB_UE_ID %u .\n",ho_required.header.s1ap_enb_ue_id);
+            log_msg(LOG_INFO, "handover required S1AP_IE_ENB_UE_ID %u .",ho_required.header.s1ap_enb_ue_id);
         }
             break;
         case S1AP_IE_HANDOVER_TYPE:
         {
-            log_msg(LOG_INFO, "handover required S1AP_IE_HANDOVER_TYPE.\n");
+            log_msg(LOG_INFO, "handover required S1AP_IE_HANDOVER_TYPE.");
 
             ho_required.handoverType =
                     ho_required_ies.data[i].val.handoverType;
@@ -87,7 +87,7 @@ int s1_handover_required_handler(InitiatingMessage_t *msg, int enb_fd)
             break;
         case S1AP_IE_CAUSE:
         {
-            log_msg(LOG_INFO, "handover required S1AP_IE_CAUSE.\n");
+            log_msg(LOG_INFO, "handover required S1AP_IE_CAUSE.");
 
             memcpy(&ho_required.cause,
                     &ho_required_ies.data[i].val.cause,
@@ -96,7 +96,7 @@ int s1_handover_required_handler(InitiatingMessage_t *msg, int enb_fd)
             break;
         case S1AP_IE_TARGET_ID:
         {
-            log_msg(LOG_INFO, "handover required S1AP_IE_TARGET_ID.\n");
+            log_msg(LOG_INFO, "handover required S1AP_IE_TARGET_ID.");
 
             memcpy(&ho_required.target_id,
                     &ho_required_ies.data[i].val.target_id,
@@ -111,14 +111,14 @@ int s1_handover_required_handler(InitiatingMessage_t *msg, int enb_fd)
             val = enb_id_buf[2] & 0xf0;
             enb_id |= val >> 4;
 
-            log_msg(LOG_INFO, "enbId %d\n", enb_id);
+            log_msg(LOG_INFO, "enbId %d", enb_id);
 
         }
             break;
         case S1AP_IE_SOURCE_TOTARGET_TRANSPARENTCONTAINER:
         {
             log_msg(LOG_INFO,
-                    "handover required S1AP_IE_SOURCE_TOTARGET_TRANSPARENTCONTAINER.\n");
+                    "handover required S1AP_IE_SOURCE_TOTARGET_TRANSPARENTCONTAINER.");
 
             ho_required.srcToTargetTranspContainer.count =
                     ho_required_ies.data[i].val.srcToTargetTranspContainer.size;
@@ -159,7 +159,7 @@ int s1_handover_required_handler(InitiatingMessage_t *msg, int enb_fd)
     cbIndex = findControlBlockWithEnbFd(enb_fd);
     if (cbIndex == INVALID_CB_INDEX)
     {
-	    log_msg(LOG_ERROR, "No CB found for enb fd %d.\n", enb_fd);
+	    log_msg(LOG_ERROR, "No CB found for enb fd %d.", enb_fd);
         if (ho_required_ies.data != NULL)
             free(ho_required_ies.data);
 	    return E_FAIL;
@@ -177,7 +177,7 @@ int s1_handover_required_handler(InitiatingMessage_t *msg, int enb_fd)
 
     if (i < 0)
     {
-        log_msg(LOG_ERROR, "Error To write in s1_handover_required_handler\n");
+        log_msg(LOG_ERROR, "Error To write in s1_handover_required_handler");
     }
 
     if (ho_required_ies.data != NULL)

--- a/src/s1ap/handlers/ics_req_paging.c
+++ b/src/s1ap/handlers/ics_req_paging.c
@@ -35,7 +35,7 @@ get_uectxtrelcmd_protoie_value(struct proto_IE *value, struct s1relcmd_info *g_u
 	
 	value->data[1].enb_ue_s1ap_id = g_uectxtrelcmd->enb_s1ap_ue_id;
 	
-	log_msg(LOG_INFO, "mme_ue_s1ap_id %d and enb_ue_s1ap_id %d\n",
+	log_msg(LOG_INFO, "mme_ue_s1ap_id %d and enb_ue_s1ap_id %d",
 					g_uectxtrelcmd->ue_idx,g_uectxtrelcmd->enb_s1ap_ue_id);
 	return SUCCESS;
 }*/
@@ -52,7 +52,7 @@ ics_req_paging_processing(struct ics_req_paging_Q_msg *g_icsreq)
 
 	struct s1ap_common_req_Q_msg req = {0};
 
-	log_msg(LOG_DEBUG,"Inside ics_req_paging processing\n");	
+	log_msg(LOG_DEBUG,"Inside ics_req_paging processing");	
 
 	req.IE_type = S1AP_INIT_CTXT_SETUP_REQ;
 	req.ue_idx = g_icsreq->ue_idx;
@@ -81,13 +81,13 @@ ics_req_paging_processing(struct ics_req_paging_Q_msg *g_icsreq)
 	}
 	memcpy(&(req.sec_key), &(g_icsreq->sec_key), KENB_SIZE);	
 	
-	log_msg(LOG_DEBUG,"Before s1ap_encoder\n");
+	log_msg(LOG_DEBUG,"Before s1ap_encoder");
 
 	int ret = s1ap_mme_encode_initiating(&req, &buffer, &length);
-	log_msg(LOG_DEBUG,"Invoked s1ap_encoder\n");
+	log_msg(LOG_DEBUG,"Invoked s1ap_encoder");
 	if(ret == -1)
 	{
-		log_msg(LOG_ERROR, "Encoding ics_req_paging failed.\n");
+		log_msg(LOG_ERROR, "Encoding ics_req_paging failed.");
 		return E_FAIL;
 	}
 
@@ -95,7 +95,7 @@ ics_req_paging_processing(struct ics_req_paging_Q_msg *g_icsreq)
 	if(buffer) {
 		free(buffer);
 	}
-	log_msg(LOG_INFO, "\n----ICS Req for paging sent to UE.---\n");
+	log_msg(LOG_INFO, "----ICS Req for paging sent to UE.---");
 	return SUCCESS;
 	
 }
@@ -108,7 +108,7 @@ void*
 ics_req_paging_handler(void *data)
 {
 
-	log_msg(LOG_INFO,"ICS Req for paging handler ready.\n");
+	log_msg(LOG_INFO,"ICS Req for paging handler ready.");
 	
 	ics_req_paging_processing((struct ics_req_paging_Q_msg *)data);
 

--- a/src/s1ap/handlers/ie_parsers.c
+++ b/src/s1ap/handlers/ie_parsers.c
@@ -30,8 +30,8 @@ ie_parse_global_enb_id(char *msg, int len)
 	memcpy(&(global_enb_id.macro_enb_id), msg+(sizeof(int)), MACRO_ENB_ID_SIZE);
 	global_enb_id.plmn = ntohl(global_enb_id.plmn);
 	//global_enb_id.macro_enb_id = ntohl(global_enb_id.macro_enb_id);
-	log_msg(LOG_INFO, "plmn %x\n", global_enb_id.plmn);
-	log_msg(LOG_INFO, "Macro enb id %x-%x-%x-%x\n", global_enb_id.macro_enb_id[0],
+	log_msg(LOG_INFO, "plmn %x", global_enb_id.plmn);
+	log_msg(LOG_INFO, "Macro enb id %x-%x-%x-%x", global_enb_id.macro_enb_id[0],
 		global_enb_id.macro_enb_id[4],global_enb_id.macro_enb_id[8],global_enb_id.macro_enb_id[12]);
 	
 	return (void*)&global_enb_id;

--- a/src/s1ap/handlers/mme_msg_delegator.c
+++ b/src/s1ap/handlers/mme_msg_delegator.c
@@ -25,7 +25,7 @@
 void
 handle_mmeapp_message(void * data)
 {
-	log_msg(LOG_INFO, "handle mme-app message \n");
+	log_msg(LOG_INFO, "handle mme-app message ");
 	
 	char *msg = ((char *) data) + (sizeof(uint32_t)*2);
 
@@ -106,7 +106,7 @@ handle_mmeapp_message(void * data)
 		erab_release_command_handler(msg);
 		break;
 	default:
-		log_msg(LOG_ERROR,"Unhandled mme-app message\n");
+		log_msg(LOG_ERROR,"Unhandled mme-app message");
 		break;
 	}
 	free(data);

--- a/src/s1ap/handlers/mme_status_transfer.c
+++ b/src/s1ap/handlers/mme_status_transfer.c
@@ -17,7 +17,7 @@
 static int
 mme_status_transfer_processing(struct mme_status_transfer_Q_msg *g_mme_status)
 {
-    log_msg(LOG_DEBUG, "Process MME Status Transfer.\n");
+    log_msg(LOG_DEBUG, "Process MME Status Transfer.");
 
     uint32_t length = 0;
     uint8_t *buffer = NULL;
@@ -27,14 +27,14 @@ mme_status_transfer_processing(struct mme_status_transfer_Q_msg *g_mme_status)
 
     if (ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding mme status transfer failed.\n");
+        log_msg(LOG_ERROR, "Encoding mme status transfer failed.");
         return E_FAIL;
     }
 
     send_sctp_msg(
             g_mme_status->target_enb_context_id, buffer, length, 1);
 
-    log_msg(LOG_DEBUG, "MME-Status-Transfer sent. No. of bytes %d\n", length);
+    log_msg(LOG_DEBUG, "MME-Status-Transfer sent. No. of bytes %d", length);
 	if(buffer != NULL) {
 		free(buffer);
 	}

--- a/src/s1ap/handlers/ni_detach_request.c
+++ b/src/s1ap/handlers/ni_detach_request.c
@@ -113,7 +113,7 @@ ni_detach_request_processing(struct ni_detach_request_Q_msg *g_acptReqInfo)
 	buffer_copy(&g_acpt_buffer, &protocolIe_criticality,
 					sizeof(protocolIe_criticality));
 
-	log_msg(LOG_INFO, "Received network initiated detach - nas message %d \n",g_acptReqInfo->nasMsgSize);
+	log_msg(LOG_INFO, "Received network initiated detach - nas message %d ",g_acptReqInfo->nasMsgSize);
 
 	datalen = g_acptReqInfo->nasMsgSize + 1; 
 
@@ -145,7 +145,7 @@ ni_detach_request_processing(struct ni_detach_request_Q_msg *g_acptReqInfo)
 void*
 ni_detach_request_handler(void *data)
 {
-   log_msg(LOG_INFO, "NI detach request handler ready.\n");
+   log_msg(LOG_INFO, "NI detach request handler ready.");
    struct ni_detach_request_Q_msg *msg = (struct ni_detach_request_Q_msg *)data;
 
    ni_detach_request_processing(msg);

--- a/src/s1ap/handlers/paging.c
+++ b/src/s1ap/handlers/paging.c
@@ -48,7 +48,7 @@ paging_processing(struct paging_req_Q_msg *g_paging)
 
 	if(ret == -1)
 	{
-		log_msg(LOG_ERROR, "Encoding paging request failed.\n");
+		log_msg(LOG_ERROR, "Encoding paging request failed.");
 		return E_FAIL;
 	}
 
@@ -56,7 +56,7 @@ paging_processing(struct paging_req_Q_msg *g_paging)
 	if(buffer != NULL) {
 		free(buffer);
 	}
-	log_msg(LOG_INFO, "-----Paging sent to UE.---\n");
+	log_msg(LOG_INFO, "-----Paging sent to UE.---");
 	return SUCCESS;
 }
 
@@ -68,7 +68,7 @@ void*
 paging_handler(void *data)
 {
 
-	log_msg(LOG_INFO, "paging handler ready.\n");
+	log_msg(LOG_INFO, "paging handler ready.");
 	
 	paging_processing((struct paging_req_Q_msg*)data);
 

--- a/src/s1ap/handlers/s1ap_encoder.c
+++ b/src/s1ap/handlers/s1ap_encoder.c
@@ -37,38 +37,38 @@ int s1ap_mme_encode_initiating(
   uint8_t **buffer,
   uint32_t *length)
 {
-	log_msg(LOG_INFO, "MME initiating msg Encode.\n");
+	log_msg(LOG_INFO, "MME initiating msg Encode.");
 	switch (message_p->IE_type) {
 		case S1AP_CTX_REL_CMD:
-			log_msg(LOG_INFO, "Ue Context release Command Encode.\n");
+			log_msg(LOG_INFO, "Ue Context release Command Encode.");
 			return s1ap_mme_encode_ue_context_release_command(
 					message_p, buffer, length);
 		case S1AP_PAGING_REQ:
-			log_msg(LOG_INFO, "Paging req Encode.\n");
+			log_msg(LOG_INFO, "Paging req Encode.");
 			return s1ap_mme_encode_paging_request(
 					message_p, buffer, length);
 
 		case S1AP_INIT_CTXT_SETUP_REQ:
-			log_msg(LOG_INFO, "Init context setup req encode\n");
+			log_msg(LOG_INFO, "Init context setup req encode");
 			return s1ap_mme_encode_initial_context_setup_request(
 					message_p, buffer, length); 
 
 		case S1AP_ATTACH_REJ:
-			log_msg(LOG_INFO, "Attach Reject encode\n");
+			log_msg(LOG_INFO, "Attach Reject encode");
 			return s1ap_mme_encode_attach_rej(
 					message_p, buffer, length); 
 		case S1AP_SERVICE_REJ:
-			log_msg(LOG_INFO, "Service Reject encode\n");
+			log_msg(LOG_INFO, "Service Reject encode");
 			return s1ap_mme_encode_service_rej(
 					message_p, buffer, length); 
 		case S1AP_TAU_REJ:
-			log_msg(LOG_INFO, "TAU Reject encode\n");
+			log_msg(LOG_INFO, "TAU Reject encode");
 			return s1ap_mme_encode_tau_rej(
 					message_p, buffer, length);
 		default:
 			log_msg(
 					LOG_WARNING,
-					"Unknown procedure ID (%d) for initiating message_p\n",
+					"Unknown procedure ID (%d) for initiating message_p",
 					(int) message_p->IE_type);
 	}
 
@@ -80,20 +80,20 @@ int s1ap_mme_encode_outcome(
   uint8_t **buffer,
   uint32_t *length)
 {
-    log_msg(LOG_INFO, "MME Outcome Message Encode.\n");
+    log_msg(LOG_INFO, "MME Outcome Message Encode.");
     switch (message_p->IE_type) {
         case S1AP_SETUP_RESPONSE:
-            log_msg(LOG_INFO, "S1 Setup Response Encode.\n");
+            log_msg(LOG_INFO, "S1 Setup Response Encode.");
             return s1ap_mme_encode_s1_setup_response(
                       message_p, buffer, length);
         case S1AP_SETUP_FAILURE:
-            log_msg(LOG_INFO, "S1 Setup failure Encode.\n");
+            log_msg(LOG_INFO, "S1 Setup failure Encode.");
             return s1ap_mme_encode_s1_setup_failure(
                       message_p, buffer, length);
         default:
             log_msg(
                   LOG_WARNING,
-                  "Unknown procedure ID (%d) for Outcome msg\n",
+                  "Unknown procedure ID (%d) for Outcome msg",
                   (int) message_p->IE_type);
       }
 
@@ -163,7 +163,7 @@ int s1ap_mme_encode_service_rej(
         memcpy(val[2].value.choice.NAS_PDU.buf, g_nas_buffer.buf, 
                 val[2].value.choice.NAS_PDU.size);
     }
-    log_msg(LOG_INFO,"Add values to list.\n");
+    log_msg(LOG_INFO,"Add values to list.");
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.DownlinkNASTransport.protocolIEs.list, &val[0]);
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.DownlinkNASTransport.protocolIEs.list, &val[1]);
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.DownlinkNASTransport.protocolIEs.list, &val[2]);
@@ -171,7 +171,7 @@ int s1ap_mme_encode_service_rej(
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer (&asn_DEF_S1AP_PDU, 0, &pdu, (void **)buffer)) < 0) 
     {
-        log_msg(LOG_ERROR, "Encoding of Service Rej failed\n");
+        log_msg(LOG_ERROR, "Encoding of Service Rej failed");
         enc_error = true;
     }
 
@@ -249,7 +249,7 @@ int s1ap_mme_encode_tau_rej(
 		memcpy(val[2].value.choice.NAS_PDU.buf, g_nas_buffer.buf,
 				val[2].value.choice.NAS_PDU.size);
 	}
-	log_msg(LOG_INFO,"Add values to list.\n");
+	log_msg(LOG_INFO,"Add values to list.");
 	ASN_SEQUENCE_ADD(&initiating_msg->value.choice.DownlinkNASTransport.protocolIEs.list, &val[0]);
 	ASN_SEQUENCE_ADD(&initiating_msg->value.choice.DownlinkNASTransport.protocolIEs.list, &val[1]);
 	ASN_SEQUENCE_ADD(&initiating_msg->value.choice.DownlinkNASTransport.protocolIEs.list, &val[2]);
@@ -257,7 +257,7 @@ int s1ap_mme_encode_tau_rej(
 	bool enc_error = false;
 	if ((enc_ret = aper_encode_to_new_buffer (&asn_DEF_S1AP_PDU, 0, &pdu, (void **)buffer)) < 0)
 	{
-		log_msg(LOG_ERROR, "Encoding of TAU Rej failed\n");
+		log_msg(LOG_ERROR, "Encoding of TAU Rej failed");
 		enc_error = true;
 	}
 
@@ -287,7 +287,7 @@ int s1ap_mme_encode_attach_rej(
 	int                                     enc_ret = -1;
 	memset ((void *)pdu_p, 0, sizeof (S1AP_PDU_t));
 
-    log_msg(LOG_DEBUG, "Encode Attach Reject\n");
+    log_msg(LOG_DEBUG, "Encode Attach Reject");
     pdu.present = S1AP_PDU_PR_initiatingMessage;
     pdu.choice.initiatingMessage = calloc(sizeof(InitiatingMessage_t), sizeof(uint8_t));
 
@@ -303,13 +303,13 @@ int s1ap_mme_encode_attach_rej(
     val[0].criticality = 0;
     val[0].value.present = DownlinkNASTransport_IEs__value_PR_MME_UE_S1AP_ID;
     val[0].value.choice.MME_UE_S1AP_ID = s1apPDU->mme_s1ap_ue_id;
-    log_msg(LOG_DEBUG, "MME_UE_S1AP_ID : %d\n",s1apPDU->mme_s1ap_ue_id);
+    log_msg(LOG_DEBUG, "MME_UE_S1AP_ID : %d",s1apPDU->mme_s1ap_ue_id);
 
     val[1].id = ProtocolIE_ID_id_eNB_UE_S1AP_ID;
     val[1].criticality = 0;
     val[1].value.present = DownlinkNASTransport_IEs__value_PR_ENB_UE_S1AP_ID;
     val[1].value.choice.ENB_UE_S1AP_ID = s1apPDU->enb_s1ap_ue_id;
-    log_msg(LOG_DEBUG, "ENB_UE_S1AP_ID : %d\n",s1apPDU->enb_s1ap_ue_id);
+    log_msg(LOG_DEBUG, "ENB_UE_S1AP_ID : %d",s1apPDU->enb_s1ap_ue_id);
 
     val[2].id = ProtocolIE_ID_id_NAS_PDU;
     val[2].criticality = 0;
@@ -339,7 +339,7 @@ int s1ap_mme_encode_attach_rej(
         memcpy(val[2].value.choice.NAS_PDU.buf, g_nas_buffer.buf, 
                 val[2].value.choice.NAS_PDU.size);
     }
-    log_msg(LOG_INFO,"Add values to list.\n");
+    log_msg(LOG_INFO,"Add values to list.");
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.DownlinkNASTransport.protocolIEs.list, &val[0]);
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.DownlinkNASTransport.protocolIEs.list, &val[1]);
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.DownlinkNASTransport.protocolIEs.list, &val[2]);
@@ -347,7 +347,7 @@ int s1ap_mme_encode_attach_rej(
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer (&asn_DEF_S1AP_PDU, 0, &pdu, (void **)buffer)) < 0) 
     {
-        log_msg(LOG_ERROR, "Encoding of Attach Reject failed\n");
+        log_msg(LOG_ERROR, "Encoding of Attach Reject failed");
         enc_error = true;
     }
 
@@ -370,7 +370,7 @@ int s1ap_mme_encode_ue_context_release_command(
   uint8_t **buffer,
   uint32_t *length)
 {
-	log_msg(LOG_DEBUG,"Inside s1ap_encoder\n");
+	log_msg(LOG_DEBUG,"Inside s1ap_encoder");
 
 	S1AP_PDU_t                              pdu = {(S1AP_PDU_PR_NOTHING)};
     InitiatingMessage_t *initiating_msg = NULL;
@@ -396,14 +396,14 @@ int s1ap_mme_encode_ue_context_release_command(
     if((s1apPDU->mme_s1ap_ue_id != 0xFFFFFFFF) 
         && (s1apPDU->enb_s1ap_ue_id != 0xFFFFFFFF))
     {
-        log_msg(LOG_INFO,"S1ap Id pair.\n");
+        log_msg(LOG_INFO,"S1ap Id pair.");
         ue_id_val.present = UE_S1AP_IDs_PR_uE_S1AP_ID_pair;
         s1apId_pair.eNB_UE_S1AP_ID = s1apPDU->enb_s1ap_ue_id;
         s1apId_pair.mME_UE_S1AP_ID = s1apPDU->mme_s1ap_ue_id;
         ue_id_val.choice.uE_S1AP_ID_pair = calloc(sizeof(struct UE_S1AP_ID_pair), 1);
         if(ue_id_val.choice.uE_S1AP_ID_pair == NULL)
         {
-            log_msg(LOG_ERROR,"calloc failed.\n");
+            log_msg(LOG_ERROR,"calloc failed.");
             free(pdu.choice.initiatingMessage);
             return -1;
         }
@@ -453,17 +453,17 @@ int s1ap_mme_encode_ue_context_release_command(
         break;
         case Cause_PR_NOTHING:
         default:
-            log_msg(LOG_WARNING,"Unknown Cause type:%d\n",s1apPDU->cause.present);
+            log_msg(LOG_WARNING,"Unknown Cause type:%d",s1apPDU->cause.present);
     }
 
-    log_msg(LOG_INFO,"Add values to list.\n");
+    log_msg(LOG_INFO,"Add values to list.");
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.UEContextReleaseCommand.protocolIEs.list, &val[0]);
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.UEContextReleaseCommand.protocolIEs.list, &val[1]);
 
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer (&asn_DEF_S1AP_PDU, 0, &pdu, (void **)buffer)) < 0) 
     {
-        log_msg(LOG_ERROR, "Encoding of Ctx Release Cmd failed\n");
+        log_msg(LOG_ERROR, "Encoding of Ctx Release Cmd failed");
         enc_error = true;
     }
 
@@ -615,7 +615,7 @@ int s1ap_mme_encode_initial_context_setup_request(
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer (&asn_DEF_S1AP_PDU, 0, &pdu, (void **)buffer)) < 0)
     {
-        log_msg(LOG_ERROR, "Encoding of Initial Context Setup Request failed\n");
+        log_msg(LOG_ERROR, "Encoding of Initial Context Setup Request failed");
         enc_error = true;
     }
 
@@ -652,7 +652,7 @@ int s1ap_mme_encode_paging_request(
 {
 	s1ap_config_t *s1ap_cfg = get_s1ap_config();
 
-    log_msg(LOG_DEBUG,"Entered s1ap_encoder->s1ap_mme_encode_paging_request\n");
+    log_msg(LOG_DEBUG,"Entered s1ap_encoder->s1ap_mme_encode_paging_request");
 
     S1AP_PDU_t pdu = {(S1AP_PDU_PR_NOTHING)};
     InitiatingMessage_t *initiating_msg = NULL;
@@ -695,7 +695,7 @@ int s1ap_mme_encode_paging_request(
     UEIdentityIndexValue->buf[1] = (index_value & 0x3) << 6;
     UEIdentityIndexValue->bits_unused = 6;
 
-    log_msg(LOG_DEBUG,"Encoding STMSI\n");
+    log_msg(LOG_DEBUG,"Encoding STMSI");
 
     val[1].id = ProtocolIE_ID_id_UEPagingID;
     val[1].criticality = 0;
@@ -716,14 +716,14 @@ int s1ap_mme_encode_paging_request(
     pagingId.choice.s_TMSI->m_TMSI.size = sizeof(uint32_t);
     memcpy(&val[1].value.choice.UEPagingID, &pagingId, sizeof(UEPagingID_t));
 
-    log_msg(LOG_INFO, "Encoding CNDomain\n");
+    log_msg(LOG_INFO, "Encoding CNDomain");
 
     val[2].id = ProtocolIE_ID_id_CNDomain;
     val[2].criticality = 0;
     val[2].value.present = PagingIEs__value_PR_CNDomain;
     val[2].value.choice.CNDomain = s1apPDU->cn_domain;
     
-    log_msg(LOG_DEBUG,"Encoding TAI List\n");
+    log_msg(LOG_DEBUG,"Encoding TAI List");
 	
     val[3].id = ProtocolIE_ID_id_TAIList;
     val[3].criticality = 0;
@@ -736,7 +736,7 @@ int s1ap_mme_encode_paging_request(
     tai_item.criticality = 0;
     tai_item.value.present = TAIItemIEs__value_PR_TAIItem;
 
-    log_msg(LOG_DEBUG,"TAI List - Encode PLMN ID\n");
+    log_msg(LOG_DEBUG,"TAI List - Encode PLMN ID");
     tai_item.value.choice.TAIItem.tAI.pLMNidentity.size = 3;
     tai_item.value.choice.TAIItem.tAI.pLMNidentity.buf = calloc(3, sizeof(uint8_t));
 
@@ -760,14 +760,14 @@ int s1ap_mme_encode_paging_request(
     }
     memcpy(tai_item.value.choice.TAIItem.tAI.pLMNidentity.buf, &s1apPDU->tai.plmn_id.idx, 3);
 
-    log_msg(LOG_DEBUG,"TAI List - Encode TAC\n");
+    log_msg(LOG_DEBUG,"TAI List - Encode TAC");
     tai_item.value.choice.TAIItem.tAI.tAC.size = 2;
     tai_item.value.choice.TAIItem.tAI.tAC.buf = calloc(2, sizeof(uint8_t));
     memcpy(tai_item.value.choice.TAIItem.tAI.tAC.buf, &s1apPDU->tai.tac, 2);
 
     ASN_SEQUENCE_ADD(&val[3].value.choice.TAIList.list, &tai_item);
 
-    log_msg(LOG_INFO,"Add values to list.\n");
+    log_msg(LOG_INFO,"Add values to list.");
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.Paging.protocolIEs.list, &val[0]);
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.Paging.protocolIEs.list, &val[1]);
     ASN_SEQUENCE_ADD(&initiating_msg->value.choice.Paging.protocolIEs.list, &val[2]);
@@ -776,7 +776,7 @@ int s1ap_mme_encode_paging_request(
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer (&asn_DEF_S1AP_PDU, 0, &pdu, (void **)buffer)) < 0) 
     {
-        log_msg(LOG_ERROR, "Encoding of Paging failed\n");
+        log_msg(LOG_ERROR, "Encoding of Paging failed");
         enc_error = true;
     }
 
@@ -800,7 +800,7 @@ int s1ap_mme_encode_s1_setup_failure(
   uint8_t **buffer,
   uint32_t *length)
 {
-    log_msg(LOG_DEBUG,"Inside s1ap_mme_encode_s1_setup_failure\n");
+    log_msg(LOG_DEBUG,"Inside s1ap_mme_encode_s1_setup_failure");
 
     S1AP_PDU_t                              pdu = {(S1AP_PDU_PR_NOTHING)};
     UnsuccessfulOutcome_t *fail_msg = NULL;
@@ -812,7 +812,7 @@ int s1ap_mme_encode_s1_setup_failure(
     pdu.choice.unsuccessfulOutcome = calloc(sizeof(UnsuccessfulOutcome_t), sizeof(uint8_t));
     if(pdu.choice.unsuccessfulOutcome == NULL)
     {
-        log_msg(LOG_ERROR,"calloc failed.\n");
+        log_msg(LOG_ERROR,"calloc failed.");
         return -1;
     }
 
@@ -854,16 +854,16 @@ int s1ap_mme_encode_s1_setup_failure(
         break;
         case Cause_PR_NOTHING:
         default:
-            log_msg(LOG_WARNING,"Unknown Cause type:%d\n",s1apPDU->cause.present);
+            log_msg(LOG_WARNING,"Unknown Cause type:%d",s1apPDU->cause.present);
     }
 
-    log_msg(LOG_INFO,"Add values to list.\n");
+    log_msg(LOG_INFO,"Add values to list.");
     ASN_SEQUENCE_ADD(&fail_msg->value.choice.S1SetupFailure.protocolIEs.list, &val[0]);
 
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer (&asn_DEF_S1AP_PDU, 0, &pdu, (void **)buffer)) < 0)
     {
-        log_msg(LOG_ERROR, "Encoding of S1 setup failure failed\n");
+        log_msg(LOG_ERROR, "Encoding of S1 setup failure failed");
         enc_error = true;
     }
 
@@ -881,7 +881,7 @@ int s1ap_mme_encode_s1_setup_response(
   uint8_t **buffer,
   uint32_t *length)
 {
-    log_msg(LOG_DEBUG,"Inside s1ap_mme_encode_s1_setup_response\n");
+    log_msg(LOG_DEBUG,"Inside s1ap_mme_encode_s1_setup_response");
 
     S1AP_PDU_t                              pdu = {(S1AP_PDU_PR_NOTHING)};
     SuccessfulOutcome_t *rsp_msg = NULL;
@@ -893,7 +893,7 @@ int s1ap_mme_encode_s1_setup_response(
     pdu.choice.successfulOutcome = calloc(sizeof(SuccessfulOutcome_t), sizeof(uint8_t));
     if(pdu.choice.successfulOutcome == NULL)
     {
-        log_msg(LOG_ERROR,"calloc failed.\n");
+        log_msg(LOG_ERROR,"calloc failed.");
         return -1;
     }
 
@@ -964,7 +964,7 @@ int s1ap_mme_encode_s1_setup_response(
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer (&asn_DEF_S1AP_PDU, 0, &pdu, (void **)buffer)) < 0)
     {
-        log_msg(LOG_ERROR, "Encoding of S1 setup Response failed\n");
+        log_msg(LOG_ERROR, "Encoding of S1 setup Response failed");
         enc_error = true;
     }
 
@@ -1026,7 +1026,7 @@ int s1ap_mme_encode_handover_request(
                 s1apPDU->cause.choice.radioNetwork;
         break;
     default:
-        log_msg(LOG_WARNING, "Unknown Cause type:%d\n",
+        log_msg(LOG_WARNING, "Unknown Cause type:%d",
                 s1apPDU->cause.present);
     }
 
@@ -1183,7 +1183,7 @@ int s1ap_mme_encode_handover_request(
     if ((enc_ret = aper_encode_to_new_buffer(&asn_DEF_S1AP_PDU, 0, &pdu,
             (void**) buffer)) < 0)
     {
-        log_msg(LOG_ERROR, "Encoding of Handover Request failed\n");
+        log_msg(LOG_ERROR, "Encoding of Handover Request failed");
         enc_error = true;
     }
 
@@ -1315,7 +1315,7 @@ int s1ap_mme_encode_handover_command(
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer(&asn_DEF_S1AP_PDU, 0, &pdu,
             (void**) buffer)) < 0) {
-        log_msg(LOG_ERROR, "Encoding of Handover Command failed\n");
+        log_msg(LOG_ERROR, "Encoding of Handover Command failed");
         enc_error = true;
     }
 
@@ -1420,7 +1420,7 @@ int s1ap_mme_encode_handover_mme_status_transfer(
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer(&asn_DEF_S1AP_PDU, 0, &pdu,
             (void**) buffer)) < 0) {
-        log_msg(LOG_ERROR, "Encoding of mme status transfer failed\n");
+        log_msg(LOG_ERROR, "Encoding of mme status transfer failed");
         enc_error = true;
     }
 
@@ -1477,7 +1477,7 @@ int s1ap_mme_encode_handover_prep_failure(
                     s1apPDU->cause.choice.radioNetwork;
             break;
         default:
-            log_msg(LOG_WARNING, "Unknown Cause type:%d\n",
+            log_msg(LOG_WARNING, "Unknown Cause type:%d",
                     s1apPDU->cause.present);
     }
 
@@ -1494,7 +1494,7 @@ int s1ap_mme_encode_handover_prep_failure(
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer(&asn_DEF_S1AP_PDU, 0, &pdu,
             (void**) buffer)) < 0) {
-        log_msg(LOG_ERROR, "Encoding of Handover Preparation Failure failed\n");
+        log_msg(LOG_ERROR, "Encoding of Handover Preparation Failure failed");
         enc_error = true;
     }
 
@@ -1549,7 +1549,7 @@ int s1ap_mme_encode_handover_cancel_ack(
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer(&asn_DEF_S1AP_PDU, 0, &pdu,
             (void**) buffer)) < 0) {
-        log_msg(LOG_ERROR, "Encoding of Handover Cancel Acknowlegde failed\n");
+        log_msg(LOG_ERROR, "Encoding of Handover Cancel Acknowlegde failed");
         enc_error = true;
     }
 
@@ -1627,7 +1627,7 @@ int s1ap_mme_encode_erab_mod_confirmation(
     bool enc_error = false;
     if ((enc_ret = aper_encode_to_new_buffer(&asn_DEF_S1AP_PDU, 0, &pdu,
             (void**) buffer)) < 0) {
-        log_msg(LOG_ERROR, "Encoding of ERAB Modification Confirmation failed\n");
+        log_msg(LOG_ERROR, "Encoding of ERAB Modification Confirmation failed");
         enc_error = true;
     }
 
@@ -1778,7 +1778,7 @@ int s1ap_mme_encode_erab_setup_request(struct erabsu_ctx_req_Q_msg *s1apPDU,
     if ((enc_ret = aper_encode_to_new_buffer(&asn_DEF_S1AP_PDU, 0, &pdu,
             (void**) buffer)) < 0)
     {
-        log_msg(LOG_ERROR, "Encoding of E_RAB Setup Request failed\n");
+        log_msg(LOG_ERROR, "Encoding of E_RAB Setup Request failed");
         enc_error = true;
     }
 
@@ -1918,7 +1918,7 @@ int s1ap_mme_encode_erab_release_command(
                 break;
             case Cause_PR_NOTHING:
             default:
-                log_msg(LOG_WARNING, "Unknown Cause type:%d\n",
+                log_msg(LOG_WARNING, "Unknown Cause type:%d",
                         s1apPDU->erab_to_be_released_list.erab_item[i].cause.present);
         }
         ASN_SEQUENCE_ADD(&(val[3].value.choice.E_RABList.list),
@@ -1956,7 +1956,7 @@ int s1ap_mme_encode_erab_release_command(
     if((enc_ret = aper_encode_to_new_buffer(&asn_DEF_S1AP_PDU, 0, &pdu,
                                             (void**) buffer)) < 0)
     {
-        log_msg(LOG_ERROR, "Encoding of E_RAB Release command failed\n");
+        log_msg(LOG_ERROR, "Encoding of E_RAB Release command failed");
         enc_error = true;
     }
 

--- a/src/s1ap/handlers/s1ap_msg_delegator.c
+++ b/src/s1ap/handlers/s1ap_msg_delegator.c
@@ -58,13 +58,13 @@ int convertToInitUeProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_ies,
                         }
                         else 
 						{
-							log_msg (LOG_ERROR, "Decoding of IE eNB_UE_S1AP_ID failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE eNB_UE_S1AP_ID failed");
 							return -1;
 						}
 
                         proto_ies->data[i].IE_type = S1AP_IE_ENB_UE_ID;
 						memcpy(&proto_ies->data[i].val.enb_ue_s1ap_id, s1apENBUES1APID_p, sizeof(ENB_UE_S1AP_ID_t));
-                        log_msg(LOG_DEBUG, "ENB UE S1ap ID decode Success = %u \n",proto_ies->data[i].val.enb_ue_s1ap_id);
+                        log_msg(LOG_DEBUG, "ENB UE S1ap ID decode Success = %lu ",proto_ies->data[i].val.enb_ue_s1ap_id);
 						s1Msg->header.s1ap_enb_ue_id = proto_ies->data[i].val.enb_ue_s1ap_id;
 					} break;
 				case ProtocolIE_ID_id_NAS_PDU:
@@ -76,7 +76,7 @@ int convertToInitUeProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_ies,
 						}
 						else 
 						{
-							log_msg (LOG_ERROR, "Decoding of IE NAS PDU failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE NAS PDU failed");
 							return -1;
 						}
 
@@ -93,11 +93,11 @@ int convertToInitUeProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_ies,
                         }
                         else 
 						{
-							log_msg (LOG_ERROR, "Decoding of IE TAI failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE TAI failed");
 							return -1;
 						}
 
-                        log_msg(LOG_DEBUG, "TAI decode Success\n");
+                        log_msg(LOG_DEBUG, "TAI decode Success");
                         proto_ies->data[i].IE_type = S1AP_IE_TAI;
 						memcpy(&proto_ies->data[i].val.tai.tac, s1apTAI_p->tAC.buf, s1apTAI_p->tAC.size);
 						memcpy(proto_ies->data[i].val.tai.plmn_id.idx,
@@ -114,11 +114,11 @@ int convertToInitUeProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_ies,
                         }
 
                         if (s1apCGI_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE CGI failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE CGI failed");
 							return -1;
 						}
 
-                        log_msg(LOG_DEBUG, "CGI decode Success\n");
+                        log_msg(LOG_DEBUG, "CGI decode Success");
                         proto_ies->data[i].IE_type = S1AP_IE_UTRAN_CGI;
 						memcpy(&proto_ies->data[i].val.utran_cgi.cell_id,
                                s1apCGI_p->cell_ID.buf, s1apCGI_p->cell_ID.size);
@@ -137,11 +137,11 @@ int convertToInitUeProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_ies,
 						    s1apRRCEstCause_p = &ie_p->value.choice.RRC_Establishment_Cause;
                         }
                         else {
-							log_msg (LOG_ERROR, "Decoding of IE RRC Cause failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE RRC Cause failed");
 							return -1;
 						}
 
-                        log_msg(LOG_DEBUG, "RRC Cause decode Success\n");
+                        log_msg(LOG_DEBUG, "RRC Cause decode Success");
                         proto_ies->data[i].IE_type = S1AP_IE_RRC_EST_CAUSE;
 						proto_ies->data[i].val.rrc_est_cause = (enum ie_RRC_est_cause) *s1apRRCEstCause_p;
 					} break;
@@ -154,7 +154,7 @@ int convertToInitUeProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_ies,
                         }
                         else 
 						{
-							log_msg (LOG_ERROR, "Decoding of IE STMSI failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE STMSI failed");
 							return -1;
 						}
 
@@ -170,7 +170,7 @@ int convertToInitUeProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_ies,
                 default:
                     {
                         proto_ies->data[i].IE_type = ie_p->id;
-                        log_msg(LOG_WARNING, "Unhandled IE %d in initial UE message ", ie_p->id);
+                        log_msg(LOG_WARNING, "Unhandled IE %lu in initial UE message ", ie_p->id);
                     }
 			}
 		}
@@ -191,7 +191,7 @@ init_ue_msg_handler(InitiatingMessage_t *msg, int enb_fd)
     uint32_t cbIndex = findControlBlockWithEnbFd(enb_fd);
     if(INVALID_CB_INDEX == cbIndex)
     {
-        log_msg(LOG_ERROR,"No CB found for enb fd %d.\n", enb_fd);
+        log_msg(LOG_ERROR,"No CB found for enb fd %d.", enb_fd);
         return E_FAIL;
     }
 
@@ -207,7 +207,7 @@ init_ue_msg_handler(InitiatingMessage_t *msg, int enb_fd)
 	s1Msg.header.destInstAddr = htonl(mmeAppInstanceNum_c);
 	s1Msg.header.srcInstAddr = htonl(s1apAppInstanceNum_c);
 
-	log_msg(LOG_INFO, "sending S1AP_INITIAL_UE_MSG msg: context_id = %u tmsi = %u \n", cbIndex, s1Msg.s_tmsi.m_TMSI);
+	log_msg(LOG_INFO, "sending S1AP_INITIAL_UE_MSG msg: context_id = %u tmsi = %u ", cbIndex, s1Msg.s_tmsi.m_TMSI);
 	send_tipc_message(ipc_S1ap_Hndl, mmeAppInstanceNum_c, (char *)&s1Msg, sizeof(s1Msg));
 
 	/*Send S1Setup response*/
@@ -221,12 +221,12 @@ UL_NAS_msg_handler(InitiatingMessage_t *msg, int enb_fd)
 	//TODO: use static instead of synamic for perf.
 	struct proto_IE proto_ies={0};
 
-	log_msg(LOG_INFO, "S1AP_UL_NAS_TX_MSG msg \n");
+	log_msg(LOG_INFO, "S1AP_UL_NAS_TX_MSG msg ");
     
     uint32_t cbIndex = findControlBlockWithEnbFd(enb_fd);
     if(INVALID_CB_INDEX == cbIndex)
     {
-        log_msg(LOG_ERROR,"No CB found for enb fd %d.\n", enb_fd);
+        log_msg(LOG_ERROR,"No CB found for enb fd %d.", enb_fd);
         return E_FAIL;
     }
 
@@ -272,12 +272,12 @@ handle_s1ap_message(void *msg)
     dec_ret = aper_decode (NULL, &asn_DEF_S1AP_PDU, (void **)&pdu_p, message, msg_size, 0, 0);
 
     if (dec_ret.code != RC_OK) {
-        log_msg(LOG_ERROR, "handle s1ap message ASN Decode PDU Failed\n");
+        log_msg(LOG_ERROR, "handle s1ap message ASN Decode PDU Failed");
         free(msg);
         return;
     }
 
-    log_msg(LOG_INFO, "handle s1ap message enb_fd = %d msg size = %d .\n",enb_fd, msg_size);
+    log_msg(LOG_INFO, "handle s1ap message enb_fd = %d msg size = %d .",enb_fd, msg_size);
     switch (pdu_p->present) {
         case S1AP_PDU_PR_initiatingMessage:
             s1ap_mme_decode_initiating (pdu_p->choice.initiatingMessage, enb_fd);
@@ -299,7 +299,7 @@ handle_s1ap_message(void *msg)
 int
 s1ap_mme_decode_successfull_outcome (SuccessfulOutcome_t* msg)
 {
-  log_msg(LOG_DEBUG,"successful outcome decode :proc code %d\n", msg->procedureCode);
+  log_msg(LOG_DEBUG,"successful outcome decode :proc code %lu", msg->procedureCode);
   switch (msg->procedureCode) {
 
 	case S1AP_INITIAL_CTX_RESP_CODE:
@@ -323,8 +323,7 @@ s1ap_mme_decode_successfull_outcome (SuccessfulOutcome_t* msg)
         break;
 		
 	default:
-		log_msg(LOG_ERROR, "Unknown procedure code - %d\n",
-		         msg->procedureCode & 0x00FF);
+		log_msg(LOG_ERROR, "Unknown procedure code - %lu", msg->procedureCode & 0x00FF);
 		break;
 	}
 	
@@ -334,14 +333,14 @@ s1ap_mme_decode_successfull_outcome (SuccessfulOutcome_t* msg)
 int
 s1ap_mme_decode_unsuccessfull_outcome (UnsuccessfulOutcome_t *msg)
 {
-    log_msg(LOG_DEBUG,"unsuccessful outcome decode : proc code %d\n", msg->procedureCode);
+    log_msg(LOG_DEBUG,"unsuccessful outcome decode : proc code %lu", msg->procedureCode);
     switch (msg->procedureCode) {
 
       case S1AP_HANDOVER_RESOURCE_ALLOCATION_CODE:
     	  s1_handover_faliure_handler(msg);
     	  break;
       default:
-    	  log_msg(LOG_ERROR, "Unknown procedure code - %d\n",msg->procedureCode & 0x00FF);
+    	  log_msg(LOG_ERROR, "Unknown procedure code - %lu",msg->procedureCode & 0x00FF);
     	  break;
     }
 
@@ -351,7 +350,7 @@ s1ap_mme_decode_unsuccessfull_outcome (UnsuccessfulOutcome_t *msg)
 int
 s1ap_mme_decode_initiating (InitiatingMessage_t *initiating_p, int enb_fd) 
 {
-  log_msg(LOG_INFO, "s1ap_mme_decode_initiating proc code %d\n", initiating_p->procedureCode);
+  log_msg(LOG_INFO, "s1ap_mme_decode_initiating proc code %lu", initiating_p->procedureCode);
   switch (initiating_p->procedureCode) {
 	case S1AP_SETUP_REQUEST_CODE:
 		s1_setup_handler(initiating_p, enb_fd);
@@ -390,8 +389,7 @@ s1ap_mme_decode_initiating (InitiatingMessage_t *initiating_p, int enb_fd)
 		break;
 
 	default:
-		log_msg(LOG_ERROR, "Unknown procedure code - %d\n",
-			initiating_p->procedureCode & 0x00FF);
+		log_msg(LOG_ERROR, "Unknown procedure code - %lu", initiating_p->procedureCode & 0x00FF);
 		break;
 	}
 	
@@ -429,7 +427,7 @@ int convertUplinkNasToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_i
                         }
                         else 
 						{
-							log_msg (LOG_ERROR, "Decoding of IE eNB_UE_S1AP_ID failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE eNB_UE_S1AP_ID failed");
 							return -1;
 						}
 
@@ -446,7 +444,7 @@ int convertUplinkNasToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_i
                         }
 						
                         if (s1apMMEUES1APID_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE MME_UE_S1AP_ID failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE MME_UE_S1AP_ID failed");
 							return -1;
 						}
 
@@ -463,7 +461,7 @@ int convertUplinkNasToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_i
                         } 
 						else
                         {
-							log_msg (LOG_ERROR, "Decoding of IE NAS PDU failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE NAS PDU failed");
 							return -1;
 						}
 
@@ -481,7 +479,7 @@ int convertUplinkNasToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_i
                         }
 						
                         if (s1apTAI_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE TAI failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE TAI failed");
 							return -1;
 						}
 
@@ -500,7 +498,7 @@ int convertUplinkNasToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_i
                         }
 						
                         if (s1apCGI_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE CGI failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE CGI failed");
 							return -1;
 						}
 
@@ -514,7 +512,7 @@ int convertUplinkNasToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_i
                 default:
                     {
                         proto_ies->data[i].IE_type = ie_p->id;
-                        log_msg(LOG_WARNING, "Unhandled IE %d", ie_p->id);
+                        log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
                     }
 			}
 		}
@@ -555,7 +553,7 @@ int convertInitCtxRspToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* proto_
                         }
 						
                         if (s1apENBUES1APID_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE eNB_UE_S1AP_ID failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE eNB_UE_S1AP_ID failed");
 							return -1;
 						}
 
@@ -573,7 +571,7 @@ int convertInitCtxRspToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* proto_
                         }
                         else 
 						{
-							log_msg (LOG_ERROR, "Decoding of IE MME_UE_S1AP_ID failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE MME_UE_S1AP_ID failed");
 							return -1;
 						}
 
@@ -591,7 +589,7 @@ int convertInitCtxRspToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* proto_
                         }
 						
                         if (s1apErabSetupList_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE s1apErabSetupList failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE s1apErabSetupList failed");
 							return -1;
 						}
 
@@ -619,7 +617,7 @@ int convertInitCtxRspToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* proto_
                                         }
 
                                         if (s1apErabSetupItem_p == NULL) {
-                                            log_msg (LOG_ERROR, "Decoding of IE s1apErabSetupItem failed\n");
+                                            log_msg (LOG_ERROR, "Decoding of IE s1apErabSetupItem failed");
                                             return -1;
                                         }
 
@@ -639,7 +637,7 @@ int convertInitCtxRspToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* proto_
 					else
 					{
                                             log_msg(LOG_ERROR,
-                                            "Decoding of IE E_RABSetupItemCtxtSURes->gTP_TEID failed\n");
+                                            "Decoding of IE E_RABSetupItemCtxtSURes->gTP_TEID failed");
                                             return -1;
                                         }
 
@@ -655,26 +653,26 @@ int convertInitCtxRspToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* proto_
 					else
 					{
 					    log_msg(LOG_ERROR,
-                                            "Decoding of IE E_RABSetupItemCtxtSURes->transp_layer_addr failed\n");
+                                            "Decoding of IE E_RABSetupItemCtxtSURes->transp_layer_addr failed");
                                             return -1;
-					}
+                    }
                                     }break;
                                 default:
                                     {
-                                        log_msg(LOG_WARNING, "Unhandled List item %d", ie_p->id);
+                                        log_msg(LOG_WARNING, "Unhandled List item %lu", ie_p->id);
                                     }
                             }
                         }
 
-		} break;
+		        } break;
                 default:
                     {
                         proto_ies->data[i].IE_type = ie_p->id;
-                        log_msg(LOG_WARNING, "Unhandled IE %d", ie_p->id);
+                        log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
                     }
-			}
-		}
-     }
+            }
+        }
+    }
 
     return 0;
 }
@@ -711,7 +709,7 @@ int convertUeCtxRelComplToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* pro
                         }
 						
                         if (s1apENBUES1APID_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE eNB_UE_S1AP_ID failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE eNB_UE_S1AP_ID failed");
 							return -1;
 						}
 
@@ -728,7 +726,7 @@ int convertUeCtxRelComplToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* pro
                         }
 						
                         if (s1apMMEUES1APID_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE MME_UE_S1AP_ID failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE MME_UE_S1AP_ID failed");
 							return -1;
 						}
 
@@ -739,7 +737,7 @@ int convertUeCtxRelComplToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* pro
                 default:
                     {
                         proto_ies->data[i].IE_type = ie_p->id;
-                        log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
+                        log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
                     }
 			}
 		}
@@ -780,7 +778,7 @@ int convertUeCtxRelReqToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto
                         }
 
                         if (s1apENBUES1APID_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE eNB_UE_S1AP_ID failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE eNB_UE_S1AP_ID failed");
 							return -1;
 						}
 
@@ -797,7 +795,7 @@ int convertUeCtxRelReqToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto
                         }
 
                         if (s1apMMEUES1APID_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE MME_UE_S1AP_ID failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE MME_UE_S1AP_ID failed");
 							return -1;
 						}
 
@@ -814,7 +812,7 @@ int convertUeCtxRelReqToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto
                         }
 
                         if (s1apCause_p == NULL) {
-							log_msg (LOG_ERROR, "Decoding of IE Cause failed\n");
+							log_msg (LOG_ERROR, "Decoding of IE Cause failed");
 							return -1;
 						}
 
@@ -823,38 +821,38 @@ int convertUeCtxRelReqToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto
                         switch(s1apCause_p->present)
                         {
                             case Cause_PR_radioNetwork:
-							    log_msg (LOG_DEBUG, "RadioNetwork case : %d\n",
+							    log_msg (LOG_DEBUG, "RadioNetwork case : %lu",
                                           s1apCause_p->choice.radioNetwork);
                                 proto_ies->data[i].val.cause.choice.radioNetwork
                                     = s1apCause_p->choice.radioNetwork;
                                 break;
                             case Cause_PR_transport:
-							    log_msg (LOG_DEBUG, "Transport case : %d\n",
+							    log_msg (LOG_DEBUG, "Transport case : %lu",
                                           s1apCause_p->choice.transport);
                                 proto_ies->data[i].val.cause.choice.transport
                                     = s1apCause_p->choice.transport;
                                 break;
                             case Cause_PR_nas:
-							    log_msg (LOG_DEBUG, "Nas case : %d\n",
+							    log_msg (LOG_DEBUG, "Nas case : %lu",
                                           s1apCause_p->choice.nas);
                                 proto_ies->data[i].val.cause.choice.nas
                                     = s1apCause_p->choice.nas;
                                 break;
                             case Cause_PR_protocol:
-							    log_msg (LOG_DEBUG, "Protocol case : %d\n",
+							    log_msg (LOG_DEBUG, "Protocol case : %lu",
                                           s1apCause_p->choice.protocol);
                                 proto_ies->data[i].val.cause.choice.protocol
                                     = s1apCause_p->choice.protocol;
                                 break;
                             case Cause_PR_misc:
-							    log_msg (LOG_DEBUG, "Misc case : %d\n",
+							    log_msg (LOG_DEBUG, "Misc case : %lu",
                                           s1apCause_p->choice.misc);
                                 proto_ies->data[i].val.cause.choice.misc
                                     = s1apCause_p->choice.misc;
                                 break;
                             case Cause_PR_NOTHING:
                             default:
-                                log_msg(LOG_WARNING, "Unknown cause %d\n", s1apCause_p->present);
+                                log_msg(LOG_WARNING, "Unknown cause %d", s1apCause_p->present);
 
                         }
 						s1apCause_p = NULL;
@@ -862,7 +860,7 @@ int convertUeCtxRelReqToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto
                 default:
                     {
                         proto_ies->data[i].IE_type = ie_p->id;
-                        log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
+                        log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
                     }
 			}
 		}
@@ -909,7 +907,7 @@ int convertUehoReqToProtoIe(InitiatingMessage_t *msg,
                 if (s1apENBUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE eNB_UE_S1AP_ID failed\n");
+                            "Decoding of IE eNB_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -930,7 +928,7 @@ int convertUehoReqToProtoIe(InitiatingMessage_t *msg,
                 if (s1apMMEUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE MME_UE_S1AP_ID failed\n");
+                            "Decoding of IE MME_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -949,7 +947,7 @@ int convertUehoReqToProtoIe(InitiatingMessage_t *msg,
 
                 if (s1apCause_p == NULL)
                 {
-                    log_msg(LOG_ERROR, "Decoding of IE Cause failed\n");
+                    log_msg(LOG_ERROR, "Decoding of IE Cause failed");
                     return -1;
                 }
 
@@ -958,13 +956,13 @@ int convertUehoReqToProtoIe(InitiatingMessage_t *msg,
                 switch (s1apCause_p->present)
                 {
                 case Cause_PR_radioNetwork:
-                    log_msg(LOG_DEBUG, "RadioNetwork case : %d\n",
+                    log_msg(LOG_DEBUG, "RadioNetwork case : %lu",
                             s1apCause_p->choice.radioNetwork);
                     proto_ies->data[i].val.cause.choice.radioNetwork =
                             s1apCause_p->choice.radioNetwork;
                     break;
                 default:
-                    log_msg(LOG_WARNING, "Unknown cause %d\n",
+                    log_msg(LOG_WARNING, "Unknown cause %d",
                             s1apCause_p->present);
 
                 }
@@ -981,7 +979,7 @@ int convertUehoReqToProtoIe(InitiatingMessage_t *msg,
 
                 if (handoverType_p == NULL)
                 {
-                    log_msg(LOG_ERROR, "Decoding of IE HandoverType failed\n");
+                    log_msg(LOG_ERROR, "Decoding of IE HandoverType failed");
                     return -1;
                 }
 
@@ -1001,7 +999,7 @@ int convertUehoReqToProtoIe(InitiatingMessage_t *msg,
 
                 if (targetID_p == NULL)
                 {
-                    log_msg(LOG_ERROR, "Decoding of IE targetID failed\n");
+                    log_msg(LOG_ERROR, "Decoding of IE targetID failed");
                     return -1;
                 }
 
@@ -1011,14 +1009,14 @@ int convertUehoReqToProtoIe(InitiatingMessage_t *msg,
                     struct TargeteNB_ID *targeteNB_ID = targetID_p->choice.targeteNB_ID;
                     if (targeteNB_ID == NULL)
                     {
-                        log_msg(LOG_ERROR, "Decoding of IE targeteNB_ID failed\n");
+                        log_msg(LOG_ERROR, "Decoding of IE targeteNB_ID failed");
                         return -1;
                     }
 
                     TAI_t *s1apTAI_p = &(targeteNB_ID->selected_TAI);
                     if (s1apTAI_p == NULL)
                     {
-                        log_msg (LOG_ERROR, "Decoding of IE TAI failed\n");
+                        log_msg (LOG_ERROR, "Decoding of IE TAI failed");
                         return -1;
                     }
 
@@ -1051,7 +1049,7 @@ int convertUehoReqToProtoIe(InitiatingMessage_t *msg,
                 if (source_ToTarget_TransparentContainer_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE Source_ToTarget_TransparentContainer failed\n");
+                            "Decoding of IE Source_ToTarget_TransparentContainer failed");
                     return -1;
                 }
 
@@ -1067,7 +1065,7 @@ int convertUehoReqToProtoIe(InitiatingMessage_t *msg,
             default:
             {
                 proto_ies->data[i].IE_type = ie_p->id;
-                log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
+                log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
             }
             }
         }
@@ -1114,7 +1112,7 @@ int convertHoAcklToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *proto_ies)
                 if (s1apENBUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE eNB_UE_S1AP_ID failed\n");
+                            "Decoding of IE eNB_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -1135,7 +1133,7 @@ int convertHoAcklToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *proto_ies)
                 if (s1apMMEUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE MME_UE_S1AP_ID failed\n");
+                            "Decoding of IE MME_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -1156,7 +1154,7 @@ int convertHoAcklToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *proto_ies)
                 if (e_RABAdmittedList_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE E_RABAdmittedList failed\n");
+                            "Decoding of IE E_RABAdmittedList failed");
                     return -1;
                 }
 
@@ -1184,7 +1182,7 @@ int convertHoAcklToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *proto_ies)
                         if (eRabAdmittedItem_p == NULL)
                         {
                             log_msg(LOG_ERROR,
-                                    "Decoding of IE eRABAdmittedItem failed\n");
+                                    "Decoding of IE eRABAdmittedItem failed");
                             return -1;
                         }
 
@@ -1231,8 +1229,7 @@ int convertHoAcklToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *proto_ies)
                         break;
                     default:
                     {
-                        log_msg(LOG_WARNING, "Unhandled List item %d",
-                                ie_p->id);
+                        log_msg(LOG_WARNING, "Unhandled List item %lu", ie_p->id);
                     }
                     }
                 }
@@ -1251,7 +1248,7 @@ int convertHoAcklToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *proto_ies)
                 if (target_ToSource_TransparentContainer_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE Target_ToSource_TransparentContainer failed\n");
+                            "Decoding of IE Target_ToSource_TransparentContainer failed");
                     return -1;
                 }
 
@@ -1268,7 +1265,7 @@ int convertHoAcklToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *proto_ies)
             default:
             {
                 proto_ies->data[i].IE_type = ie_p->id;
-                log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
+                log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
             }
 
             }
@@ -1315,7 +1312,7 @@ int convertHoNotifyToProtoIe(InitiatingMessage_t *msg,
                 if (s1apENBUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE eNB_UE_S1AP_ID failed\n");
+                            "Decoding of IE eNB_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -1337,7 +1334,7 @@ int convertHoNotifyToProtoIe(InitiatingMessage_t *msg,
                 if (s1apMMEUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE MME_UE_S1AP_ID failed\n");
+                            "Decoding of IE MME_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -1359,7 +1356,7 @@ int convertHoNotifyToProtoIe(InitiatingMessage_t *msg,
 
                 if (s1apCGI_p == NULL)
                 {
-                    log_msg(LOG_ERROR, "Decoding of IE CGI failed\n");
+                    log_msg(LOG_ERROR, "Decoding of IE CGI failed");
                     return -1;
                 }
 
@@ -1381,7 +1378,7 @@ int convertHoNotifyToProtoIe(InitiatingMessage_t *msg,
 
                 if (s1apTAI_p == NULL)
                 {
-                    log_msg(LOG_ERROR, "Decoding of IE TAI failed\n");
+                    log_msg(LOG_ERROR, "Decoding of IE TAI failed");
                     return -1;
                 }
 
@@ -1396,7 +1393,7 @@ int convertHoNotifyToProtoIe(InitiatingMessage_t *msg,
             default:
             {
                 proto_ies->data[i].IE_type = ie_p->id;
-                log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
+                log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
             }
 
             }
@@ -1444,7 +1441,7 @@ int convertEnbStatusTransferToProtoIe(InitiatingMessage_t *msg,
                 if (s1apENBUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE eNB_UE_S1AP_ID failed\n");
+                            "Decoding of IE eNB_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -1466,7 +1463,7 @@ int convertEnbStatusTransferToProtoIe(InitiatingMessage_t *msg,
                 if (s1apMMEUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE MME_UE_S1AP_ID failed\n");
+                            "Decoding of IE MME_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -1491,7 +1488,7 @@ int convertEnbStatusTransferToProtoIe(InitiatingMessage_t *msg,
                 if (s1apContainer_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE ENB_STATUS_TRANSFER_TRANSPARENTCONTAINER failed\n");
+                            "Decoding of IE ENB_STATUS_TRANSFER_TRANSPARENTCONTAINER failed");
                     return -1;
                 }
 
@@ -1524,7 +1521,7 @@ int convertEnbStatusTransferToProtoIe(InitiatingMessage_t *msg,
                         if (bearersSubjectToStatusTransferItem == NULL)
                         {
                             log_msg(LOG_ERROR,
-                                    "Decoding of IE bearersSubjectToStatusTransferItem failed\n");
+                                    "Decoding of IE bearersSubjectToStatusTransferItem failed");
                             return -1;
                         }
 
@@ -1547,7 +1544,7 @@ int convertEnbStatusTransferToProtoIe(InitiatingMessage_t *msg,
                         break;
                     default:
                     {
-                        log_msg(LOG_WARNING, "Unhandled List item %d", ie->id);
+                        log_msg(LOG_WARNING, "Unhandled List item %lu", ie->id);
                     }
 
                     }
@@ -1557,7 +1554,7 @@ int convertEnbStatusTransferToProtoIe(InitiatingMessage_t *msg,
             default:
             {
                 proto_ies->data[i].IE_type = ie_p->id;
-                log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
+                log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
             }
 
             }
@@ -1605,7 +1602,7 @@ int convertHoFailureToProtoIe(UnsuccessfulOutcome_t *msg,
                 if (s1apMMEUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE MME_UE_S1AP_ID failed\n");
+                            "Decoding of IE MME_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -1625,7 +1622,7 @@ int convertHoFailureToProtoIe(UnsuccessfulOutcome_t *msg,
 
                 if (s1apCause_p == NULL)
                 {
-                    log_msg(LOG_ERROR, "Decoding of IE Cause failed\n");
+                    log_msg(LOG_ERROR, "Decoding of IE Cause failed");
                     return -1;
                 }
 
@@ -1634,13 +1631,13 @@ int convertHoFailureToProtoIe(UnsuccessfulOutcome_t *msg,
                 switch (s1apCause_p->present)
                 {
                 case Cause_PR_radioNetwork:
-                    log_msg(LOG_DEBUG, "RadioNetwork case : %d\n",
+                    log_msg(LOG_DEBUG, "RadioNetwork case : %lu",
                             s1apCause_p->choice.radioNetwork);
                     proto_ies->data[i].val.cause.choice.radioNetwork =
                             s1apCause_p->choice.radioNetwork;
                     break;
                 default:
-                    log_msg(LOG_WARNING, "Unknown cause %d\n",
+                    log_msg(LOG_WARNING, "Unknown cause %d",
                             s1apCause_p->present);
 
                 }
@@ -1650,7 +1647,7 @@ int convertHoFailureToProtoIe(UnsuccessfulOutcome_t *msg,
             default:
             {
                 proto_ies->data[i].IE_type = ie_p->id;
-                log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
+                log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
             }
 
             }
@@ -1697,7 +1694,7 @@ int convertUeHoCancelToProtoIe(InitiatingMessage_t *msg,
                 if (s1apENBUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE eNB_UE_S1AP_ID failed\n");
+                            "Decoding of IE eNB_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -1719,7 +1716,7 @@ int convertUeHoCancelToProtoIe(InitiatingMessage_t *msg,
                 if (s1apMMEUES1APID_p == NULL)
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE MME_UE_S1AP_ID failed\n");
+                            "Decoding of IE MME_UE_S1AP_ID failed");
                     return -1;
                 }
 
@@ -1739,7 +1736,7 @@ int convertUeHoCancelToProtoIe(InitiatingMessage_t *msg,
 
                 if (s1apCause_p == NULL)
                 {
-                    log_msg(LOG_ERROR, "Decoding of IE Cause failed\n");
+                    log_msg(LOG_ERROR, "Decoding of IE Cause failed");
                     return -1;
                 }
 
@@ -1748,23 +1745,21 @@ int convertUeHoCancelToProtoIe(InitiatingMessage_t *msg,
                 switch (s1apCause_p->present)
                 {
                 case Cause_PR_radioNetwork:
-                    log_msg(LOG_DEBUG, "RadioNetwork case : %d\n",
-                            s1apCause_p->choice.radioNetwork);
+                    log_msg(LOG_DEBUG, "RadioNetwork case : %lu", s1apCause_p->choice.radioNetwork);
                     proto_ies->data[i].val.cause.choice.radioNetwork =
                             s1apCause_p->choice.radioNetwork;
                     break;
                 default:
-                    log_msg(LOG_WARNING, "Unknown cause %d\n",
-                            s1apCause_p->present);
+                    log_msg(LOG_WARNING, "Unknown cause %d", s1apCause_p->present);
 
                 }
                 s1apCause_p = NULL;
             }
-                break;
+            break;
             default:
             {
                 proto_ies->data[i].IE_type = ie_p->id;
-                log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
+                log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
             }
             }
         }
@@ -1813,7 +1808,7 @@ int convertErabModIndToProtoIe(InitiatingMessage_t *msg, struct proto_IE *proto_
 		else
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE eNB_UE_S1AP_ID failed\n");
+                            "Decoding of IE eNB_UE_S1AP_ID failed");
                     return -1;
                 }
             } break;
@@ -1835,7 +1830,7 @@ int convertErabModIndToProtoIe(InitiatingMessage_t *msg, struct proto_IE *proto_
 		else
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE MME_UE_S1AP_ID failed\n");
+                            "Decoding of IE MME_UE_S1AP_ID failed");
                     return -1;
                 }
             } break;
@@ -1888,7 +1883,7 @@ int convertErabModIndToProtoIe(InitiatingMessage_t *msg, struct proto_IE *proto_
 				    else
 				    {
                                         log_msg(LOG_ERROR,
-                                        "Decoding of IE E_RABToBeModifiedItemBearerModInd->dL_GTP_TEID failed\n");
+                                        "Decoding of IE E_RABToBeModifiedItemBearerModInd->dL_GTP_TEID failed");
                                         return -1;
                                     }
 
@@ -1906,36 +1901,36 @@ int convertErabModIndToProtoIe(InitiatingMessage_t *msg, struct proto_IE *proto_
 				    else
 				    {
                                         log_msg(LOG_ERROR,
-                                        "Decoding of IE E_RABToBeModifiedItemBearerModInd->transportLayerAddress failed\n");
+                                        "Decoding of IE E_RABToBeModifiedItemBearerModInd->transportLayerAddress failed");
                                         return -1;
                                     }
 				}
 				else
                                 {
                                     log_msg(LOG_ERROR,
-                                        "Decoding of IE E_RABToBeModifiedItemBearerModInd failed\n");
+                                        "Decoding of IE E_RABToBeModifiedItemBearerModInd failed");
                                     return -1;
                                 }
                     	    }break;
                     	    default:
                     	    {
-                                log_msg(LOG_WARNING, "Unhandled List item %d",
-                                                  ie_p->id);
+                                log_msg(LOG_WARNING, "Unhandled List item %lu", ie_p->id);
                             }
                         }
-		    }
+		            }
                 }
-		else
+		        else
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE E_RABToBeModifiedListBearerModInd failed\n");
+                            "Decoding of IE E_RABToBeModifiedListBearerModInd failed");
                     return -1;
                 }
-            } break;
-	    default:
+            } 
+            break;
+	        default:
             {
                 proto_ies->data[i].IE_type = ie_p->id;
-		log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
+		        log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
             }
 
             }
@@ -1958,7 +1953,7 @@ int convertErabSetupRespToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *pro
         no_of_IEs = protocolIes->list.count;
         proto_ies->no_of_IEs = no_of_IEs;
 
-        log_msg(LOG_INFO, "No of IEs = %d\n", no_of_IEs);
+        log_msg(LOG_INFO, "No of IEs = %d", no_of_IEs);
         proto_ies->data = calloc(sizeof(struct proto_IE_data), no_of_IEs);
 
         for (int i = 0; i < protocolIes->list.count; i++)
@@ -1985,7 +1980,7 @@ int convertErabSetupRespToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *pro
 		else
                 {
                     log_msg(LOG_ERROR,
-                            "Decoding of IE eNB_UE_S1AP_ID failed\n");
+                            "Decoding of IE eNB_UE_S1AP_ID failed");
                     return -1;
                 }
             } break;
@@ -2004,10 +1999,9 @@ int convertErabSetupRespToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *pro
                     memcpy(&proto_ies->data[i].val.mme_ue_s1ap_id,
                             s1apMMEUES1APID_p, sizeof(MME_UE_S1AP_ID_t));
                 }
-		else
+		        else
                 {
-                    log_msg(LOG_ERROR,
-                            "Decoding of IE MME_UE_S1AP_ID failed\n");
+                    log_msg(LOG_ERROR, "Decoding of IE MME_UE_S1AP_ID failed");
                     return -1;
                 }
             } break;
@@ -2020,8 +2014,8 @@ int convertErabSetupRespToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *pro
                     e_RABSetupList_p = &ie_p->value.choice.E_RABSetupListBearerSURes;
                 }
 
-		if (e_RABSetupList_p != NULL)
-		{
+		        if (e_RABSetupList_p != NULL)
+		        {
                     proto_ies->data[i].IE_type = S1AP_IE_E_RAB_SETUP_LIST_BEARER_SU_RES;
 
                     proto_ies->data[i].val.erab_su_list.count =
@@ -2034,76 +2028,72 @@ int convertErabSetupRespToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *pro
                         switch (ie_p->id)
                         {
                             case ProtocolIE_ID_id_E_RABSetupItemBearerSURes:
-			    {
-                        	E_RABSetupItemBearerSURes_t *eRabSetupItem_p = NULL;
-                        	if (E_RABSetupItemBearerSUResIEs__value_PR_E_RABSetupItemBearerSURes
-                                	== ie_p->value.present)
-                        	{
-                            	    eRabSetupItem_p =
-                                        &ie_p->value.choice.E_RABSetupItemBearerSURes;
-                        	}
+			                {
+                        	    E_RABSetupItemBearerSURes_t *eRabSetupItem_p = NULL;
+                        	    if (E_RABSetupItemBearerSUResIEs__value_PR_E_RABSetupItemBearerSURes
+                                    	== ie_p->value.present)
+                        	    {
+                                	    eRabSetupItem_p =
+                                            &ie_p->value.choice.E_RABSetupItemBearerSURes;
+                        	    }
 
-                        	if (eRabSetupItem_p != NULL)
-				{
+                        	    if (eRabSetupItem_p != NULL)
+				                {
 
-                      		    proto_ies->data[i].val.erab_su_list.erab_su_item[j].e_RAB_ID =
-                                        (uint8_t) eRabSetupItem_p->e_RAB_ID;
+                      		        proto_ies->data[i].val.erab_su_list.erab_su_item[j].e_RAB_ID =
+                                            (uint8_t) eRabSetupItem_p->e_RAB_ID;
 
-				    if (eRabSetupItem_p->gTP_TEID.buf != NULL)
-				    {
-                        		memcpy(
-                                	&(proto_ies->data[i].val.erab_su_list.erab_su_item[j].gtp_teid),
-                               		eRabSetupItem_p->gTP_TEID.buf, eRabSetupItem_p->gTP_TEID.size);
+				                    if (eRabSetupItem_p->gTP_TEID.buf != NULL)
+				                    {
+                                       	memcpy(
+                                              	&(proto_ies->data[i].val.erab_su_list.erab_su_item[j].gtp_teid),
+                                           		eRabSetupItem_p->gTP_TEID.buf, eRabSetupItem_p->gTP_TEID.size);
 
-                        		proto_ies->data[i].val.erab_su_list.erab_su_item[j].gtp_teid =
-                                	    ntohl(
-                                            proto_ies->data[i].val.erab_su_list.erab_su_item[j].gtp_teid);
-
-				    }
-				    else
-				    {
-                                        log_msg(LOG_ERROR,
-                                        "Decoding of IE E_RABSetupItemBearerSURes->gTP_TEID failed\n");
-                                        return -1;
+                                       	proto_ies->data[i].val.erab_su_list.erab_su_item[j].gtp_teid =
+                                              	    ntohl(proto_ies->data[i].val.erab_su_list.erab_su_item[j].gtp_teid);
+				                    }
+				                    else
+				                    {
+                                            log_msg(LOG_ERROR,
+                                            "Decoding of IE E_RABSetupItemBearerSURes->gTP_TEID failed");
+                                            return -1;
                                     }
 
-                        	    if (eRabSetupItem_p->transportLayerAddress.buf != NULL)
-				    {
-					memcpy(
-                                	&(proto_ies->data[i].val.erab_su_list.erab_su_item[j].transportLayerAddress),
-                                	eRabSetupItem_p->transportLayerAddress.buf,
-                                	eRabSetupItem_p->transportLayerAddress.size);
+                        	        if (eRabSetupItem_p->transportLayerAddress.buf != NULL)
+				                    {
+					                    memcpy(
+                                    	&(proto_ies->data[i].val.erab_su_list.erab_su_item[j].transportLayerAddress),
+                                    	eRabSetupItem_p->transportLayerAddress.buf,
+                                    	eRabSetupItem_p->transportLayerAddress.size);
 
-                        		proto_ies->data[i].val.erab_su_list.erab_su_item[j].transportLayerAddress =
-                                	    ntohl(
-                                       	    proto_ies->data[i].val.erab_su_list.erab_su_item[j].transportLayerAddress);
-				    }
-				    else
-				    {
+                        	    	proto_ies->data[i].val.erab_su_list.erab_su_item[j].transportLayerAddress =
+                                    	    ntohl(
+                                           	    proto_ies->data[i].val.erab_su_list.erab_su_item[j].transportLayerAddress);
+				                    }
+                                    else
+                                    {
                                         log_msg(LOG_ERROR,
-                                        "Decoding of IE E_RABSetupItemBearerSURes->transportLayerAddress failed\n");
+                                                "Decoding of IE E_RABSetupItemBearerSURes->transportLayerAddress failed");
                                         return -1;
                                     }
-				}
-				else
-                                {
-                                    log_msg(LOG_ERROR,
-                                        "Decoding of IE E_RABSetupItemBearerSURes failed\n");
-                                    return -1;
                                 }
-                    	    }break;
+                                else
+                                {
+                                    log_msg(LOG_ERROR,"Decoding of IE E_RABSetupItemBearerSURes failed");
+                                        return -1;
+                                }
+                    	    }
+                            break;
                     	    default:
                     	    {
-                                log_msg(LOG_WARNING, "Unhandled List item %d",
-                                                  ie_p->id);
+                                log_msg(LOG_WARNING, "Unhandled List item %lu", ie_p->id);
                             }
                         }
-		    }
+		            }
                 }
-		else
+		        else
                 {
-                    log_msg(LOG_ERROR,
-                            "Decoding of IE E_RABSetupItemBearerSURes failed\n");
+                    log_msg(LOG_ERROR,"Decoding of IE E_RABSetupItemBearerSURes failed");
                     return -1;
                 }
             } break;
@@ -2141,7 +2131,7 @@ int convertErabSetupRespToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *pro
                                         (uint8_t) eRabFailedToSetupItem_p->e_RAB_ID;
 
                         	    Cause_t *s1apCause_p = &eRabFailedToSetupItem_p->cause;
-				    if(s1apCause_p != NULL)
+				                if(s1apCause_p != NULL)
                         	    {
                             		proto_ies->data[i].val.erab_fail_list.erab_fail_item[j].cause.present =
                                         	s1apCause_p->present;
@@ -2149,50 +2139,46 @@ int convertErabSetupRespToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *pro
                             		{
                                 	    case Cause_PR_radioNetwork:
                                 	    {
-                                    		log_msg(LOG_DEBUG, "RadioNetwork case : %d\n",
-                                            	s1apCause_p->choice.radioNetwork);
+                                    		log_msg(LOG_DEBUG, "RadioNetwork case : %lu", s1apCause_p->choice.radioNetwork);
                                     		proto_ies->data[i].val.erab_fail_list.erab_fail_item[j].
                                         	cause.choice.radioNetwork =
                                             		s1apCause_p->choice.radioNetwork;
                                 	    }break;
                                 	    default:
-
-                                    		log_msg(LOG_WARNING, "Unknown cause %d\n", 
-                                            			s1apCause_p->present);
+                                    		log_msg(LOG_WARNING, "Unknown cause %d", s1apCause_p->present);
                             		}
                         	    }
                         	    else
                         	    {
                             		log_msg(LOG_ERROR, 
-                                    		"Decoding of IE E_RABFailedToSetupItemBearerSURes->Cause failed\n");
+                                    		"Decoding of IE E_RABFailedToSetupItemBearerSURes->Cause failed");
                             		return -1;
                         	    }
                     		}    
                     		else
                     		{
-                        	    log_msg(LOG_ERROR, "Decoding of IE E_RABFailedToSetupItemBearerSURes failed\n");
+                        	    log_msg(LOG_ERROR, "Decoding of IE E_RABFailedToSetupItemBearerSURes failed");
                         	    return -1;
                     		}
                 	    } break;
                 	    default:
                 	    {
-                    		log_msg(LOG_WARNING, "Unhandled List item %d \n", ie_p->id);
+                    		log_msg(LOG_WARNING, "Unhandled List item %lu", ie_p->id);
                 	    }
             		}
         	    }
     		}
     		else
     		{
-        	    log_msg(LOG_ERROR, "Decoding of IE E_RABFailedToSetupListBearerSURes failed\n");
+        	    log_msg(LOG_ERROR, "Decoding of IE E_RABFailedToSetupListBearerSURes failed");
         	    return -1;
     		}
 	    } break;  
-	    default:
-            {
-                proto_ies->data[i].IE_type = ie_p->id;
-		log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
-            }
-
+	            default:
+                {
+                    proto_ies->data[i].IE_type = ie_p->id;
+		            log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
+                }
             }
         }
     }
@@ -2213,7 +2199,7 @@ int convertErabRelRespToProtoIe(SuccessfulOutcome_t *msg,
         no_of_IEs = protocolIes->list.count;
         proto_ies->no_of_IEs = no_of_IEs;
 
-        log_msg(LOG_INFO, "No of IEs = %d\n", no_of_IEs);
+        log_msg(LOG_INFO, "No of IEs = %d", no_of_IEs);
         proto_ies->data = calloc(sizeof(struct proto_IE_data), no_of_IEs);
 
         for (int i = 0; i < protocolIes->list.count; i++)
@@ -2240,11 +2226,11 @@ int convertErabRelRespToProtoIe(SuccessfulOutcome_t *msg,
                     else
                     {
                         log_msg(LOG_ERROR,
-                                "Decoding of IE eNB_UE_S1AP_ID failed\n");
+                                "Decoding of IE eNB_UE_S1AP_ID failed");
                         return -1;
                     }
                 }
-                    break;
+                break;
                 case ProtocolIE_ID_id_MME_UE_S1AP_ID:
                 {
                     MME_UE_S1AP_ID_t *s1apMMEUES1APID_p = NULL;
@@ -2263,11 +2249,11 @@ int convertErabRelRespToProtoIe(SuccessfulOutcome_t *msg,
                     else
                     {
                         log_msg(LOG_ERROR,
-                                "Decoding of IE MME_UE_S1AP_ID failed\n");
+                                "Decoding of IE MME_UE_S1AP_ID failed");
                         return -1;
                     }
                 }
-                    break;
+                break;
                 case ProtocolIE_ID_id_E_RABReleaseListBearerRelComp:
                 {
                     E_RABReleaseListBearerRelComp_t *e_RABReleaseList_p = NULL;
@@ -2311,15 +2297,14 @@ int convertErabRelRespToProtoIe(SuccessfulOutcome_t *msg,
                                     else
                                     {
                                         log_msg(LOG_ERROR,
-                                                "Decoding of IE E_RABReleaseItemBearerRelComp failed\n");
+                                                "Decoding of IE E_RABReleaseItemBearerRelComp failed");
                                         return -1;
                                     }
                                 }
                                     break;
                                 default:
                                 {
-                                    log_msg(LOG_WARNING,
-                                            "Unhandled List item %d", ie_p->id);
+                                    log_msg(LOG_WARNING, "Unhandled List item %lu", ie_p->id);
                                 }
                             }
                         }
@@ -2327,11 +2312,11 @@ int convertErabRelRespToProtoIe(SuccessfulOutcome_t *msg,
                     else
                     {
                         log_msg(LOG_ERROR,
-                                "Decoding of IE E_RABReleaseItemBearerRelComp failed\n");
+                                "Decoding of IE E_RABReleaseItemBearerRelComp failed");
                         return -1;
                     }
                 }
-                    break;
+                break;
                 case ProtocolIE_ID_id_E_RABFailedToReleaseList:
                 {
                     E_RABList_t *e_RABFailedToReleaseList_p = NULL;
@@ -2373,8 +2358,7 @@ int convertErabRelRespToProtoIe(SuccessfulOutcome_t *msg,
                                         proto_ies->data[i].val.erab_failed_to_release_list.erab_item[j].e_RAB_ID =
                                                 (uint8_t) eRabFailedToReleaseItem_p->e_RAB_ID;
 
-                                        Cause_t *s1apCause_p =
-                                                &eRabFailedToReleaseItem_p->cause;
+                                        Cause_t *s1apCause_p = &eRabFailedToReleaseItem_p->cause;
                                         if(s1apCause_p != NULL)
                                         {
                                             proto_ies->data[i].val.erab_failed_to_release_list.erab_item[j].cause.present =
@@ -2383,39 +2367,31 @@ int convertErabRelRespToProtoIe(SuccessfulOutcome_t *msg,
                                             {
                                                 case Cause_PR_radioNetwork:
                                                 {
-                                                    log_msg(LOG_DEBUG,
-                                                            "RadioNetwork case : %d\n",
-                                                            s1apCause_p->choice.radioNetwork);
+                                                    log_msg(LOG_DEBUG, "RadioNetwork case : %lu", s1apCause_p->choice.radioNetwork);
                                                     proto_ies->data[i].val.erab_failed_to_release_list.erab_item[j].cause.choice.radioNetwork =
                                                             s1apCause_p->choice.radioNetwork;
                                                 }
-                                                    break;
+                                                break;
                                                 default:
-                                                    log_msg(LOG_WARNING,
-                                                            "Unknown cause %d\n",
-                                                            s1apCause_p->present);
+                                                    log_msg(LOG_WARNING, "Unknown cause %d", s1apCause_p->present);
                                             }
                                         }
                                         else
                                         {
-                                            log_msg(LOG_ERROR,
-                                                    "Decoding of IE eRabFailedToReleaseItem->Cause failed\n");
+                                            log_msg(LOG_ERROR, "Decoding of IE eRabFailedToReleaseItem->Cause failed");
                                             return -1;
                                         }
                                     }
                                     else
                                     {
-                                        log_msg(LOG_ERROR,
-                                                "Decoding of IE eRabFailedToReleaseItem failed\n");
+                                        log_msg(LOG_ERROR, "Decoding of IE eRabFailedToReleaseItem failed");
                                         return -1;
                                     }
                                 }
                                     break;
                                 default:
                                 {
-                                    log_msg(LOG_WARNING,
-                                            "Unhandled List item %d \n",
-                                            ie_p->id);
+                                    log_msg(LOG_WARNING, "Unhandled List item %lu", ie_p->id);
                                 }
                             }
                         }
@@ -2423,17 +2399,16 @@ int convertErabRelRespToProtoIe(SuccessfulOutcome_t *msg,
                     else
                     {
                         log_msg(LOG_ERROR,
-                                "Decoding of IE eRabFailedToReleaseItem_p failed\n");
+                                "Decoding of IE eRabFailedToReleaseItem_p failed");
                         return -1;
                     }
                 }
-                    break;
+                break;
                 default:
                 {
                     proto_ies->data[i].IE_type = ie_p->id;
-                    log_msg(LOG_WARNING, "Unhandled IE %d\n", ie_p->id);
+                    log_msg(LOG_WARNING, "Unhandled IE %lu", ie_p->id);
                 }
-
             }
         }
     }

--- a/src/s1ap/handlers/s1ap_tau_response_handler.c
+++ b/src/s1ap/handlers/s1ap_tau_response_handler.c
@@ -37,7 +37,7 @@ get_tau_rsp_protoie_value(struct proto_IE *value, struct tauResp_Q_msg *g_tauRes
 	value->data[0].val.mme_ue_s1ap_id = g_tauRespInfo->ue_idx;
 	value->data[1].val.enb_ue_s1ap_id = g_tauRespInfo->s1ap_enb_ue_id;
 
-	log_msg(LOG_INFO, "mme_ue_s1ap_id %d and enb_ue_s1ap_id %d\n",
+	log_msg(LOG_INFO, "mme_ue_s1ap_id %d and enb_ue_s1ap_id %d",
 			g_tauRespInfo->ue_idx, g_tauRespInfo->s1ap_enb_ue_id);
 
 	//free(value->data);
@@ -196,7 +196,7 @@ tau_rsp_processing(struct tauResp_Q_msg *g_tauRespInfo)
 	buffer_copy(&g_buffer, &protocolIe_criticality,
 					sizeof(protocolIe_criticality));
 
-	log_msg(LOG_INFO, "Received TAU response from mme-app. Nas message %d \n",g_tauRespInfo->nasMsgSize);
+	log_msg(LOG_INFO, "Received TAU response from mme-app. Nas message %d ",g_tauRespInfo->nasMsgSize);
 	datalen = g_tauRespInfo->nasMsgSize + 1; 
 
 	buffer_copy(&g_buffer, &datalen,
@@ -209,7 +209,7 @@ tau_rsp_processing(struct tauResp_Q_msg *g_tauRespInfo)
 	memcpy(g_buffer.buf + s1ap_len_pos, &datalen, sizeof(datalen));
 
    	send_sctp_msg(g_tauRespInfo->enb_fd, g_buffer.buf, g_buffer.pos,1);
-	log_msg(LOG_INFO, "\nTAU RESP received from MME\n");
+	log_msg(LOG_INFO, "TAU RESP received from MME");
     if(s1apPDU.value.data)
     {
         free(s1apPDU.value.data);
@@ -223,7 +223,7 @@ void*
 tau_response_handler(void *data)
 {
 
-	log_msg(LOG_INFO, "TAU response handler ready.\n");
+	log_msg(LOG_INFO, "TAU response handler ready.");
 
 	tau_rsp_processing((struct tauResp_Q_msg *)data);
 	

--- a/src/s1ap/handlers/s1setup.c
+++ b/src/s1ap/handlers/s1setup.c
@@ -51,20 +51,20 @@ s1_setup_response(int enb_fd, struct PLMN *plmn)
 	local_plmn_id.idx[0] = plmn->idx[0];
 	local_plmn_id.idx[1] = plmn->idx[1];
 	local_plmn_id.idx[2] = plmn->idx[2];
-	log_msg(LOG_DEBUG,"Number of mnc digits %d \n", plmn->mnc_digits);
+	log_msg(LOG_DEBUG,"Number of mnc digits %d ", plmn->mnc_digits);
     memcpy(&rsp_msg.mme_plmn_id, &local_plmn_id, 3);
     rsp_msg.rel_cap = s1ap_cfg->rel_cap;
 
     int ret = s1ap_mme_encode_outcome(&rsp_msg, &buffer, &length);
     if(ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding S1 setup response failed.\n");
+        log_msg(LOG_ERROR, "Encoding S1 setup response failed.");
         return E_FAIL;
     }
 
 
     send_sctp_msg_with_fd(enb_fd, buffer, length, 0);
-   	log_msg(LOG_INFO, "buffer size is %d\n", length);
+   	log_msg(LOG_INFO, "buffer size is %d", length);
     if(buffer)
     {
         free(buffer);
@@ -87,12 +87,12 @@ s1_setup_failure(struct s1ap_common_req_Q_msg* s1ap_setup_failure)
     int ret = s1ap_mme_encode_outcome(s1ap_setup_failure, &buffer, &length);
     if(ret == -1)
     {
-        log_msg(LOG_ERROR, "Encoding S1 setup failure failed.\n");
+        log_msg(LOG_ERROR, "Encoding S1 setup failure failed.");
         return E_FAIL;
     }
 
     send_sctp_msg_with_fd(enb_fd, buffer, length, 0);
-  	log_msg(LOG_ERROR, "S1ap setup failure \n");
+  	log_msg(LOG_ERROR, "S1ap setup failure ");
     if(buffer)
     {
         free(buffer);
@@ -128,7 +128,7 @@ s1_setup_handler(InitiatingMessage_t *msg, int enb_fd)
 					Global_ENB_ID_t *geNb = &ie_p->value.choice.Global_ENB_ID;
 					if(geNb->eNB_ID.present == ENB_ID_PR_macroENB_ID) 
 					{
-						log_msg(LOG_DEBUG, "macro eNB id size %d \n", geNb->eNB_ID.choice.macroENB_ID.size);
+						log_msg(LOG_DEBUG, "macro eNB id size %lu", geNb->eNB_ID.choice.macroENB_ID.size);
                         uint8_t *enb_id_buf = geNb->eNB_ID.choice.macroENB_ID.buf;
                         uint32_t val = enb_id_buf[0];
                         enbStruct.enbId_m |= val << 12;
@@ -139,7 +139,7 @@ s1_setup_handler(InitiatingMessage_t *msg, int enb_fd)
 					}
                     else if (geNb->eNB_ID.present == ENB_ID_PR_homeENB_ID)
                     {
-						log_msg(LOG_DEBUG, "home eNB id size %d \n", 
+						log_msg(LOG_DEBUG, "home eNB id size %lu", 
                                   geNb->eNB_ID.choice.homeENB_ID.size);
                         uint8_t *enb_id_buf = geNb->eNB_ID.choice.homeENB_ID.buf;
                         uint32_t val = enb_id_buf[0];
@@ -156,7 +156,7 @@ s1_setup_handler(InitiatingMessage_t *msg, int enb_fd)
 				case ProtocolIE_ID_id_eNBname:
 				{
 					ENBname_t *eNbName = &ie_p->value.choice.ENBname;
-					log_msg(LOG_DEBUG, "S1 Setup Message with eNB name %s \n", eNbName->buf);
+					log_msg(LOG_DEBUG, "S1 Setup Message with eNB name %s ", eNbName->buf);
                     strcpy(enbStruct.eNbName, (const char *)eNbName->buf);
 					break;
 				}
@@ -173,15 +173,15 @@ s1_setup_handler(InitiatingMessage_t *msg, int enb_fd)
 							tac_i = (tac_i<<8) | tac->tAC.buf[t]; 
 						}
 
-						log_msg(LOG_INFO, "S1setup Supported Tac %d %d size %d ..Final tac %d \n", tac->tAC.buf[0], tac->tAC.buf[1] , tac->tAC.size, tac_i);
+						log_msg(LOG_INFO, "S1setup Supported Tac %d %d size %lu ..Final tac %d ", tac->tAC.buf[0], tac->tAC.buf[1] , tac->tAC.size, tac_i);
 						BPLMNs_t *plmns = &tac->broadcastPLMNs; 
-						log_msg(LOG_INFO, "S1setup Supported PLMNS %d \n", plmns->list.count);
+						log_msg(LOG_INFO, "S1setup Supported PLMNS %d ", plmns->list.count);
 						for(int p=0; p<plmns->list.count; p++)
 						{
 							PLMNidentity_t *plmn = plmns->list.array[p]; 
 							char plmn_s[10] = {'\0'};
 							memcpy(plmn_s, plmn->buf, plmn->size);
-							log_msg(LOG_INFO, "S1setup Supported PLMN %s Plmn buffer size %d \n", plmn_s, plmn->size);
+							log_msg(LOG_INFO, "S1setup Supported PLMN %s Plmn buffer size %lu ", plmn_s, plmn->size);
 							struct PLMN plmn_struct = {0}; 
 							for(int b=0; b< plmn->size; b++) 
 							{
@@ -194,8 +194,8 @@ s1_setup_handler(InitiatingMessage_t *msg, int enb_fd)
 								  (s1ap_cfg->plmns[config_plmn].idx[1] == plmn_struct.idx[1]) &&
 								  (s1ap_cfg->plmns[config_plmn].idx[2] == plmn_struct.idx[2])) 
 								{
-									log_msg(LOG_INFO, "PLMN match found  Configured %x %x %x \n", s1ap_cfg->plmns[config_plmn].idx[0], s1ap_cfg->plmns[config_plmn].idx[1], s1ap_cfg->plmns[config_plmn].idx[2]);
-									log_msg(LOG_INFO, "PLMN match found  Received %x %x %x \n", plmn_struct.idx[0], plmn_struct.idx[1], plmn_struct.idx[2]);
+									log_msg(LOG_INFO, "PLMN match found  Configured %x %x %x ", s1ap_cfg->plmns[config_plmn].idx[0], s1ap_cfg->plmns[config_plmn].idx[1], s1ap_cfg->plmns[config_plmn].idx[2]);
+									log_msg(LOG_INFO, "PLMN match found  Received %x %x %x ", plmn_struct.idx[0], plmn_struct.idx[1], plmn_struct.idx[2]);
                                     memcpy(&enbStruct.tai_m.plmn_id,
                                            &plmn_struct, 
                                            3); //sizeof(struct PLMN)); plmn struct has some more fields
@@ -206,8 +206,8 @@ s1_setup_handler(InitiatingMessage_t *msg, int enb_fd)
 								}
 								else 
 								{
-									log_msg(LOG_INFO, "PLMN match not found  - Configured - %x %x %x \n", s1ap_cfg->plmns[config_plmn].idx[0], s1ap_cfg->plmns[config_plmn].idx[1], s1ap_cfg->plmns[config_plmn].idx[2]);
-									log_msg(LOG_INFO, "PLMN match not found Received - %x %x %x \n", plmn_struct.idx[0], plmn_struct.idx[1], plmn_struct.idx[2]);
+									log_msg(LOG_INFO, "PLMN match not found  - Configured - %x %x %x ", s1ap_cfg->plmns[config_plmn].idx[0], s1ap_cfg->plmns[config_plmn].idx[1], s1ap_cfg->plmns[config_plmn].idx[2]);
+									log_msg(LOG_INFO, "PLMN match not found Received - %x %x %x ", plmn_struct.idx[0], plmn_struct.idx[1], plmn_struct.idx[2]);
 								}
 							}
 							if(config_plmn >= s1ap_cfg->num_plmns)
@@ -231,28 +231,28 @@ s1_setup_handler(InitiatingMessage_t *msg, int enb_fd)
 
     if(match_found)
     {
-        log_msg(LOG_DEBUG, "PLMN Match found. Create CB and add Enb Info.\n");
+        log_msg(LOG_DEBUG, "PLMN Match found. Create CB and add Enb Info.");
         cbIndex = findControlBlockWithEnbId(enbStruct.enbId_m);
         if(INVALID_CB_INDEX == cbIndex)
         {
-            log_msg(LOG_DEBUG, "No ENb ctx found for enb id %d.\n", enbStruct.enbId_m);
+            log_msg(LOG_DEBUG, "No ENb ctx found for enb id %d.", enbStruct.enbId_m);
             cbIndex = createControlBlock();
             if(INVALID_CB_INDEX == cbIndex)
             {
                 log_msg(LOG_ERROR,"CB creation failed.");
                 return E_FAIL;
             }
-            log_msg(LOG_DEBUG, "New ctx block %d allocated for found for enb id %d.\n", cbIndex, enbStruct.enbId_m);
+            log_msg(LOG_DEBUG, "New ctx block %d allocated for found for enb id %d.", cbIndex, enbStruct.enbId_m);
             setValuesForEnbCtx(cbIndex, &enbStruct, false);
         }
         else
         {
-            log_msg(LOG_DEBUG, "ENB Ctx found for enb id %d. Update values.\n",enbStruct.enbId_m);
+            log_msg(LOG_DEBUG, "ENB Ctx found for enb id %d. Update values.",enbStruct.enbId_m);
             enbStruct.restart_counter++;
             cbIndex = setValuesForEnbCtx(cbIndex, &enbStruct, true);
             if(INVALID_CB_INDEX == cbIndex)
             {
-                log_msg(LOG_ERROR,"Set values in Enb Ctx failed.\n");
+                log_msg(LOG_ERROR,"Set values in Enb Ctx failed.");
                 struct s1ap_common_req_Q_msg s1ap_setup_failure = {0};
                 s1ap_setup_failure.IE_type = S1AP_SETUP_FAILURE;
                 s1ap_setup_failure.enb_fd = enb_fd;
@@ -264,7 +264,7 @@ s1_setup_handler(InitiatingMessage_t *msg, int enb_fd)
     }
     else
     {
-        log_msg(LOG_ERROR, "No PLMN Match found for enb id %d.\n",enbStruct.enbId_m);
+        log_msg(LOG_ERROR, "No PLMN Match found for enb id %d.",enbStruct.enbId_m);
         /* Send S1Setup Failure.*/
    	    struct s1ap_common_req_Q_msg s1ap_setup_failure = {0};
         s1ap_setup_failure.IE_type = S1AP_SETUP_FAILURE;

--- a/src/s1ap/handlers/uectxtrelease_cmd.c
+++ b/src/s1ap/handlers/uectxtrelease_cmd.c
@@ -29,13 +29,13 @@
 static int
 relcmd_processing(struct s1relcmd_info *g_uectxtrelcmd)
 {
-	log_msg(LOG_DEBUG,"Process Ctx rel cmd.\n");
+	log_msg(LOG_DEBUG,"Process Ctx rel cmd.");
 	uint32_t length = 0;
 	uint8_t *buffer = NULL;
 
 	struct s1ap_common_req_Q_msg req = {0};
 
-	log_msg(LOG_DEBUG,"Inside relcmd processing\n");
+	log_msg(LOG_DEBUG,"Inside relcmd processing");
 
 	req.IE_type = S1AP_CTX_REL_CMD;
 	req.enb_fd = g_uectxtrelcmd->enb_fd;
@@ -44,13 +44,13 @@ relcmd_processing(struct s1relcmd_info *g_uectxtrelcmd)
 	req.cause.present = g_uectxtrelcmd->cause.present;
 	req.cause.choice.radioNetwork = g_uectxtrelcmd->cause.choice.radioNetwork;
 
-	log_msg(LOG_DEBUG,"Before s1ap_encoder\n");
+	log_msg(LOG_DEBUG,"Before s1ap_encoder");
 
 	int ret = s1ap_mme_encode_initiating(&req, &buffer, &length);
-	log_msg(LOG_DEBUG,"Invoked s1ap_encoder\n");
+	log_msg(LOG_DEBUG,"Invoked s1ap_encoder");
 	if(ret == -1)
 	{
-		log_msg(LOG_ERROR, "Encoding ctx rel cmd failed.\n");
+		log_msg(LOG_ERROR, "Encoding ctx rel cmd failed.");
 		return E_FAIL;
 	}
 
@@ -59,7 +59,7 @@ relcmd_processing(struct s1relcmd_info *g_uectxtrelcmd)
 	if(buffer != NULL) {
 		free(buffer);
 	}
-	log_msg(LOG_INFO, "-----S1 Release Command sent to UE. len %d ret %d---\n", length, ret);
+	log_msg(LOG_INFO, "-----S1 Release Command sent to UE. len %d ret %d---", length, ret);
 	return SUCCESS;
 
 }
@@ -71,7 +71,7 @@ void*
 s1_release_command_handler(void *data)
 {
 
-	log_msg(LOG_INFO, "s1 release command handler ready.\n");
+	log_msg(LOG_INFO, "s1 release command handler ready.");
 	
 	relcmd_processing((struct s1relcmd_info *)data);
 

--- a/src/s1ap/json_config.c
+++ b/src/s1ap/json_config.c
@@ -84,13 +84,13 @@ parse_s1ap_conf(s1ap_config_t *config)
 			// over
 			break;
 		}
-		log_msg(LOG_INFO, "Parsed plmn %s \n", plmn);
+		log_msg(LOG_INFO, "Parsed plmn %s ", plmn);
 		uint16_t mcc_i, mnc_i;
 		uint16_t mnc_digits=3;
         get_mcc_mnc(plmn, &mcc_i, &mnc_i, &mnc_digits);
         config->plmn_mcc_mnc[count-1].mcc = mcc_i;
 		config->plmn_mcc_mnc[count-1].mnc = mnc_i;
-		log_msg(LOG_INFO, "Parsed plmn mcc - %d mnc - %d \n", mcc_i, mnc_i);
+		log_msg(LOG_INFO, "Parsed plmn mcc - %d mnc - %d ", mcc_i, mnc_i);
 		unsigned char mcc_dig_1 = mcc_i / 100; 
 		unsigned char mcc_dig_2 = (mcc_i / 10) % 10; 
 		unsigned char mcc_dig_3 = mcc_i % 10; 
@@ -117,7 +117,7 @@ parse_s1ap_conf(s1ap_config_t *config)
 		count++;
 	}
 	config->num_plmns = count - 1;
-	log_msg(LOG_ERROR,"Config parsing success \n");
+	log_msg(LOG_ERROR,"Config parsing success ");
 	return SUCCESS;
 }
 

--- a/src/s1ap/main.c
+++ b/src/s1ap/main.c
@@ -187,7 +187,7 @@ init_s1ap_workers()
 void *
 accept_sctp(void *data)
 {
-	log_msg(LOG_INFO, "accept connection on sctp sock\n");
+	log_msg(LOG_INFO, "accept connection on sctp sock");
 	int new_socket = 0;
 	int activity = 0;
 	int i = 0;
@@ -222,22 +222,22 @@ accept_sctp(void *data)
 		activity = select(max_sd + 1, &readfds, NULL, NULL, NULL);
 
 		if ((activity < 0) && (errno != EINTR)) {
-			log_msg(LOG_ERROR, "select error.\n");
+			log_msg(LOG_ERROR, "select error.");
 		 }
 
 		if (FD_ISSET(g_sctp_fd, &readfds)) {
 
 			if ((new_socket = accept_sctp_socket(g_sctp_fd)) == -1) {
-				log_msg(LOG_ERROR, "Error in accept on sctp socket.\n");
+				log_msg(LOG_ERROR, "Error in accept on sctp socket.");
 			}
 
 			int mtu = 1000;
 			int ret = setsockopt(new_socket, SOL_SCTP, SCTP_MAXSEG,&mtu, sizeof(mtu));
 			if(ret == -1 ) {
-				log_msg(LOG_ERROR, "1 setsockopt() failed %s \n",strerror(errno));
+				log_msg(LOG_ERROR, "1 setsockopt() failed %s ",strerror(errno));
 			}
 
-			log_msg(LOG_INFO, "New Connection Established\n.");
+			log_msg(LOG_INFO, "New Connection Established.");
 
 			for (i = 0; i < MAX_ENB; i++) {
 
@@ -267,7 +267,7 @@ accept_sctp(void *data)
                     send_tipc_message(ipc_S1ap_Hndl, mmeAppInstanceNum_c, (char *)&s1Msg, sizeof(s1apEnbStatus_Msg_t));
                     
                     clearControlBlockDetailsEnbFd(sd, &temp);
-                    log_msg(LOG_ERROR, "enb fd = %d eNB %s - Tac %d - disconnected \n", sd, temp.eNbName, temp.tai_m.tac);
+                    log_msg(LOG_ERROR, "enb fd = %d eNB %s - Tac %d - disconnected ", sd, temp.eNbName, temp.tai_m.tac);
                     close(sd);
                     enb_socket[i] = 0;
                     /* MME-app should get notificaiton that peer is down ? 
@@ -314,14 +314,14 @@ init_sctp()
 {
 	s1ap_config_t *s1ap_cfg = get_s1ap_config();
 	
-	log_msg(LOG_INFO, "Create sctp sock, ip:%d, port:%d\n",
+	log_msg(LOG_INFO, "Create sctp sock, ip:%d, port:%d",
 			s1ap_cfg->s1ap_local_ip, s1ap_cfg->sctp_port);
 	/*Create MME sctp listned socket*/
 	g_sctp_fd = create_sctp_socket(s1ap_cfg->s1ap_local_ip,
 					s1ap_cfg->sctp_port);
 
 	if (g_sctp_fd == -1) {
-		log_msg(LOG_ERROR, "Error in creating sctp socket. \n");
+		log_msg(LOG_ERROR, "Error in creating sctp socket. ");
 		return -E_FAIL;
 	}
 
@@ -333,7 +333,7 @@ init_sctp()
 
 	int ret = pthread_create(&acceptSctp_t, &attr,&accept_sctp, NULL);
 	if(ret < 0) {
-		log_msg(LOG_ERROR,"SCTP ACCEPTS THREAD FAILED\n");
+		log_msg(LOG_ERROR,"SCTP ACCEPTS THREAD FAILED");
 		return -E_FAIL;
 	}
 
@@ -352,7 +352,7 @@ init_writer_ipc()
 	if ((ipc_S1ap_Hndl  = create_tipc_socket()) <= 0)
 		return -E_FAIL;
 
-	log_msg(LOG_INFO, "Writer IPCs initialized\n");
+	log_msg(LOG_INFO, "Writer IPCs initialized");
 
 	return SUCCESS;
 }
@@ -366,12 +366,12 @@ start_mme_resp_handlers()
 {
 	if ((ipc_tipc_reader = create_tipc_socket()) <= 0)
 	{
-		log_msg(LOG_ERROR, "Failed to create IPC Reader tipc socket \n");
+		log_msg(LOG_ERROR, "Failed to create IPC Reader tipc socket ");
 		return -E_FAIL;
 	}
 	if ( bind_tipc_socket(ipc_tipc_reader, s1apAppInstanceNum_c) != 1)
 	{
-		log_msg(LOG_ERROR, "Failed to bind IPC Reader tipc socket \n");
+		log_msg(LOG_ERROR, "Failed to bind IPC Reader tipc socket ");
 		return -E_FAIL;
 	}
 
@@ -379,11 +379,11 @@ start_mme_resp_handlers()
 	g_tpool_tipc_reader = thread_pool_new(5);
 
 	if (g_tpool_tipc_reader == NULL) {
-		log_msg(LOG_ERROR, "Error in creating thread pool. \n");
+		log_msg(LOG_ERROR, "Error in creating thread pool. ");
 		return -E_FAIL_INIT;
 	}
 
-	log_msg(LOG_INFO, "S1AP Listener theadpool initalized.\n");
+	log_msg(LOG_INFO, "S1AP Listener theadpool initalized.");
 
 	// thread to read incoming ipc messages from tipc socket
 	pthread_attr_t attr;
@@ -429,7 +429,7 @@ start_sctp_threads()
 	res = pthread_create(&sctp_writer, &attr,
 			sctp_write, NULL);
 	if (res != 0) {
-		log_msg(LOG_ERROR, "Error in creating sctp writer thread.\n");
+		log_msg(LOG_ERROR, "Error in creating sctp writer thread.");
 		pthread_attr_destroy(&attr);
 		return -E_FAIL;
 	}
@@ -466,12 +466,12 @@ main(int argc, char **argv)
 	s1ap_parse_config(s1ap_inst->s1ap_config);
 
 	if (init_writer_ipc() != SUCCESS) {
-		log_msg(LOG_ERROR, "Error in initializing writer ipc.\n");
+		log_msg(LOG_ERROR, "Error in initializing writer ipc.");
 		return -E_FAIL_INIT;
 	}
 
 	if (start_mme_resp_handlers() != SUCCESS) {
-			log_msg(LOG_ERROR, "Error in starting mme response handlers.\n");
+			log_msg(LOG_ERROR, "Error in starting mme response handlers.");
 			return -E_FAIL_INIT;
 	}
 
@@ -479,23 +479,23 @@ main(int argc, char **argv)
 	g_tpool = thread_pool_new(THREADPOOL_SIZE);
 
 	if (g_tpool == NULL) {
-		log_msg(LOG_ERROR, "Error in creating thread pool. \n");
+		log_msg(LOG_ERROR, "Error in creating thread pool. ");
 		return -E_FAIL_INIT;
 	}
-	log_msg(LOG_INFO, "S1AP Listener theadpool initalized.\n");
+	log_msg(LOG_INFO, "S1AP Listener theadpool initalized.");
 
 
 	if (init_sctp() != SUCCESS) {
-		log_msg(LOG_ERROR, "Error in initializing sctp server.\n");
+		log_msg(LOG_ERROR, "Error in initializing sctp server.");
 		return -E_FAIL_INIT;
 	}
-	log_msg(LOG_INFO, "SCTP socket open - success \n");
+	log_msg(LOG_INFO, "SCTP socket open - success ");
 
 	if (start_sctp_threads() != SUCCESS) {
-		log_msg(LOG_ERROR, "Error in creating sctp reader/writer thread.\n");
+		log_msg(LOG_ERROR, "Error in creating sctp reader/writer thread.");
 		return -E_FAIL_INIT;
 	}
-	log_msg(LOG_INFO, "sctp reader/writer thread started.\n");
+	log_msg(LOG_INFO, "sctp reader/writer thread started.");
 
 	register_config_updates();
 

--- a/src/s1ap/options.c
+++ b/src/s1ap/options.c
@@ -43,9 +43,9 @@ void parse_args(int argc, char **argv)
 	} while (c != -1);
 
 	if ((args_set & REQ_ARGS) != REQ_ARGS) {
-		log_msg(LOG_ERROR, "Usage: %s\n", argv[0]);
+		log_msg(LOG_ERROR, "Usage: %s", argv[0]);
 		for (c = 0; long_options[c].name; ++c) {
-			log_msg(LOG_ERROR, "\t[ -%s | -%c ] %s\n",
+			log_msg(LOG_ERROR, "\t[ -%s | -%c ] %s",
 					long_options[c].name,
 					long_options[c].val,
 					long_options[c].name);
@@ -65,7 +65,7 @@ void convert_imsi_to_bcd_str(uint8_t *src, uint8_t* dest)
 {
   if (!src || !dest)
   {
-      log_msg(LOG_ERROR, "invalid buffer pointers.\n");
+      log_msg(LOG_ERROR, "invalid buffer pointers.");
       return;
   }
 

--- a/src/s1ap/s1apContextManager/s1apContextWrapper.cpp
+++ b/src/s1ap/s1apContextManager/s1apContextWrapper.cpp
@@ -20,21 +20,21 @@ uint32_t createControlBlock_cpp()
     EnbContext* enbCtxt_p = NULL;
     cb = mme::S1apDataGroupManager::Instance()->allocateCB();
     if(cb == NULL) {
-        log_msg(LOG_ERROR, "failed to allocate CB \n");
+        log_msg(LOG_ERROR, "failed to allocate CB ");
         return INVALID_ENTRY;
     }
     enbCtxt_p = static_cast <EnbContext *>(cb->getPermDataBlock());
     if (enbCtxt_p != NULL)
     {
-        log_msg(LOG_ERROR, "Enb Context exists in newly allocated CB. Should release and allocate again. : TBD.\n");
+        log_msg(LOG_ERROR, "Enb Context exists in newly allocated CB. Should release and allocate again. : TBD.");
         return INVALID_ENTRY;
     }
 
-    log_msg(LOG_DEBUG, "Allocate Enb context for CB.\n");
+    log_msg(LOG_DEBUG, "Allocate Enb context for CB.");
     enbCtxt_p = mme::S1apDataGroupManager::Instance()->getEnbContext();
     if(NULL == enbCtxt_p)
     {
-        log_msg(LOG_ERROR, "Enb Context alloc failed.\n");
+        log_msg(LOG_ERROR, "Enb Context alloc failed.");
         return INVALID_ENTRY;
     }
 
@@ -50,7 +50,7 @@ uint32_t findControlBlockWithEnbId_cpp(uint32_t enbId)
 
     if (cbIndex <= 0)
     {
-        log_msg(LOG_ERROR, "Failed to find control block with enbid :%d.\n",enbId);
+        log_msg(LOG_ERROR, "Failed to find control block with enbid :%d.",enbId);
         return INVALID_CB_INDEX;
     }
 
@@ -64,7 +64,7 @@ bool clearControlBlockDetailsEnbFd_cpp(uint32_t enbFd, struct EnbStruct *enbStru
 
     if (cbIndex <= 0)
     {
-        log_msg(LOG_ERROR, "Failed to find control block with enbFd :%d.\n",enbFd);
+        log_msg(LOG_ERROR, "Failed to find control block with enbFd :%d.",enbFd);
         return false; 
     }
 
@@ -74,7 +74,7 @@ bool clearControlBlockDetailsEnbFd_cpp(uint32_t enbFd, struct EnbStruct *enbStru
         cb = mme::S1apDataGroupManager::Instance()->findControlBlock(cbIndex);
         if(NULL == cb)
         {
-            log_msg(LOG_ERROR,"Control block not found for cb Index %d.\n", cbIndex);
+            log_msg(LOG_ERROR,"Control block not found for cb Index %d.", cbIndex);
             return false;
         }
 
@@ -83,22 +83,22 @@ bool clearControlBlockDetailsEnbFd_cpp(uint32_t enbFd, struct EnbStruct *enbStru
         strcpy(enbStructCtx->eNbName, enbCtxt_p->getEnbname());
         int val = mme::S1apDataGroupManager::Instance()->deleteenbIdkey(
                                                                         enbCtxt_p->getEnbId());
-        log_msg(LOG_DEBUG,"clearControlBlock : delete enbid2 %d: %d\n", enbCtxt_p->getEnbId(),val);
+        log_msg(LOG_DEBUG,"clearControlBlock : delete enbid2 %d: %d", enbCtxt_p->getEnbId(),val);
         val = mme::S1apDataGroupManager::Instance()->deleteenbFdkey(
                                                                     enbCtxt_p->getEnbFd());
-        log_msg(LOG_DEBUG,"clearControlBlock : delete enbfd2 %d: %d\n", enbCtxt_p->getEnbFd(), val);
-        log_msg(LOG_DEBUG,"clearControlBlock : fd map size after delete2 : %d.\n", 
+        log_msg(LOG_DEBUG,"clearControlBlock : delete enbfd2 %d: %d", enbCtxt_p->getEnbFd(), val);
+        log_msg(LOG_DEBUG,"clearControlBlock : fd map size after delete2 : %d.", 
                 mme::S1apDataGroupManager::Instance()->sizeEnbFdKeyMap());
-        log_msg(LOG_DEBUG,"clearControlBlock : Id map size after delete2 : %d.\n", 
+        log_msg(LOG_DEBUG,"clearControlBlock : Id map size after delete2 : %d.", 
                 mme::S1apDataGroupManager::Instance()->sizeEnbIdKeyMap());
-        log_msg(LOG_DEBUG,"clearControlBlock : deallocate cb for index %d\n", cbIndex);
+        log_msg(LOG_DEBUG,"clearControlBlock : deallocate cb for index %d", cbIndex);
         mme::S1apDataGroupManager::Instance()->deleteEnbContext(enbCtxt_p);
         mme::S1apDataGroupManager::Instance()->deAllocateCB(cbIndex);
         return true;
     }
     else
     {
-        log_msg(LOG_ERROR, "Failed to find control block with cbIndex :%d.\n",cbIndex);
+        log_msg(LOG_ERROR, "Failed to find control block with cbIndex :%d.",cbIndex);
         return true;
     }
 
@@ -111,7 +111,7 @@ uint32_t findControlBlockWithEnbFd_cpp(uint32_t enbFd)
 
     if (cbIndex <= 0)
     {
-        log_msg(LOG_ERROR, "Failed to find control block with enbFd :%d.\n",enbFd);
+        log_msg(LOG_ERROR, "Failed to find control block with enbFd :%d.",enbFd);
         return INVALID_CB_INDEX;
     }
 
@@ -127,7 +127,7 @@ uint32_t getEnbFdWithCbIndex_cpp(uint32_t cbIndex)
         cb = mme::S1apDataGroupManager::Instance()->findControlBlock(cbIndex);
         if(NULL == cb)
         {
-            log_msg(LOG_ERROR,"Control block not found for cb Index %d.\n", cbIndex);
+            log_msg(LOG_ERROR,"Control block not found for cb Index %d.", cbIndex);
             return INVALID_CB_INDEX;
         }
 
@@ -137,7 +137,7 @@ uint32_t getEnbFdWithCbIndex_cpp(uint32_t cbIndex)
     }
     else
     {
-        log_msg(LOG_ERROR, "Failed to find control block with cbIndex :%d.\n",cbIndex);
+        log_msg(LOG_ERROR, "Failed to find control block with cbIndex :%d.",cbIndex);
         return INVALID_CB_INDEX;
     }
 
@@ -151,7 +151,7 @@ uint32_t setValuesForEnbCtx_cpp(uint32_t cbIndex, EnbStruct* enbCtx, bool update
         cb = mme::S1apDataGroupManager::Instance()->findControlBlock(cbIndex);
         if(NULL == cb)
         {
-            log_msg(LOG_ERROR,"Control block not found for cb Index %d.\n", cbIndex);
+            log_msg(LOG_ERROR,"Control block not found for cb Index %d.", cbIndex);
             return INVALID_CB_INDEX;
         }
 
@@ -160,21 +160,21 @@ uint32_t setValuesForEnbCtx_cpp(uint32_t cbIndex, EnbStruct* enbCtx, bool update
         {
             if(update && (enbCbCtx->getTai().tac != enbCtx->tai_m.tac))
             {
-                log_msg(LOG_ERROR,"Different Enbs accessing same context tacNew : %d, tacOld : %d.\n", enbCbCtx->getTai().tac, enbCtx->tai_m.tac);
+                log_msg(LOG_ERROR,"Different Enbs accessing same context tacNew : %d, tacOld : %d.", enbCbCtx->getTai().tac, enbCtx->tai_m.tac);
                 return INVALID_CB_INDEX;
             }
             else {
                 int val = mme::S1apDataGroupManager::Instance()->deleteenbIdkey(
                                                             enbCbCtx->getEnbId());
-                log_msg(LOG_DEBUG,"setValuesForEnb : delete enbid %d: %d\n", 
+                log_msg(LOG_DEBUG,"setValuesForEnb : delete enbid %d: %d", 
                                     enbCbCtx->getEnbId(),val);
                 val = mme::S1apDataGroupManager::Instance()->deleteenbFdkey(
                                                             enbCbCtx->getEnbFd());
-                log_msg(LOG_DEBUG,"setValuesForEnb : delete enbfd %d: %d\n", 
+                log_msg(LOG_DEBUG,"setValuesForEnb : delete enbfd %d: %d", 
                                     enbCbCtx->getEnbFd(), val);
-                log_msg(LOG_DEBUG,"setValuesForEnb : fd map size after delete : %d.\n", 
+                log_msg(LOG_DEBUG,"setValuesForEnb : fd map size after delete : %d.", 
                         mme::S1apDataGroupManager::Instance()->sizeEnbFdKeyMap());
-                log_msg(LOG_DEBUG,"setValuesForEnb : Id map size after delete : %d.\n", 
+                log_msg(LOG_DEBUG,"setValuesForEnb : Id map size after delete : %d.", 
                 mme::S1apDataGroupManager::Instance()->sizeEnbIdKeyMap());
                 enbCbCtx->setEnbFd(enbCtx->enbFd_m);
                 enbCbCtx->setEnbId(enbCtx->enbId_m);
@@ -183,16 +183,16 @@ uint32_t setValuesForEnbCtx_cpp(uint32_t cbIndex, EnbStruct* enbCtx, bool update
                 enbCbCtx->setEnbname(enbCtx->eNbName, strlen(enbCtx->eNbName));
                 enbCbCtx->setRestartCounter(enbCbCtx->getRestartCounter()+1);
                 enbCtx->restart_counter = enbCbCtx->getRestartCounter();
-                log_msg(LOG_DEBUG,"setValuesForEnb : Enbs accessing context tacNew : %d, tacOld : %d name = %s .\n", enbCbCtx->getTai().tac, enbCtx->tai_m.tac, enbCtx->eNbName);
+                log_msg(LOG_DEBUG,"setValuesForEnb : Enbs accessing context tacNew : %d, tacOld : %d name = %s .", enbCbCtx->getTai().tac, enbCtx->tai_m.tac, enbCtx->eNbName);
                 val = mme::S1apDataGroupManager::Instance()->addenbIdkey(
                                               enbCtx->enbId_m, cbIndex);
-                log_msg(LOG_DEBUG,"setValuesForEnb : cbIndex : %d, add enbId %d: %d\n", cbIndex, enbCbCtx->getEnbId(),val);
+                log_msg(LOG_DEBUG,"setValuesForEnb : cbIndex : %d, add enbId %d: %d", cbIndex, enbCbCtx->getEnbId(),val);
                 val = mme::S1apDataGroupManager::Instance()->addenbFdkey(
                                               enbCtx->enbFd_m, cbIndex);
-                log_msg(LOG_DEBUG,"setValuesForEnb : cbIndex : %d, add enbFd %d: %d\n", cbIndex, enbCbCtx->getEnbFd(),val);
-                log_msg(LOG_DEBUG,"setValuesForEnb : fd map size after add : %d.\n", 
+                log_msg(LOG_DEBUG,"setValuesForEnb : cbIndex : %d, add enbFd %d: %d", cbIndex, enbCbCtx->getEnbFd(),val);
+                log_msg(LOG_DEBUG,"setValuesForEnb : fd map size after add : %d.", 
                         mme::S1apDataGroupManager::Instance()->sizeEnbFdKeyMap());
-                log_msg(LOG_DEBUG,"setValuesForEnb : Id map size after add : %d.\n", 
+                log_msg(LOG_DEBUG,"setValuesForEnb : Id map size after add : %d.", 
                         mme::S1apDataGroupManager::Instance()->sizeEnbIdKeyMap());
             }
         }
@@ -204,7 +204,7 @@ uint32_t setValuesForEnbCtx_cpp(uint32_t cbIndex, EnbStruct* enbCtx, bool update
     }
     else
     {
-        log_msg(LOG_ERROR, "Failed to find control block with cbIndex :%d.\n",cbIndex);
+        log_msg(LOG_ERROR, "Failed to find control block with cbIndex :%d.",cbIndex);
         return INVALID_CB_INDEX;
     }
 

--- a/src/s1ap/s1ap_config.c
+++ b/src/s1ap/s1ap_config.c
@@ -19,12 +19,12 @@ extern s1ap_instance_t *s1ap_inst;
 void s1ap_config_change_cbk(char *config_file, uint32_t flags)
 {
 	// Run the script with this file. It generates new config for mme
-	log_msg(LOG_INFO, "Received %s . File %s Flags %x \n", __FUNCTION__, config_file, flags);
+	log_msg(LOG_INFO, "Received %s . File %s Flags %x ", __FUNCTION__, config_file, flags);
 
     char cmd[128];  
     sprintf(cmd, "cp %s %s ",config_file, "/openmme/target/conf/s1ap.json"); 
     int ret = system(cmd);
-    log_msg(LOG_DEBUG,"command %s return value %d \n", cmd, ret);
+    log_msg(LOG_DEBUG,"command %s return value %d ", cmd, ret);
 
 
 	s1ap_config_t *current_config = get_s1ap_config();

--- a/src/s1ap/sctp_conn.c
+++ b/src/s1ap/sctp_conn.c
@@ -33,7 +33,7 @@ int create_sctp_socket(unsigned int remote_ip, unsigned short port)
 
 	if (connSock == -1)
 	{
-		log_msg(LOG_ERROR, "Socket creation failed\n");
+		log_msg(LOG_ERROR, "Socket creation failed");
 		return -1;
 	}
 
@@ -49,7 +49,7 @@ int create_sctp_socket(unsigned int remote_ip, unsigned short port)
 	if(ret == -1 )
 	{
 		perror("Bind:");
-		log_msg(LOG_ERROR, "Bind failed \n");
+		log_msg(LOG_ERROR, "Bind failed ");
 		close(connSock);
 		return -1;
 	}
@@ -65,7 +65,7 @@ int create_sctp_socket(unsigned int remote_ip, unsigned short port)
 
 	if(ret == -1 )
 	{
-		log_msg(LOG_ERROR, "setsockopt() failed \n");
+		log_msg(LOG_ERROR, "setsockopt() failed ");
 		close(connSock);
 		return -1;
 	}
@@ -73,13 +73,13 @@ int create_sctp_socket(unsigned int remote_ip, unsigned short port)
 	ret = setsockopt(connSock, SOL_SCTP, SCTP_MAXSEG,&mtu, sizeof(mtu));
 	if(ret == -1 )
 	{
-		log_msg(LOG_ERROR, "1 setsockopt() failed %s \n",strerror(errno));
+		log_msg(LOG_ERROR, "1 setsockopt() failed %s ",strerror(errno));
 	}
 
 	ret = listen(connSock, MAX_PENDING_CONN);
 	if(ret == -1 )
 	{
-		log_msg(LOG_ERROR, "listen() failed \n");
+		log_msg(LOG_ERROR, "listen() failed ");
 		close(connSock);
 		return -1;
 	}

--- a/src/s6a/fd_init.c
+++ b/src/s6a/fd_init.c
@@ -18,7 +18,6 @@
 /**Globals and externs**/
 extern struct fd_dict_objects g_fd_dict_objs;
 extern struct fd_dict_data g_fd_dict_data;
-extern bool g_nolog;
 extern enum log_levels g_log_level;
 /**Globals and externs**/
 
@@ -58,7 +57,6 @@ dump_fd_msg(struct msg *msg)
 	//char *buf = NULL;
 	//int len = 0;
 
-	if (g_nolog) return;
 
 	//TODO: correct - fprintf(stderr, "%s\n", fd_msg_dump_treeview(&buf, &len, NULL, msg,
 	//			fd_g_config->cnf_dict, 0, 1));
@@ -78,7 +76,7 @@ get_ue_idx_from_fd_resp(unsigned char *sid, int sidlen)
 	char *tmp = strrchr((char *)sid, ';');
 
 	index = strtol(++tmp, NULL, 10);
-	log_msg(LOG_INFO, "Received resp for index %d\n", index);
+	log_msg(LOG_INFO, "Received resp for index %d", index);
 	return index;
 }
 

--- a/src/s6a/handlers/aia_handler.c
+++ b/src/s6a/handlers/aia_handler.c
@@ -148,7 +148,7 @@ get_aia_sec_vector(struct avp *avp_data, aia_Q_msg_t *aia)
 static
 void send_to_stage2(aia_Q_msg_t *aia_msg)
 {
-	TRACE_ENTRY("\n****************WRITE TO g_Q_mme_S6a_fd");
+	TRACE_ENTRY("****************WRITE TO g_Q_mme_S6a_fd");
 
 	aia_msg->header.destInstAddr = htonl(mmeAppInstanceNum_c);
 	aia_msg->header.srcInstAddr = htonl(s6AppInstanceNum_c);
@@ -170,14 +170,14 @@ int aia_resp_callback(struct msg **buf, struct avp *_avp,
 	struct avp *sub_avp = NULL;
 	struct avp_hdr *element = NULL;
 
-	log_msg(LOG_INFO, "\nCallback ----- >AIA recvd\n");
+	log_msg(LOG_INFO, "Callback ----- >AIA recvd");
 
 	dump_fd_msg(resp);
 	//TODO - workaround for dump call. Remove this.
 	{
 		char * buf = NULL;
 		size_t len = 0;
-		log_msg(LOG_DEBUG,"*********AIA CALLBACK******%s\n", fd_msg_dump_treeview(&buf, &len, NULL, resp,
+		log_msg(LOG_DEBUG,"*********AIA CALLBACK******%s", fd_msg_dump_treeview(&buf, &len, NULL, resp,
 					fd_g_config->cnf_dict, 0, 1));
 		free(buf);
 	}
@@ -185,7 +185,7 @@ int aia_resp_callback(struct msg **buf, struct avp *_avp,
 	CHECK_FCT_DO(fd_sess_getsid(session, &sess_id, (size_t*)&sess_id_len),
 		return S6A_FD_ERROR);
 
-	log_msg(LOG_INFO, "\nCallback ----- >session id=%s \n",sess_id);
+	log_msg(LOG_INFO, "Callback ----- >session id=%s ",sess_id);
     
 	aia_msg.header.msg_type = auth_info_answer;
 	/*Retrieve UE index embedded in to session ID string at AIR time*/
@@ -199,7 +199,7 @@ int aia_resp_callback(struct msg **buf, struct avp *_avp,
 		res = avp_hdr->avp_value->u32;
 
 		if (DIAMETER_SUCCESS != res) {
-			log_msg(LOG_ERROR, "Diameter error with HSS\n");
+			log_msg(LOG_ERROR, "Diameter error with HSS");
 		}
 	} else {
 		struct fd_result fd_res;

--- a/src/s6a/handlers/clr_handler.c
+++ b/src/s6a/handlers/clr_handler.c
@@ -57,7 +57,7 @@ clr_resp_callback(struct msg **buf, struct avp *avps, struct session *sess,
 	/*read session id and extract ue index*/
 	CHECK_FCT_DO(fd_sess_getsid(sess, &sess_id, (size_t*)&sess_id_len),
 			return S6A_FD_ERROR);
-	log_msg(LOG_INFO, "\n CLR callback ----- >session id=%s \n",sess_id);
+	log_msg(LOG_INFO, "CLR callback ----- >session id=%s ",sess_id);
     
 
 	/*AVP: Cancellation-Type*/

--- a/src/s6a/handlers/detach_session_handler.c
+++ b/src/s6a/handlers/detach_session_handler.c
@@ -119,10 +119,10 @@ send_rpc_purge(struct s6a_Q_msg *pur_msg, char imsi[])
 	strncpy(msg.data.pur.imsi, imsi, IMSI_STR_LEN);
 
 	if (write(g_our_hss_fd, &msg, HSS_REQ_MSG_SIZE) < 0) {
-		log_msg(LOG_ERROR, "HSS PUR msg send failed.\n");
+		log_msg(LOG_ERROR, "HSS PUR msg send failed.");
 		perror("writing on stream socket");
 	}
-	log_msg(LOG_INFO, "PUR msg send to hss\n");
+	log_msg(LOG_INFO, "PUR msg send to hss");
 }
 
 /**
@@ -132,11 +132,11 @@ static int
 detach_processing(struct s6a_Q_msg * purge_msg)
 {
 	/*Parse and validate  the buffer*/
-	log_msg(LOG_INFO, "IMSI recvd - %s\n",purge_msg-> imsi);
+	log_msg(LOG_INFO, "IMSI recvd - %s",purge_msg-> imsi);
 	if (HSS_FD == g_s6a_cfg.hss_type)
 		send_purge(purge_msg, (char *)purge_msg-> imsi);
 	else {
-		log_msg(LOG_INFO, "Sending over IPC \n");
+		log_msg(LOG_INFO, "Sending over IPC ");
 		send_rpc_purge(purge_msg, (char *)purge_msg-> imsi);
 	}
 
@@ -150,7 +150,7 @@ void*
 detach_handler(void *data)
 {
 
-	log_msg(LOG_INFO, "Detach Q handler ready.\n");
+	log_msg(LOG_INFO, "Detach Q handler ready.");
 
 	detach_processing((struct s6a_Q_msg *) data);
 

--- a/src/s6a/handlers/hss_message_delegator.c
+++ b/src/s6a/handlers/hss_message_delegator.c
@@ -27,7 +27,7 @@ hss_resp_handler(void *message)
 {
 	struct hss_resp_msg *msg = (struct hss_resp_msg*)message;
 
-	log_msg(LOG_INFO, "HSS response msg handler for ue_idx %d\n",
+	log_msg(LOG_INFO, "HSS response msg handler for ue_idx %d",
 			msg->ue_idx);
 
 	switch(msg->hdr){
@@ -46,7 +46,7 @@ hss_resp_handler(void *message)
 		break;
 
 	default:
-		log_msg(LOG_ERROR, "Unknown message received from HSS - %d\n",
+		log_msg(LOG_ERROR, "Unknown message received from HSS - %d",
 			msg->hdr);
 	}
 

--- a/src/s6a/handlers/purge_handler.c
+++ b/src/s6a/handlers/purge_handler.c
@@ -34,7 +34,7 @@ extern int g_Q_mme_S6a_fd;
 static
 void send_to_stage2(purge_resp_Q_msg_t *purge_rsp)
 {
-	TRACE_ENTRY("\n****************WRITE TO g_Q_mme_S6a_fd");
+	TRACE_ENTRY("****************WRITE TO g_Q_mme_S6a_fd");
 
 	purge_rsp->header.destInstAddr = htonl(mmeAppInstanceNum_c);
 	purge_rsp->header.srcInstAddr = htonl(s6AppInstanceNum_c);
@@ -67,7 +67,7 @@ purge_resp_callback(struct msg **buf, struct avp *avps, struct session *sess,
 	/*read session id and extract ue index*/
 	CHECK_FCT_DO(fd_sess_getsid(sess, &sess_id, (size_t*)&sess_id_len),
 			return S6A_FD_ERROR);
-	log_msg(LOG_INFO, "\nPurge callback ----- >session id=%s \n",sess_id);
+	log_msg(LOG_INFO, "Purge callback ----- >session id=%s ",sess_id);
     
 	purge_rsp.header.msg_type = purge_answser;
 	purge_rsp.header.ue_idx = get_ue_idx_from_fd_resp(sess_id, sess_id_len);

--- a/src/s6a/handlers/s6a_decoder.c
+++ b/src/s6a/handlers/s6a_decoder.c
@@ -37,17 +37,17 @@ parse_supported_features_avp(struct avp *avp_ptr, supported_features *supp_featu
         {
             case FEAT_LIST_ID_AVP_CODE:
                 {
-                    log_msg(LOG_DEBUG,"found feature_list_id avp %u \n",hdr->avp_value->u32);
+                    log_msg(LOG_DEBUG,"found feature_list_id avp %u ",hdr->avp_value->u32);
                     supp_features->feature_list_id = hdr->avp_value->u32;
                 } break;
             case FEAT_LIST_AVP_CODE:
                 {
-                    log_msg(LOG_DEBUG,"found feature_list avp  %u \n",hdr->avp_value->u32);
+                    log_msg(LOG_DEBUG,"found feature_list avp  %u ",hdr->avp_value->u32);
                     supp_features->feature_list = hdr->avp_value->u32;
                 } break;
             case SUPP_FEAT_VENDOR_ID_AVP_CODE:
             {
-                    log_msg(LOG_DEBUG,"found vendor_id avp  %u \n",hdr->avp_value->u32);
+                    log_msg(LOG_DEBUG,"found vendor_id avp  %u ",hdr->avp_value->u32);
                     break;
             }
             default:

--- a/src/s6a/handlers/s6a_req_handler.c
+++ b/src/s6a/handlers/s6a_req_handler.c
@@ -157,8 +157,8 @@ send_FD_ULR(struct s6a_Q_msg *aia_msg, char imsi[])
 void
 dump_s6a_msg(struct s6a_Q_msg *air_msg)
 {
-	log_msg(LOG_INFO, "Received index= %d\n",air_msg->ue_idx);
-	log_msg(LOG_INFO, "Received plmn %x %x %x= %d\n",air_msg->tai.plmn_id.idx[0],
+	log_msg(LOG_INFO, "Received index= %d",air_msg->ue_idx);
+	log_msg(LOG_INFO, "Received plmn %x %x %x= %d",air_msg->tai.plmn_id.idx[0],
 			air_msg->tai.plmn_id.idx[1], air_msg->tai.plmn_id.idx[2]);
 }
 
@@ -177,7 +177,7 @@ send_FD_AIR(struct s6a_Q_msg *aia_msg, char imsi[])
 	struct s6a_sess_info s6a_sess = {.sess_id="", .sess_id_len = 0};
 	union avp_value val;
 
-	log_msg(LOG_INFO, "In Send AIR:\n");
+	log_msg(LOG_INFO, "In Send AIR:");
 	dump_s6a_msg(aia_msg);
 
 	/*Create FD header and message for authentication info request.*/
@@ -273,10 +273,10 @@ send_rpc_AIR(struct s6a_Q_msg *air_msg, char imsi[])
 	memcpy(msg.data.air.plmn_id, air_msg->tai.plmn_id.idx, 3);
 
 	if (write(g_our_hss_fd, &msg, HSS_REQ_MSG_SIZE) < 0) {
-		log_msg(LOG_ERROR, "HSS AIR msg send failed.\n");
+		log_msg(LOG_ERROR, "HSS AIR msg send failed.");
 		 		perror("writing on stream socket");
 	}
-	log_msg(LOG_INFO, "AIR msg send to hss for ue_idx %d\n",
+	log_msg(LOG_INFO, "AIR msg send to hss for ue_idx %d",
 		air_msg->ue_idx);
 }
 
@@ -295,10 +295,10 @@ send_rpc_ULR(struct s6a_Q_msg *ulr_msg, char imsi[])
 	memcpy(msg.data.air.plmn_id, ulr_msg->tai.plmn_id.idx, 3);
 
 	if (write(g_our_hss_fd, &msg, HSS_REQ_MSG_SIZE) < 0) {
-		log_msg(LOG_ERROR, "HSS ULR msg send failed.\n");
+		log_msg(LOG_ERROR, "HSS ULR msg send failed.");
 		perror("writing on stream socket");
 	}
-	log_msg(LOG_INFO, "ULR msg send to hss\n");
+	log_msg(LOG_INFO, "ULR msg send to hss");
 }
 
 
@@ -334,7 +334,7 @@ imsi_bin_to_str(unsigned char *b_imsi, char *s_imsi)
 static int
 AIR_processing(struct s6a_Q_msg * air_msg)
 {
-	log_msg(LOG_INFO, "IMSI recvd - %s\n %d \n", air_msg->imsi, air_msg->msg_type);
+	log_msg(LOG_INFO, "IMSI recvd - %s %d ", air_msg->imsi, air_msg->msg_type);
 
 	if(HSS_FD == g_s6a_cfg.hss_type) {
 		if(air_msg->msg_type == auth_info_request)
@@ -343,7 +343,7 @@ AIR_processing(struct s6a_Q_msg * air_msg)
 		else if(air_msg->msg_type == update_loc_request)
 			send_FD_ULR(air_msg, (char *)air_msg-> imsi);
 	} else {
-		log_msg(LOG_INFO, "Sending over IPC\n");
+		log_msg(LOG_INFO, "Sending over IPC");
 		send_rpc_AIR(air_msg, (char *) air_msg->imsi);
 		send_rpc_ULR(air_msg, (char *) air_msg->imsi);
 

--- a/src/s6a/handlers/ula_handler.c
+++ b/src/s6a/handlers/ula_handler.c
@@ -182,9 +182,9 @@ parse_ula_subscription_data(struct avp *avp_ptr, ula_Q_msg_t *ula)
 						// if(g_fd_dict_data.service_slection ==
 						if (493 == apn_cfg_element->avp_code){
 
-							log_msg(LOG_INFO, "APN name recvd from hss - %s\n",
+							log_msg(LOG_INFO, "APN name recvd from hss - %s",
 									apn_cfg_element->avp_value->os.data);
-							log_msg(LOG_INFO, "APN length recvd from hss - %lu\n",
+							log_msg(LOG_INFO, "APN length recvd from hss - %lu",
 									apn_cfg_element->avp_value->os.len);
 
 							ula->selected_apn.val[0] = apn_cfg_element->avp_value->os.len;
@@ -197,7 +197,7 @@ parse_ula_subscription_data(struct avp *avp_ptr, ula_Q_msg_t *ula)
 						if (848 == apn_cfg_element->avp_code && ula->static_addr == 0){
 							struct sockaddr_in  temp;
 							int result = fd_dictfct_Address_interpret(apn_cfg_element->avp_value, &temp);
-							log_msg(LOG_INFO, "Served IP address found %d %s \n", result, inet_ntoa(temp.sin_addr)); 
+							log_msg(LOG_INFO, "Served IP address found %d %s ", result, inet_ntoa(temp.sin_addr)); 
 							ula->static_addr = temp.sin_addr.s_addr; // network order
 						} 
 						apn_cfg_prof_itr = apn_cfg_itr;
@@ -243,7 +243,7 @@ ula_resp_callback(struct msg **buf, struct avp *avp_ptr, struct session *sess,
 	CHECK_FCT_DO(fd_sess_getsid(sess, &sess_id, (size_t*)&sess_id_len),
 		return S6A_FD_ERROR);
 
-	log_msg(LOG_INFO, "\nCallback ----- >session id=%s \n", sess_id);
+	log_msg(LOG_INFO, "Callback ----- >session id=%s ", sess_id);
 
 	ula_msg.res = SUCCESS;
 	ue_idx = get_ue_idx_from_fd_resp(sess_id, sess_id_len);
@@ -262,11 +262,11 @@ ula_resp_callback(struct msg **buf, struct avp *avp_ptr, struct session *sess,
                     case SUPP_FEAT_AVP_CODE:
                     {
                         supported_features_list *supp_features_list = &ula_msg.supp_features_list;
-                        log_msg(LOG_DEBUG, "Found SUPP_FEAT_AVP_CODE\n");
+                        log_msg(LOG_DEBUG, "Found SUPP_FEAT_AVP_CODE");
                         if(supp_features_list->count < 2) {
                             int ret = parse_supported_features_avp(avp, &supp_features_list->supp_features[supp_features_list->count]);
                             if(ret == SUCCESS) {
-                                log_msg(LOG_DEBUG, "parse_supported_features_avp success\n");
+                                log_msg(LOG_DEBUG, "parse_supported_features_avp success");
                                 supp_features_list->count ++;
                             }
                         }

--- a/src/s6a/main.c
+++ b/src/s6a/main.c
@@ -63,7 +63,7 @@ init_hss_rpc()
 
 	g_our_hss_fd = socket(AF_UNIX, SOCK_STREAM, 0);
 	if (g_our_hss_fd < 0) {
-		log_msg(LOG_ERROR, "HSS socket creation failed.\n");
+		log_msg(LOG_ERROR, "HSS socket creation failed.");
 		perror("Error opening HSS socket");
 		exit(-1);
 	}
@@ -73,12 +73,12 @@ init_hss_rpc()
 
 	if (connect(g_our_hss_fd, (struct sockaddr *)&hss_serv,
 	sizeof(struct sockaddr_un)) < 0) {
-		log_msg(LOG_ERROR, "HSS connect failed.\n");
+		log_msg(LOG_ERROR, "HSS connect failed.");
 		perror("connecting HSS socket");
 		close(g_our_hss_fd);
 		exit(-1);
 	}
-	log_msg(LOG_INFO, "Connected to HSS\n");
+	log_msg(LOG_INFO, "Connected to HSS");
 }
 
 /**
@@ -90,7 +90,7 @@ init_hss_rpc()
 static int
 init_fd()
 {
-	log_msg(LOG_INFO, "INIT FD .. .\n");
+	log_msg(LOG_INFO, "INIT FD .. .");
 
 	/* Initialize the core freeDiameter library */
 	CHECK_FCT_DO(fd_core_initialize(), return S6A_FD_ERROR);
@@ -174,19 +174,19 @@ init_handlers()
 {
 	if ((ipc_reader_tipc_s6 = create_tipc_socket()) <= 0)
 	{
-		log_msg(LOG_ERROR, "Failed to create IPC Reader tipc socket \n");
+		log_msg(LOG_ERROR, "Failed to create IPC Reader tipc socket ");
 		return -E_FAIL;
 	}
 	if ( bind_tipc_socket(ipc_reader_tipc_s6, s6AppInstanceNum_c) != 1)
 	{
-		log_msg(LOG_ERROR, "failed to bind port name %s\n", strerror(errno));
+		log_msg(LOG_ERROR, "failed to bind port name %s", strerror(errno));
 		return -E_FAIL;
 	}
 
 	g_tpool_tipc_reader_s6a = thread_pool_new(3);
 
 	if (g_tpool_tipc_reader_s6a == NULL) {
-		log_msg(LOG_ERROR, "Error in creating thread pool. \n");
+		log_msg(LOG_ERROR, "Error in creating thread pool. ");
 		return -E_FAIL_INIT;
 	}
 	pthread_attr_t attr;
@@ -212,10 +212,10 @@ init_s6a_ipc()
 {
 	g_Q_mme_S6a_fd = create_tipc_socket();
 	if (g_Q_mme_S6a_fd == -1) {
-		log_msg(LOG_ERROR, "Error in opening writer IPC channel\n");
+		log_msg(LOG_ERROR, "Error in opening writer IPC channel");
 		pthread_exit(NULL);
 	}
-	log_msg(LOG_INFO, "S6a response - mme-app TIPC: Connected.\n");
+	log_msg(LOG_INFO, "S6a response - mme-app TIPC: Connected.");
 	return 0;
 }
 
@@ -245,18 +245,18 @@ s6a_run()
 
 		if ((len = read(g_our_hss_fd, buf,
 						sizeof(struct hss_resp_msg))) < 0) {
-			log_msg(LOG_ERROR, "Error reading hss buff\n");
+			log_msg(LOG_ERROR, "Error reading hss buff");
 	                perror("reading stream message");
 			exit(-1);
 		} else if (len == 0) {
-			log_msg(LOG_ERROR, "Error reading hss buff\n");
+			log_msg(LOG_ERROR, "Error reading hss buff");
 	                perror("reading stream message");
 			exit(-1);
 		}else {
 			unsigned char *tmp_buf = (unsigned char *)
 					calloc(sizeof(char), len);
 			memcpy(tmp_buf, buf, len);
-			log_msg(LOG_INFO, "HSS Received msg len : %d \n",len);
+			log_msg(LOG_INFO, "HSS Received msg len : %d ",len);
 			insert_job(g_tpool, hss_resp_handler, tmp_buf);
 		}
 	}
@@ -299,7 +299,7 @@ main(int argc, char **argv)
 		/* Initialize thread pool for handling HSS resp*/
 		g_tpool = thread_pool_new(HSS_RESP_THREADPOOL_SIZE);
 		if (g_tpool == NULL) {
-			log_msg(LOG_ERROR, "Error in creating thread pool. \n");
+			log_msg(LOG_ERROR, "Error in creating thread pool. ");
 			return -1;
 		}
 	}

--- a/src/stateMachineFwk/actionTable.cpp
+++ b/src/stateMachineFwk/actionTable.cpp
@@ -74,7 +74,7 @@ namespace SM
 	{
 		if(NULL != nextStatep)
 		{
-			log_msg(LOG_DEBUG,"\nnext State : - %d \n",nextStatep->getStateId());
+			log_msg(LOG_DEBUG,"next State : - %d ",nextStatep->getStateId());
 		}
 	}
 }	

--- a/src/stateMachineFwk/controlBlock.cpp
+++ b/src/stateMachineFwk/controlBlock.cpp
@@ -229,7 +229,7 @@ namespace SM
     {
         std::lock_guard<std::mutex> lock(mutex_m);
         
-        log_msg(LOG_INFO, "CB state transition from %d to %d\n", cbState_m, state);
+        log_msg(LOG_DEBUG, "CB state transition from %d to %d", cbState_m, state);
 
         cbState_m = state;
     }

--- a/src/stateMachineFwk/permDataBlock.cpp
+++ b/src/stateMachineFwk/permDataBlock.cpp
@@ -33,7 +33,7 @@ PermDataBlock::~PermDataBlock()
 void PermDataBlock::display()
 {
 	// Display all data fields
-	log_msg(LOG_DEBUG,"\nContext ID - %d \n",contextID);
+	log_msg(LOG_DEBUG,"Context ID - %d ",contextID);
 }
 }
 

--- a/src/stateMachineFwk/state.cpp
+++ b/src/stateMachineFwk/state.cpp
@@ -43,7 +43,7 @@ namespace SM
 	{
 		for(auto& eventToActionsMapEntry : eventToActionsMap)
 		{
-			log_msg(LOG_DEBUG, "Event Id = %d \n", eventToActionsMapEntry.first);
+			log_msg(LOG_DEBUG, "Event Id = %d ", eventToActionsMapEntry.first);
 			ActionTable& act = eventToActionsMapEntry.second;
 			act.display();
 		}

--- a/src/stateMachineFwk/stateMachineEngine.cpp
+++ b/src/stateMachineFwk/stateMachineEngine.cpp
@@ -59,7 +59,7 @@ ActStatus StateMachineEngine::handleProcedureEvent(ControlBlock &cb,
 
     SmUtility *util = SmUtility::Instance();
     log_msg(LOG_DEBUG,
-            "################ Executing actions for event: %s and State: %s #################\n",
+            "### Executing actions for event: %s and State: %s ###",
             util->convertEventToString(smCtxt.evt.getEventId()).c_str(),
             currentState_p->getStateName());
 
@@ -81,7 +81,7 @@ void StateMachineEngine::run()
 
     if (cb->getControlBlockState() == FREE)
     {
-        log_msg(LOG_ERROR, "A freed Control Block found in Procedure Queue\n");
+        log_msg(LOG_ERROR, "A freed Control Block found in Procedure Queue");
         return;
     }
 
@@ -106,7 +106,7 @@ void StateMachineEngine::run()
             if (currentState_p == NULL)
             {
                 log_msg(LOG_ERROR, "Current state is NULL"
-                        " for control block idx %d\n", cb->getCBIndex());
+                        " for control block idx %d", cb->getCBIndex());
                 break;
             }
 
@@ -114,7 +114,7 @@ void StateMachineEngine::run()
 
             EventStatus eStatus = currentState_p->validateEvent(*cb, tempData_p, smCtxt.evt);
 
-            log_msg(LOG_INFO, "Event Status %d\n", eStatus);
+            log_msg(LOG_INFO, "Event Status %d", eStatus);
 
             switch (eStatus)
             {
@@ -133,7 +133,7 @@ void StateMachineEngine::run()
 
                 if (ret == ABORT)
                 {
-                    log_msg(LOG_INFO, "Abort Event Initiated \n");
+                    log_msg(LOG_INFO, "Abort Event Initiated ");
 
                     uint16_t currentEventId = smCtxt.evt.getEventId();
 


### PR DESCRIPTION
1. add timestamp
2. add function name, line number, file name in the logs
3. Reduce checks during logging.
4. Made logging as macro instead of function call
5. Removed __FUNCTION__ and __FILE__ in the individual logs and its part of logging macro