### PR TITLE
apply correct bounds for various array inputs

### DIFF
--- a/include/cmn/memPoolManager.h
+++ b/include/cmn/memPoolManager.h
@@ -46,7 +46,7 @@ namespace cmn {
 				blockArray_mpa.reset(blkArray_p.release());
 
 				uint32_t  i = 1;
-				for (; i < numOfBlocks; i++)
+				for (; i < (numOfBlocks - 1); i++)
 				{
 					blockArray_mpa[i-1].setNextMemBlock(&blockArray_mpa[i]);
 				}

--- a/src/s1ap/handlers/handover_ack.c
+++ b/src/s1ap/handlers/handover_ack.c
@@ -88,6 +88,11 @@ int s1_handover_ack_handler(SuccessfulOutcome_t *msg)
             log_msg(LOG_INFO,
                     "Handover Request Ack S1AP_IE_TARGET_TOSOURCE_TRANSPARENTCONTAINER.");
 
+            if (s1_ho_ack_ies.data[i].val.targetToSrcTranspContainer.size > TRANS_CONT_SIZE) {
+                log_msg(LOG_WARNING, "IE with oversized Target_ToSource_TransparentContainer received--discarding");
+                break;
+            }
+
             handover_ack.targetToSrcTranspContainer.count =
                     s1_ho_ack_ies.data[i].val.targetToSrcTranspContainer.size;
 

--- a/src/s1ap/handlers/handover_required.c
+++ b/src/s1ap/handlers/handover_required.c
@@ -120,6 +120,11 @@ int s1_handover_required_handler(InitiatingMessage_t *msg, int enb_fd)
             log_msg(LOG_INFO,
                     "handover required S1AP_IE_SOURCE_TOTARGET_TRANSPARENTCONTAINER.");
 
+            if (ho_required_ies.data[i].val.srcToTargetTranspContainer.size > TRANS_CONT_SIZE) {
+                log_msg(LOG_ERROR, "failed to decode IE: TransparentContainer too large");
+                break;
+            }
+
             ho_required.srcToTargetTranspContainer.count =
                     ho_required_ies.data[i].val.srcToTargetTranspContainer.size;
 

--- a/src/s1ap/handlers/s1ap_msg_delegator.c
+++ b/src/s1ap/handlers/s1ap_msg_delegator.c
@@ -80,6 +80,11 @@ int convertToInitUeProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_ies,
 							return -1;
 						}
 
+                        if (s1apNASPDU_p->size > MAX_NAS_MSG_SIZE) {
+                            log_msg(LOG_ERROR, "Decoding of IE NAS PDU failed due to oversized buffer");
+                            return -1;
+                        }
+
                         proto_ies->data[i].IE_type = S1AP_IE_NAS_PDU;
 						memcpy(s1Msg->nasMsg.nasMsgBuf, (char*)s1apNASPDU_p->buf, s1apNASPDU_p->size);
 						s1Msg->nasMsg.nasMsgSize = s1apNASPDU_p->size;
@@ -468,6 +473,11 @@ int convertUplinkNasToProtoIe(InitiatingMessage_t *msg, struct proto_IE* proto_i
 							return -1;
 						}
 
+                        if (s1apNASPDU_p->size > MAX_NAS_MSG_SIZE) {
+                            log_msg(LOG_ERROR, "Decoding of IE NAS PDU failed due to oversized buffer");
+                            return -1;
+                        }
+
                         proto_ies->data[i].IE_type = S1AP_IE_NAS_PDU; 
 						memcpy(s1Msg->nasMsg.nasMsgBuf, (char*)s1apNASPDU_p->buf, s1apNASPDU_p->size);
 						s1Msg->nasMsg.nasMsgSize = s1apNASPDU_p->size;
@@ -629,6 +639,10 @@ int convertInitCtxRspToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* proto_
 
 					if(s1apErabSetupItem_p->gTP_TEID.buf != NULL)
 					{
+						if (s1apErabSetupItem_p->gTP_TEID.size != 4) {
+							log_msg(LOG_ERROR, "Decoding of IE E_RABSetupItemCtxtSURes failed due to incorrect sized GTP_TEID");
+							return -1;
+						}
                                             memcpy(
                                                 &(proto_ies->data[i].val.erab.elements[j].su_res.gtp_teid),
                                                 s1apErabSetupItem_p->gTP_TEID.buf,
@@ -646,6 +660,11 @@ int convertInitCtxRspToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE* proto_
 
 					if(s1apErabSetupItem_p->transportLayerAddress.buf != NULL)
 					{
+                        if (s1apErabSetupItem_p->transportLayerAddress.size != sizeof(int)) {
+                            log_msg(LOG_ERROR, "Decoding of IE E_RABSetupItemCtxtSURes->transp_layer_addr failed due to incorrect sized buffer");
+                            return -1;
+                        }
+
                                             memcpy(
                                                 &(proto_ies->data[i].val.erab.elements[j].su_res.transp_layer_addr),
                                                 s1apErabSetupItem_p->transportLayerAddress.buf,
@@ -1186,6 +1205,12 @@ int convertHoAcklToProtoIe(SuccessfulOutcome_t *msg, struct proto_IE *proto_ies)
                         {
                             log_msg(LOG_ERROR,
                                     "Decoding of IE eRABAdmittedItem failed");
+                            return -1;
+                        }
+
+                        if (eRabAdmittedItem_p->dL_transportLayerAddress->size != 4) {
+                            log_msg(LOG_ERROR,
+                                    "Decoding of IE eRABAdmittedItem DL TransportLayerAddress failed");
                             return -1;
                         }
 


### PR DESCRIPTION
Fixes several out-of-bounds memory accesses that can be triggered via an unauthenticated cellular device.

Partially deals with #143, though the ASN.1 files for S1AP will still need to be regenerated using a new version of the asn1c compiler (e.g. https://github.com/mouse07410/asn1c) in order to resolve the buffer overflow issues contained within it. It appears to be a static-compiled library that is stored in the git repo and linked at build time.