### PR TITLE
MME not able to decode PCO parameter Rcvd from UE

### DIFF
--- a/src/s11/handlers/s11_CS_resp_handler.c
+++ b/src/s11/handlers/s11_CS_resp_handler.c
@@ -92,15 +92,6 @@ s11_CS_resp_handler(MsgBuffer* message, GtpV2MessageHeader* hdr, uint32_t sgw_ip
 		csr_info.pco_length = msgData.protocolConfigurationOptions.pcoValue.count;
 		memcpy(&csr_info.pco_options[0], &msgData.protocolConfigurationOptions.pcoValue.values[0], msgData.protocolConfigurationOptions.pcoValue.count);
 	}
-	else
-	{
-		/* Temporary hardcoding so that UE gets min DNS address.*/
-		char pco_options[27] = {0x80, 0x80, 0x21, 0x10, 0x03, 0x00, 0x00,0x10, 0x81, 0x06, 0x08,0x08,0x08, 0x08,0x83,0x06,0x08,0x08,0x08,0x04,0x00,0x0d, 0x04,0x08,0x08,0x08,0x08};
-		memcpy(&csr_info.pco_options[0], &pco_options[0], 27);
-		csr_info.pco_length = 27;
-	}
-
-
 
 	csr_info.header.destInstAddr = htonl(mmeAppInstanceNum_c);
 	csr_info.header.srcInstAddr = htonl(s11AppInstanceNum_c);


### PR DESCRIPTION
MME while decoding nas message was overwriting pco options under
certain conditions and this was causing PCO not sent to SPGW. This
leads to MME filling default pco parameters to UE. Fix is to fix
bug and remove default pco parameters from MME.