### PR TITLE
Fix Attach Type and Abort Attach Handler

### DIFF
--- a/scripts/SMCodeGen/dataModels/stateMachineAppModel.json
+++ b/scripts/SMCodeGen/dataModels/stateMachineAppModel.json
@@ -505,7 +505,6 @@
                                 "Name":"ABORT_EVENT",
                                 "Actions":[
                                     "DEL_SESSION_REQ",
-                                    "SEND_ATTACH_REJECT",
                                     "SEND_S1_REL_CMD_TO_UE",
                                     "ABORT_ATTACH"
                                 ],
@@ -544,7 +543,6 @@
                                 "Name":"ABORT_EVENT",
                                 "Actions":[
                                     "DEL_SESSION_REQ",
-                                    "SEND_ATTACH_REJECT",
                                     "SEND_S1_REL_CMD_TO_UE",
                                     "ABORT_ATTACH"
                                 ],
@@ -583,7 +581,6 @@
                                 "Name":"ABORT_EVENT",
                                 "Actions":[
                                     "DEL_SESSION_REQ",
-                                    "SEND_ATTACH_REJECT",
                                     "SEND_S1_REL_CMD_TO_UE",
                                     "ABORT_ATTACH"
                                 ],
@@ -633,7 +630,6 @@
                                 "Name":"ABORT_EVENT",
                                 "Actions":[
                                     "DEL_SESSION_REQ",
-                                    "SEND_ATTACH_REJECT",
                                     "SEND_S1_REL_CMD_TO_UE",
                                     "ABORT_ATTACH"
                                 ],

--- a/src/mme-app/actionHandlers/attachActionHandlers.cpp
+++ b/src/mme-app/actionHandlers/attachActionHandlers.cpp
@@ -1036,7 +1036,7 @@ ActStatus ActionHandlers::send_init_ctxt_req_to_ue(SM::ControlBlock& cb)
 	    nas.elements_len ++;
 
 	nas.elements = (nas_pdu_elements *) calloc(nas.elements_len,sizeof(nas_pdu_elements));
-	nas.elements[0].pduElement.attach_res = 2; /* EPS Only */
+	nas.elements[0].pduElement.attach_res = 1; /* EPS Only */
 	nas.elements[1].pduElement.t3412 = 224; 
 	nas.elements[2].pduElement.tailist.type = 1;
 	nas.elements[2].pduElement.tailist.num_of_elements = 0;

--- a/src/mme-app/mmeStates/attachStates.cpp
+++ b/src/mme-app/mmeStates/attachStates.cpp
@@ -934,7 +934,6 @@ void AttachWfInitCtxtRespAttCmp::initialize()
         {
                 ActionTable actionTable;
                 actionTable.addAction(&ActionHandlers::del_session_req);
-                actionTable.addAction(&ActionHandlers::send_attach_reject);
                 actionTable.addAction(&ActionHandlers::send_s1_rel_cmd_to_ue);
                 actionTable.addAction(&ActionHandlers::abort_attach);
                 eventToActionsMap[ABORT_EVENT] = actionTable;
@@ -1013,7 +1012,6 @@ void AttachWfInitCtxtResp::initialize()
         {
                 ActionTable actionTable;
                 actionTable.addAction(&ActionHandlers::del_session_req);
-                actionTable.addAction(&ActionHandlers::send_attach_reject);
                 actionTable.addAction(&ActionHandlers::send_s1_rel_cmd_to_ue);
                 actionTable.addAction(&ActionHandlers::abort_attach);
                 eventToActionsMap[ABORT_EVENT] = actionTable;
@@ -1092,7 +1090,6 @@ void AttachWfAttCmp::initialize()
         {
                 ActionTable actionTable;
                 actionTable.addAction(&ActionHandlers::del_session_req);
-                actionTable.addAction(&ActionHandlers::send_attach_reject);
                 actionTable.addAction(&ActionHandlers::send_s1_rel_cmd_to_ue);
                 actionTable.addAction(&ActionHandlers::abort_attach);
                 eventToActionsMap[ABORT_EVENT] = actionTable;
@@ -1179,7 +1176,6 @@ void AttachWfMbResp::initialize()
         {
                 ActionTable actionTable;
                 actionTable.addAction(&ActionHandlers::del_session_req);
-                actionTable.addAction(&ActionHandlers::send_attach_reject);
                 actionTable.addAction(&ActionHandlers::send_s1_rel_cmd_to_ue);
                 actionTable.addAction(&ActionHandlers::abort_attach);
                 eventToActionsMap[ABORT_EVENT] = actionTable;


### PR DESCRIPTION
This bug fix includes the following changes:

1. Attach Result value is changed to "1" in the attach accept message, as we support only the EPS Attach.
2. Attach Reject Action is removed in the abort handling of states after sending out attach accept.