### PR TITLE
eNB statistics fix

### DIFF
--- a/src/mme-app/msgHandlers/s1MsgHandler.cpp
+++ b/src/mme-app/msgHandlers/s1MsgHandler.cpp
@@ -729,6 +729,7 @@ void S1MsgHandler::handleS1apEnbStatusMsg_v(IpcEMsgUnqPtr eMsg)
         log_msg(LOG_INFO, " Supported only 1024 eNBs ");
         return;
     }
+
      // new enb found  
      struct s1apEnbStatus_Msg *temp = NULL;
      if(enb->status == 0) {
@@ -751,7 +752,7 @@ void S1MsgHandler::handleS1apEnbStatusMsg_v(IpcEMsgUnqPtr eMsg)
      if(enb->status == 1)
         mmeStats::Instance()->increment(mmeStatsCounter::ENB_NUM_ACTIVE, {{"enbname",enbname.str()}, {"enbid",enbid.str()},{"tac",tac.str()}});
      else
-        mmeStats::Instance()->decrement(mmeStatsCounter::ENB_NUM_ACTIVE, {{"enbname",enbname.str()}, {"enbid",enbid.str()},{"tac",tac.str()}});
+        mmeStats::Instance()->set(mmeStatsCounter::ENB_NUM_ACTIVE, 0, {{"enbname",enbname.str()}, {"enbid",enbid.str()},{"tac",tac.str()}});
     return;
 
 }

--- a/src/s1ap/handlers/s1setup.c
+++ b/src/s1ap/handlers/s1setup.c
@@ -284,6 +284,7 @@ s1_setup_handler(InitiatingMessage_t *msg, int enb_fd)
     s1Msg.status = 1;
     s1Msg.context_id = temp_cbIndex;
     s1Msg.enbId_m = enbStruct.enbId_m;
+    s1Msg.tacid = enbStruct.tai_m.tac;
     s1Msg.restart_counter = enbStruct.restart_counter;
     strncpy(s1Msg.eNbName, enbStruct.eNbName, 128);
 	send_tipc_message(ipc_S1ap_Hndl, mmeAppInstanceNum_c, (char *)&s1Msg, sizeof(s1apEnbStatus_Msg_t));


### PR DESCRIPTION
1. Updating TAC ID correctly
2. If eNB is down the reset the counter to 0 instead of calling decrement.